### PR TITLE
Bump MIN_LO_ITEM_ENERGY from 7 to 9

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -576,7 +576,7 @@
     "AssumeMasterworkOptions": {
       "All": "All armor will use masterworked stats and will have an energy level of 10.",
       "Legendary": "Legendary armor will use masterworked stats and will have an energy level of 10.",
-      "None": "All armor will use its current stats and will have a minimum energy level of 7."
+      "None": "All armor will use its current stats and will have a minimum energy level of {{minLoItemEnergy}}."
     },
     "ChooseAlternateTitle": "Choose another item",
     "CompareLoadout": "Compare Loadout",

--- a/src/app/loadout-builder/filter/EnergyOptions.tsx
+++ b/src/app/loadout-builder/filter/EnergyOptions.tsx
@@ -3,6 +3,7 @@ import RadioButtons, { Option } from 'app/dim-ui/RadioButtons';
 import { t } from 'app/i18next-t';
 import { Dispatch, useCallback, useMemo } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
+import { loDefaultArmorEnergyRules } from '../types';
 import styles from './EnergyOptions.m.scss';
 import { loMenuSection } from './LoadoutOptimizerMenuItems';
 
@@ -17,7 +18,9 @@ export default function EnergyOptions({
     () => [
       {
         label: t('LoadoutBuilder.None'),
-        tooltip: t('LoadoutBuilder.AssumeMasterworkOptions.None'),
+        tooltip: t('LoadoutBuilder.AssumeMasterworkOptions.None', {
+          minLoItemEnergy: loDefaultArmorEnergyRules.minItemEnergy,
+        }),
         value: AssumeArmorMasterwork.None,
       },
       {

--- a/src/app/loadout-builder/item-filter.test.ts
+++ b/src/app/loadout-builder/item-filter.test.ts
@@ -5,12 +5,11 @@ import { DimStore } from 'app/inventory/store-types';
 import { isPluggableItem } from 'app/inventory/store/sockets';
 import { isLoadoutBuilderItem } from 'app/loadout/item-utils';
 import { ModMap, categorizeArmorMods } from 'app/loadout/mod-assignment-utils';
-import { plugCategoryHashToBucketHash } from 'app/loadout/mod-utils';
 import { count } from 'app/utils/collections';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import _, { stubFalse, stubTrue } from 'lodash';
-import { fontOfWisdomModHash } from 'testing/test-item-utils';
+import { elementalChargeModHash, stacksOnStacksModHash } from 'testing/test-item-utils';
 import { getTestDefinitions, getTestStores } from 'testing/test-utils';
 import { FilterInfo, filterItems } from './item-filter';
 import {
@@ -27,6 +26,8 @@ describe('loadout-builder item-filter', () => {
   let defs: D2ManifestDefinitions;
   let store: DimStore;
   let items: DimItem[];
+  let stacksOnStacksMod: PluggableInventoryItemDefinition;
+  let elementalChargeMod: PluggableInventoryItemDefinition;
 
   const defaultArgs = {
     lockedExoticHash: undefined,
@@ -47,6 +48,20 @@ describe('loadout-builder item-filter', () => {
     store = _.maxBy(stores, (store) => count(allItems, (item) => isValidItem(store, item)))!;
     items = allItems.filter((item) => isValidItem(store, item));
     noMods = categorizeArmorMods([], items);
+
+    stacksOnStacksMod = defs.InventoryItem.get(
+      stacksOnStacksModHash,
+    ) as PluggableInventoryItemDefinition;
+    expect(isPluggableItem(stacksOnStacksMod)).toBe(true);
+    expect(stacksOnStacksMod.plug.energyCost!.energyCost).toBe(4);
+    expect(stacksOnStacksMod.plug.plugCategoryHash).toBe(PlugCategoryHashes.EnhancementsV2Legs);
+
+    elementalChargeMod = defs.InventoryItem.get(
+      elementalChargeModHash,
+    ) as PluggableInventoryItemDefinition;
+    expect(isPluggableItem(elementalChargeMod)).toBe(true);
+    expect(elementalChargeMod.plug.energyCost!.energyCost).toBe(3);
+    expect(elementalChargeMod.plug.plugCategoryHash).toBe(PlugCategoryHashes.EnhancementsV2Legs);
   });
 
   function noPinInvariants(filteredItems: ItemsByBucket, filterInfo: FilterInfo) {
@@ -92,15 +107,9 @@ describe('loadout-builder item-filter', () => {
   });
 
   it('filters out items with insufficient energy capacity', () => {
-    const fontOfWisdomMod = defs.InventoryItem.get(
-      fontOfWisdomModHash,
-    ) as PluggableInventoryItemDefinition;
-    expect(isPluggableItem(fontOfWisdomMod)).toBe(true);
-    expect(fontOfWisdomMod.plug.energyCost!.energyCost).toBe(3);
-    expect(fontOfWisdomMod.plug.plugCategoryHash).toBe(PlugCategoryHashes.EnhancementsV2Head);
-
     const { modMap, unassignedMods } = categorizeArmorMods(
-      [fontOfWisdomMod, fontOfWisdomMod, fontOfWisdomMod],
+      // 10 cost
+      [stacksOnStacksMod, elementalChargeMod, elementalChargeMod],
       items,
     );
 
@@ -130,7 +139,7 @@ describe('loadout-builder item-filter', () => {
       for (const bucketHash of LockableBucketHashes) {
         const removedNum = filterInfo.perBucketStats[bucketHash].cantFitMods;
 
-        if (bucketHash === BucketHashes.Helmet) {
+        if (bucketHash === BucketHashes.LegArmor) {
           if (expectAllItemsFit) {
             expect(removedNum).toBe(0);
           } else {
@@ -285,30 +294,19 @@ describe('loadout-builder item-filter', () => {
   });
 
   it('mod assignment may cause exotic slot to not have options', () => {
-    // Find an exotic where every copy has less than 4 energy
+    // Find a leg armor exotic where every copy does not have 10 energy
     const exotic = items.find(
       (i) =>
         i.isExotic &&
+        i.bucket.hash === BucketHashes.LegArmor &&
         items.every(
-          (otherItem) => otherItem.hash !== i.hash || otherItem.energy!.energyCapacity < 9,
+          (otherItem) => otherItem.hash !== i.hash || otherItem.energy!.energyCapacity < 10,
         ),
     )!;
 
-    const socket = exotic.sockets?.allSockets.find(
-      (i) =>
-        i.plugged &&
-        plugCategoryHashToBucketHash[
-          i.plugged.plugDef.plug.plugCategoryHash as PlugCategoryHashes
-        ] === exotic.bucket.hash,
-    )!;
-    const mod = socket.plugSet!.plugs.find(
-      (plug) =>
-        plug.plugDef.plug.energyCost?.energyCost && plug.plugDef.plug.energyCost.energyCost >= 3,
-    )!.plugDef;
-
-    // 3 mods with at least 3 cost each
     const { modMap, unassignedMods } = categorizeArmorMods(
-      new Array<PluggableInventoryItemDefinition>(3).fill(mod),
+      // 10 cost
+      [stacksOnStacksMod, elementalChargeMod, elementalChargeMod],
       items,
     );
     expect(unassignedMods.length).toBe(0);

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -137,7 +137,7 @@ export const LOCKED_EXOTIC_ANY_EXOTIC = -2;
 /**
  * The minimum armour energy value used in the LO Builder
  */
-export const MIN_LO_ITEM_ENERGY = 7;
+export const MIN_LO_ITEM_ENERGY = 9;
 /**
  * The armor energy rules that Loadout Optimizer uses by default.
  * Requires a reasonable and inexpensive amount of upgrade materials.

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -618,7 +618,7 @@
     "AssumeMasterworkOptions": {
       "All": "All armor will use masterworked stats and will have an energy level of 10.",
       "Legendary": "Legendary armor will use masterworked stats and will have an energy level of 10.",
-      "None": "All armor will use its current stats and will have a minimum energy level of 7."
+      "None": "All armor will use its current stats and will have a minimum energy level of {{minLoItemEnergy}}."
     },
     "AutoStatMods": "Automatically add stat mods",
     "AutomaticallyPicked": "This mod was added automatically to improve build stats.",

--- a/src/testing/test-item-utils.ts
+++ b/src/testing/test-item-utils.ts
@@ -7,8 +7,10 @@ export const recoveryModHash = 4204488676; // InventoryItem "Recovery Mod"
 export const enhancedOperatorAugmentModHash = 817361141; // InventoryItem "Enhanced Operator Augment"
 /** class item mod, 3 energy */
 export const distributionModHash = 4039026690; // InventoryItem "Distribution"
-/** helmet mod, 3 energy */
-export const fontOfWisdomModHash = 1130820873; // InventoryItem "Font of Wisdom"
+/** legs mod, 4 energy */
+export const stacksOnStacksModHash = 3994043492; // InventoryItem "Stacks on Stacks"
+/** legs mod, 3 energy */
+export const elementalChargeModHash = 3712696020; // InventoryItem "Elemental Charge"
 
 /** 1st class item mod with mutual exclusion behavior, 1 energy */
 export const empoweringFinishModHash = 84503918; // InventoryItem "Empowered Finish"


### PR DESCRIPTION
As far as I can tell, the original idea was that upgrades up to level 7 don't cost "endgame materials" such as enhancement prisms or ascendant shards. Feedback has been that the 7 feels arbitrary and unexpected and users don't really have control over it.

Over the years enhancement prisms have only become easier to get so this bumps the assumed min energy to 9. It's certainly more in line with what users might expect - an item that is "assume masterworked" has 10 assumed capacity and masterworked stats, everything else has no masterworked stats and assumes 9 capacity.

Limited survey of what other tools do:
* DLB assumes either everything is masterworked or everything has exactly the stats and energy capacity it has. Exceeding an armor piece's current capacity with slot-specific mods is allowed, and DLB will use `min(armor_capacity, 10 - sum(slot_specific_mod_costs))` for auto mods (which can result in it effectively recommending upgrading armor capacity to 10 without taking masterwork stats into account).
* D2AP has "assume masterwork" toggles that only affect stats, and separately allows limiting the cost of auto mods per slot, but will otherwise suggest mods that exceed the current energy capacity for non-assumed-masterworked items - so it doesn't even have the concept of something requiring 10 energy capacity in my understanding since it only offers auto mods.