### PR TITLE
Fold super selection into subclass icon

### DIFF
--- a/src/app/loadout/item-utils.ts
+++ b/src/app/loadout/item-utils.ts
@@ -47,7 +47,11 @@ export function getSubclassPlugs(
   defs: D2ManifestDefinitions,
   subclass: ResolvedLoadoutItem | undefined,
 ) {
-  const plugs: { plug: PluggableInventoryItemDefinition; canBeRemoved: boolean }[] = [];
+  const plugs: {
+    plug: PluggableInventoryItemDefinition;
+    canBeRemoved: boolean;
+    socketCategoryHash: number;
+  }[] = [];
 
   if (subclass?.item.sockets?.categories) {
     for (const category of subclass.item.sockets.categories) {
@@ -62,7 +66,7 @@ export function getSubclassPlugs(
         const hash = override || (!canBeRemoved && initial);
         const plug = hash && defs.InventoryItem.get(hash);
         if (plug && isPluggableItem(plug)) {
-          plugs.push({ plug, canBeRemoved });
+          plugs.push({ plug, canBeRemoved, socketCategoryHash: category.category.hash });
         }
       }
     }

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -8,7 +8,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getSubclassPlugs } from '../item-utils';
@@ -75,9 +75,6 @@ export default function LoadoutEditSubclass({
                   // plugs in the loadout and they may be different to the popup
                   onClick={plugs.length ? undefined : onClick}
                   item={subclass.item}
-                  // don't show the selected Super ability because we are displaying the Super ability plug next
-                  // to the subclass icon
-                  hideSelectedSuper
                 />
               )}
             </ItemPopupTrigger>
@@ -96,13 +93,16 @@ export default function LoadoutEditSubclass({
       </div>
       {plugs.length ? (
         <div className={styles.subclassMods}>
-          {plugs?.map((plug) => (
-            <PlugDef
-              key={getModRenderKey(plug.plug)}
-              plug={plug.plug}
-              forClassType={subclass?.item.classType}
-            />
-          ))}
+          {plugs?.map(
+            (plug) =>
+              plug.socketCategoryHash !== SocketCategoryHashes.Super && (
+                <PlugDef
+                  key={getModRenderKey(plug.plug)}
+                  plug={plug.plug}
+                  forClassType={subclass?.item.classType}
+                />
+              ),
+          )}
         </div>
       ) : (
         <div className={styles.modsPlaceholder}>{t('Loadouts.Abilities')}</div>

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -6,6 +6,7 @@ import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import clsx from 'clsx';
+import { SocketCategoryHashes } from 'data/d2/generated-enums';
 import { useMemo } from 'react';
 import { getSubclassPlugs } from '../item-utils';
 import { createGetModRenderKey } from '../mod-utils';
@@ -42,9 +43,6 @@ export default function LoadoutSubclassSection({
                   // plugs in the loadout and they may be different to the popup
                   onClick={plugs.length ? undefined : onClick}
                   item={subclass.item}
-                  // don't show the selected Super ability because we are displaying the Super ability plug next
-                  // to the subclass icon
-                  hideSelectedSuper
                 />
               )}
             </ItemPopupTrigger>
@@ -61,13 +59,16 @@ export default function LoadoutSubclassSection({
       </div>
       {plugs.length ? (
         <div className={styles.subclassMods}>
-          {plugs?.map((plug) => (
-            <PlugDef
-              key={getModRenderKey(plug.plug)}
-              plug={plug.plug}
-              forClassType={subclass?.item.classType}
-            />
-          ))}
+          {plugs?.map(
+            (plug) =>
+              plug.socketCategoryHash !== SocketCategoryHashes.Super && (
+                <PlugDef
+                  key={getModRenderKey(plug.plug)}
+                  plug={plug.plug}
+                  forClassType={subclass?.item.classType}
+                />
+              ),
+          )}
         </div>
       ) : (
         <div className={styles.modsPlaceholder}>{t('Loadouts.Abilities')}</div>


### PR DESCRIPTION
This change stops showing the subclass' super separately in the loadout view and editors, instead showing it directly on the subclass diamond:

Before:
<img width="214" alt="Screenshot 2023-11-05 at 4 53 25 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/131224fd-0cba-4b97-b173-248e35d48946">

After:
<img width="213" alt="Screenshot 2023-11-05 at 4 53 10 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/9ef493f2-c5f7-4642-81da-02c5f1b8bee0">