### PR TITLE
Precache test manifest

### DIFF
--- a/.github/workflows/pr-test-and-lint.yml
+++ b/.github/workflows/pr-test-and-lint.yml
@@ -27,8 +27,17 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Cache Manifest
+        id: destiny-manifest
+        uses: actions/cache@v3
+        with:
+          path: manifest-cache
+          key: destiny-manifest
+
       - name: Jest Test
         run: pnpm jest
+        env:
+          CLEAN_MANIFEST_CACHE: true
 
       - uses: actions/upload-artifact@v3  # upload test results
         if: success() || failure()        # run this step even if previous step failed

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "cross-env NODE_ENV=test jest --verbose",
+    "test": "jest -i src/testing/precache-manifest.test.ts && cross-env NODE_ENV=test LOCAL_MANIFEST=true jest --verbose",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint src --ext .js,.ts,.tsx",
     "lint:prettier": "prettier \"src/**/*.{js,ts,tsx,cjs,mjs,cts,mts,scss}\" --check",

--- a/src/testing/precache-manifest.test.ts
+++ b/src/testing/precache-manifest.test.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getTestManifestJson } from './test-utils';
+
+test('precache manifest', async () => {
+  const [_manifest, filename] = await getTestManifestJson();
+  console.log('Loaded manifest to', filename);
+
+  // This is for our CI workers - it prevents the cache from accumulating manifests
+  if (process.env.CLEAN_MANIFEST_CACHE) {
+    const cacheDir = path.resolve(__dirname, '..', '..', 'manifest-cache');
+    const files = (await fs.readdir(cacheDir)).filter((f) => f !== path.basename(filename));
+    console.log(
+      'Cleaning manifest cache of files',
+      files,
+      files.map((f) => path.join(cacheDir, f)),
+    );
+    await Promise.all(files.map((f) => fs.unlink(path.join(cacheDir, f))));
+  }
+});


### PR DESCRIPTION
This is pretty kludgy but it aims to solve the problem in #9981 - multiple tests are running at once, they're all downloading the manifest together, and writing to the same file concurrently, which breaks all the tests. Fixing this is complicated because Jest goes to great lengths to sandbox test runs, so they can't really communicate with each other (this is why my original attempt of using `_.once` didn't work).

This version works by running a single "test" first, all by itself, which simply downloads the manifest. I tried to get this to just be a straightforward script but the combination of ESM and TypeScript has rendered ts-node inoperable and test-utils makes use of too much normal DIM code. After this has run, we run the full test suite with the `LOCAL_MANIFEST` environment variable, which switches the manifest-fetching logic to just look for the most recent JSON file in the manifest cache directory and use it. This has the advantage of skipping the remote manifest info calls as well.

I also added a cache step to the GitHub action, so ideally most test runs should start out with a fresh manifest and not have to download it from bungie.net at all. I also added a fallback so when bungie.net is down, we use whatever cached manifest is there. To keep the GHA cache from growing, when run from GHA we set another environment variable that causes us to delete all but the most recent manifest file.

An alternative I was thinking about was to use a lockfile strategy, leveraging [node-proper-lockfile](https://github.com/moxystudio/node-proper-lockfile) - this has the advantage of not requiring the pre-cache step but would still require most of the other machinery (deleting all but the most recent file for GHA caching, using the most recent file to avoid calling the manifest API a ton, etc). I might try it out after this, but for now, this should resolve our test flakiness issues.