### PR TITLE
Always include vendor items in LO

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -358,6 +358,9 @@ export default memo(function LoadoutBuilder({
       <LoadoutOptimizerExotic
         lockedExoticHash={lockedExoticHash}
         classType={selectedStore.classType}
+        className={styles.loadoutEditSection}
+        storeId={selectedStore.id}
+        includeVendorItems={includeVendorItems}
         lbDispatch={lbDispatch}
       />
       <LoadoutEditModsSection

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -358,9 +358,7 @@ export default memo(function LoadoutBuilder({
       <LoadoutOptimizerExotic
         lockedExoticHash={lockedExoticHash}
         classType={selectedStore.classType}
-        className={styles.loadoutEditSection}
-        storeId={selectedStore.id}
-        includeVendorItems={includeVendorItems}
+        vendorItems={vendorItems}
         lbDispatch={lbDispatch}
       />
       <LoadoutEditModsSection

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -172,7 +172,10 @@ export default memo(function LoadoutBuilder({
     vendorItems,
     vendorItemsLoading,
     error: vendorError,
-  } = useLoVendorItems(selectedStoreId, includeVendorItems);
+  } = useLoVendorItems(
+    selectedStoreId,
+    $featureFlags.statConstraintEditor ? true : includeVendorItems,
+  );
   const armorItems = useArmorItems(classType, vendorItems);
 
   const { modMap: lockedModMap, unassignedMods } = useMemo(
@@ -321,28 +324,30 @@ export default memo(function LoadoutBuilder({
         />
       )}
       <EnergyOptions assumeArmorMasterwork={assumeArmorMasterwork} lbDispatch={lbDispatch} />
-      <div className={loMenuSection}>
-        <CheckButton
-          onChange={setIncludeVendorItems}
-          name="includeVendorItems"
-          checked={includeVendorItems}
-        >
-          {vendorError ? (
-            <PressTip tooltip={vendorError.message}>
-              <span>
-                <AppIcon icon={faExclamationTriangle} />
-              </span>
-            </PressTip>
-          ) : (
-            vendorItemsLoading && (
-              <span>
-                <AppIcon icon={refreshIcon} spinning={true} />
-              </span>
-            )
-          )}{' '}
-          {t('LoadoutBuilder.IncludeVendorItems')}
-        </CheckButton>
-      </div>
+      {!$featureFlags.statConstraintEditor && (
+        <div className={loMenuSection}>
+          <CheckButton
+            onChange={setIncludeVendorItems}
+            name="includeVendorItems"
+            checked={includeVendorItems}
+          >
+            {vendorError ? (
+              <PressTip tooltip={vendorError.message}>
+                <span>
+                  <AppIcon icon={faExclamationTriangle} />
+                </span>
+              </PressTip>
+            ) : (
+              vendorItemsLoading && (
+                <span>
+                  <AppIcon icon={refreshIcon} spinning={true} />
+                </span>
+              )
+            )}{' '}
+            {t('LoadoutBuilder.IncludeVendorItems')}
+          </CheckButton>
+        </div>
+      )}
       {isPhonePortrait && (
         <div className={styles.guide}>
           <ol start={2}>

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -24,23 +24,17 @@ import { LOCKED_EXOTIC_ANY_EXOTIC, LOCKED_EXOTIC_NO_EXOTIC, LockableBucketHashes
 import styles from './ExoticPicker.m.scss';
 import ExoticTile, { FakeExoticTile, LockedExoticWithPlugs } from './ExoticTile';
 
-interface Props {
-  lockedExoticHash?: number;
-  classType: DestinyClass;
-  onSelected: (lockedExoticHash: number) => void;
-  onClose: () => void;
-}
-
 /**
  * Find all exotic armor in this character's inventory that could be locked in LO.
  */
 function findLockableExotics(
   allItems: DimItem[],
+  vendorItems: DimItem[],
   classType: DestinyClass,
   defs: D2ManifestDefinitions,
 ) {
   // Find all the armor 2 exotics.
-  const exotics = allItems.filter(
+  const exotics = [...allItems, ...vendorItems].filter(
     (item) => item.isExotic && item.classType === classType && isLoadoutBuilderItem(item),
   );
   const orderedExotics = _.sortBy(exotics, (item) =>
@@ -142,15 +136,19 @@ function filterAndGroupExotics(
 
 /** A drawer to select an exotic for your build. */
 export default function ExoticPicker({ lockedExoticHash, classType, onSelected, onClose }: Props) {
+  classType: DestinyClass;
   const defs = useD2Definitions()!;
   const language = useSelector(languageSelector);
   const [query, setQuery] = useState('');
 
   const allItems = useSelector(allItemsSelector);
+  const vendorItems = useSelector((state: RootState) =>
+    includeVendorItems ? characterVendorItemsSelector(state, storeId) : emptyArray<DimItem>(),
+  );
 
   const lockableExotics = useMemo(
-    () => findLockableExotics(allItems, classType, defs),
-    [allItems, classType, defs],
+    () => findLockableExotics(allItems, vendorItems, classType, defs),
+    [allItems, vendorItems, classType, defs],
   );
 
   const filteredOrderedAndGroupedExotics = useMemo(

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -135,16 +135,24 @@ function filterAndGroupExotics(
 }
 
 /** A drawer to select an exotic for your build. */
-export default function ExoticPicker({ lockedExoticHash, classType, onSelected, onClose }: Props) {
+export default function ExoticPicker({
+  lockedExoticHash,
+  classType,
+  vendorItems,
+  onSelected,
+  onClose,
+}: {
+  lockedExoticHash?: number;
   classType: DestinyClass;
+  vendorItems: DimItem[];
+  onSelected: (lockedExoticHash: number) => void;
+  onClose: () => void;
+}) {
   const defs = useD2Definitions()!;
   const language = useSelector(languageSelector);
   const [query, setQuery] = useState('');
 
   const allItems = useSelector(allItemsSelector);
-  const vendorItems = useSelector((state: RootState) =>
-    includeVendorItems ? characterVendorItemsSelector(state, storeId) : emptyArray<DimItem>(),
-  );
 
   const lockableExotics = useMemo(
     () => findLockableExotics(allItems, vendorItems, classType, defs),

--- a/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
@@ -23,10 +23,16 @@ export type ChooseItemFunction = (
 
 export const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
   classType,
+  className,
+  storeId,
+  includeVendorItems,
   lockedExoticHash,
   lbDispatch,
 }: {
   classType: DestinyClass;
+  storeId: string;
+  className?: string;
+  includeVendorItems: boolean;
   lockedExoticHash: number | undefined;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
@@ -52,7 +58,9 @@ export const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
       {showExoticPicker && (
         <ExoticPicker
           lockedExoticHash={lockedExoticHash}
+          storeId={storeId}
           classType={classType}
+          includeVendorItems={includeVendorItems}
           onSelected={(exotic) => lbDispatch({ type: 'lockExotic', lockedExoticHash: exotic })}
           onClose={() => setShowExoticPicker(false)}
         />

--- a/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerMenuItems.tsx
@@ -23,16 +23,12 @@ export type ChooseItemFunction = (
 
 export const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
   classType,
-  className,
-  storeId,
-  includeVendorItems,
+  vendorItems,
   lockedExoticHash,
   lbDispatch,
 }: {
   classType: DestinyClass;
-  storeId: string;
-  className?: string;
-  includeVendorItems: boolean;
+  vendorItems: DimItem[];
   lockedExoticHash: number | undefined;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
@@ -58,9 +54,8 @@ export const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
       {showExoticPicker && (
         <ExoticPicker
           lockedExoticHash={lockedExoticHash}
-          storeId={storeId}
           classType={classType}
-          includeVendorItems={includeVendorItems}
+          vendorItems={vendorItems}
           onSelected={(exotic) => lbDispatch({ type: 'lockExotic', lockedExoticHash: exotic })}
           onClose={() => setShowExoticPicker(false)}
         />


### PR DESCRIPTION
This makes two changes:
1. When using the new stat editor (a proxy for "new LO features"), always include vendor items and hide the preference.
2. Include vendor items in the exotic picker, since selecting a vendor item will still let you build sets.