### PR TITLE
Stat constraint editor styling fixes

### DIFF
--- a/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
@@ -7,24 +7,22 @@
 }
 
 .grip {
+  grid-area: grip;
   opacity: 0.5;
   font-size: 10px;
   padding-left: 10px;
+  padding-top: 8px;
   align-self: stretch;
   composes: flexRow from '../../dim-ui/common.m.scss';
-  align-items: center;
-}
-
-.ignored {
-  opacity: 0.4;
+  align-items: flex-start;
 }
 
 .row {
   display: grid;
-  grid-template-columns: 1fr min-content;
+  grid-template-columns: min-content 1fr min-content;
   grid-template-areas:
-    'name buttons'
-    'bar bar';
+    'grip name buttons'
+    'grip bar bar';
   gap: 4px 4px;
   margin-bottom: 2px;
   background-color: black;
@@ -33,6 +31,10 @@
 
   > * {
     white-space: nowrap;
+  }
+
+  &.ignored {
+    grid-template-areas: 'grip name buttons';
   }
 }
 
@@ -53,6 +55,10 @@
   overflow: hidden;
   align-self: stretch;
   width: 100%;
+
+  .ignored & {
+    opacity: 0.4;
+  }
 }
 
 .statBar {
@@ -68,7 +74,7 @@
   background-color: var(--theme-button-bg);
   color: var(--theme-button-text);
   font-size: 12px;
-  height: 24px;
+  height: 20px;
   box-sizing: border-box;
 
   /* stylelint-disable-next-line no-descending-specificity */
@@ -105,7 +111,7 @@
   padding: 4px 6px;
   opacity: 0.9;
 
-  &.ignored,
+  .ignored &,
   &:disabled {
     opacity: 0.9;
     color: #555;
@@ -113,7 +119,9 @@
 
   &:hover,
   &:focus-visible {
-    color: var(--theme-accent-primary);
+    &:not(:disabled) {
+      color: var(--theme-accent-primary);
+    }
   }
 }
 

--- a/src/app/loadout-builder/filter/StatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.tsx
@@ -113,34 +113,34 @@ function StatRow({
     <Draggable draggableId={statHash.toString()} index={index}>
       {(provided, snapshot) => (
         <div
-          className={clsx(styles.row, { [styles.dragging]: snapshot.isDragging })}
+          className={clsx(styles.row, {
+            [styles.dragging]: snapshot.isDragging,
+            [styles.ignored]: statConstraint.ignored,
+          })}
           data-index={index}
           ref={provided.innerRef}
           {...provided.draggableProps}
         >
+          <span
+            className={styles.grip}
+            {...provided.dragHandleProps}
+            tabIndex={-1}
+            aria-hidden={true}
+          >
+            <AppIcon icon={dragHandleIcon} />
+          </span>
           <div className={styles.name}>
-            <span
-              className={styles.grip}
-              {...provided.dragHandleProps}
-              tabIndex={-1}
-              aria-hidden={true}
-            >
-              <AppIcon icon={dragHandleIcon} />
-            </span>
             <button
               type="button"
               role="checkbox"
               aria-checked={!statConstraint.ignored}
-              className={clsx({ [styles.ignored]: statConstraint.ignored }, styles.rowControl)}
+              className={styles.rowControl}
               onClick={handleIgnore}
               title={t('LoadoutBuilder.IgnoreStat')}
             >
               <AppIcon icon={statConstraint.ignored ? faSquare : faCheckSquare} />
             </button>
-            <div
-              className={clsx({ [styles.ignored]: statConstraint.ignored }, styles.label)}
-              {...provided.dragHandleProps}
-            >
+            <div className={styles.label} {...provided.dragHandleProps}>
               <BungieImage
                 className={styles.iconStat}
                 src={statDef.displayProperties.icon}


### PR DESCRIPTION
Before:
<img width="336" alt="Screenshot 2023-11-04 at 6 25 16 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/29666eca-cfe2-4ef7-9f2b-e88211483815">

After:
<img width="339" alt="Screenshot 2023-11-04 at 6 21 56 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/c1411a71-27e0-481d-9902-429a4352eb43">

Some of the suggestions @guise had made, plus some other mild tweaks.

