### PR TITLE
Clean up vendors styles

### DIFF
--- a/src/app/destiny1/vendors/D1VendorItem.m.scss
+++ b/src/app/destiny1/vendors/D1VendorItem.m.scss
@@ -9,13 +9,11 @@
   vertical-align: text-bottom;
 }
 
-.vendorCosts {
-  margin-top: -4px;
-  margin-bottom: 4px;
-}
-
 .cost {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
   font-size: 10px;
   margin-top: 1px;
-  text-align: center;
 }

--- a/src/app/destiny1/vendors/D1VendorItem.m.scss.d.ts
+++ b/src/app/destiny1/vendors/D1VendorItem.m.scss.d.ts
@@ -4,7 +4,6 @@ interface CssExports {
   'cost': string;
   'currency': string;
   'notEnough': string;
-  'vendorCosts': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/destiny1/vendors/D1VendorItem.tsx
+++ b/src/app/destiny1/vendors/D1VendorItem.tsx
@@ -21,7 +21,7 @@ export default function D1VendorItem({ saleItem, owned, totalCoins }: Props) {
       extraData={{ failureStrings: [saleItem.failureStrings] }}
     >
       {saleItem.costs.length > 0 && (
-        <div className={styles.vendorCosts}>
+        <div>
           {saleItem.costs.map((cost) => (
             <D1VendorItemCost key={cost.currency.itemHash} cost={cost} totalCoins={totalCoins} />
           ))}

--- a/src/app/destiny1/vendors/D1VendorItems.tsx
+++ b/src/app/destiny1/vendors/D1VendorItems.tsx
@@ -32,16 +32,20 @@ export default function D1VendorItems({
       {!_.isEmpty(allCurrencies) && (
         <div className={styles.currencies}>
           {Object.values(allCurrencies).map((currency) => (
-            <div className={styles.currency} key={currency.itemHash}>
+            <div key={currency.itemHash}>
               {totalCoins?.[currency.itemHash] || 0}{' '}
-              <BungieImage src={currency.icon} title={currency.itemName} />
+              <BungieImage
+                src={currency.icon}
+                className={styles.currencyIcon}
+                title={currency.itemName}
+              />
             </div>
           ))}
         </div>
       )}
       <div className={styles.itemCategories}>
         {vendor.categories.map((category) => (
-          <div className={styles.vendorRow} key={category.index}>
+          <div key={category.index}>
             <h3 className={styles.categoryTitle}>{category.title || 'Unknown'}</h3>
             <div className={styles.vendorItems}>
               {_.sortBy(category.saleItems, (i) => i.item.name).map((item) => (

--- a/src/app/vendors/Vendor.m.scss
+++ b/src/app/vendors/Vendor.m.scss
@@ -13,6 +13,7 @@
   font-size: 12px;
   flex: 1;
   opacity: 0.6;
+  text-align: left;
 }
 
 .title {
@@ -26,7 +27,6 @@
 .countdown {
   font-size: 11px;
   text-align: right;
-  flex: 1;
   margin-left: 8px;
   white-space: nowrap;
 }

--- a/src/app/vendors/VendorItem.m.scss
+++ b/src/app/vendors/VendorItem.m.scss
@@ -4,7 +4,6 @@
   cursor: pointer;
   height: 54px;
   width: 123px;
-  margin-right: 4px;
 }
 
 .ownershipIcon {
@@ -40,12 +39,15 @@
 }
 
 .vendorItem {
-  display: flex;
-  flex-direction: column;
+  composes: flexColumn from '../dim-ui/common.m.scss';
   align-items: center;
   position: relative;
-  margin-right: var(--item-margin);
-  cursor: pointer;
+  width: min-content;
+  text-align: center;
+
+  :global(.item) {
+    cursor: pointer;
+  }
 
   :global(.item-img) {
     object-fit: cover;
@@ -56,11 +58,6 @@
   :global(.item) {
     opacity: 0.3;
   }
-}
-
-.vendorCosts {
-  margin-top: -4px;
-  margin-bottom: 4px;
 }
 
 .cost {

--- a/src/app/vendors/VendorItem.m.scss.d.ts
+++ b/src/app/vendors/VendorItem.m.scss.d.ts
@@ -8,7 +8,6 @@ interface CssExports {
   'ownershipIcon': string;
   'tile': string;
   'unavailable': string;
-  'vendorCosts': string;
   'vendorItem': string;
 }
 export const cssExports: CssExports;

--- a/src/app/vendors/VendorItemComponent.tsx
+++ b/src/app/vendors/VendorItemComponent.tsx
@@ -68,7 +68,7 @@ export default function VendorItemComponent({
       extraData={{ failureStrings: item.failureStrings, characterId, owned, acquired, mod }}
     >
       {item.costs.length > 0 && (
-        <div className={styles.vendorCosts}>
+        <div>
           {item.costs.map((cost) => (
             <Cost key={cost.itemHash} cost={cost} className={styles.cost} />
           ))}

--- a/src/app/vendors/VendorItems.m.scss
+++ b/src/app/vendors/VendorItems.m.scss
@@ -1,48 +1,45 @@
 @use '../variables.scss' as *;
 
 .currencies {
-  font-size: 12px;
-  margin-top: 4px;
-  margin-bottom: 4px;
   display: flex;
   flex-flow: row wrap;
-  row-gap: 4px;
+  gap: 4px 10px;
+  font-size: 12px;
+  margin-top: 4px;
   justify-content: flex-end;
+  float: right;
 
   @include phone-portrait {
     margin-right: var(--item-margin);
   }
 }
 
-.currency {
-  margin-left: 10px;
-  &:first-child {
-    margin-left: 0;
-  }
-  img {
-    vertical-align: bottom;
-    height: 16px;
-    width: 16px;
-  }
+.currencyIcon {
+  vertical-align: bottom;
+  height: 16px;
+  width: 16px;
 }
 
 .itemCategories {
-  display: flex;
-  flex-flow: row wrap;
+  composes: flexWrap from '../dim-ui/common.m.scss';
   margin-bottom: 1.5em;
+  gap: 4px 32px;
+  float: left;
+  margin-top: 8px;
 
   @include phone-portrait {
-    display: block;
+    flex-flow: column nowrap;
+    gap: 8px 0;
   }
 }
 
 .categoryTitle {
   margin-top: 10px;
-  margin-left: 2px;
   text-transform: uppercase;
   font-size: 12px;
   color: #ccc;
   margin-bottom: 4px;
+
   &:first-child {
     margin-top: 0;
   }
@@ -50,25 +47,12 @@
 
 .vendorItems {
   composes: flexWrap from '../dim-ui/common.m.scss';
-
-  :global(.item) {
-    cursor: pointer;
-    margin-bottom: 4px;
-  }
+  gap: var(--item-margin);
 }
 
 .vendorContents {
   @include phone-portrait {
     margin-left: var(--inventory-column-padding);
     margin-right: calc(var(--inventory-column-padding) - var(--item-margin));
-  }
-}
-
-.vendorRow {
-  margin-bottom: 4px;
-  margin-right: 32px;
-
-  @include phone-portrait {
-    margin-right: 0;
   }
 }

--- a/src/app/vendors/VendorItems.m.scss.d.ts
+++ b/src/app/vendors/VendorItems.m.scss.d.ts
@@ -3,11 +3,10 @@
 interface CssExports {
   'categoryTitle': string;
   'currencies': string;
-  'currency': string;
+  'currencyIcon': string;
   'itemCategories': string;
   'vendorContents': string;
   'vendorItems': string;
-  'vendorRow': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/vendors/VendorItems.tsx
+++ b/src/app/vendors/VendorItems.tsx
@@ -47,11 +47,12 @@ export default function VendorItems({
       {vendor.currencies.length > 0 && (
         <div className={styles.currencies}>
           {vendor.currencies.map((currency) => (
-            <div className={styles.currency} key={currency.hash}>
+            <div key={currency.hash}>
               {(currencyLookups?.[currency.hash] || 0).toLocaleString()}{' '}
               <BungieImage
                 height={16}
                 width={16}
+                className={styles.currencyIcon}
                 src={currency.displayProperties.icon}
                 title={currency.displayProperties.name}
               />
@@ -61,7 +62,7 @@ export default function VendorItems({
       )}
       <div className={styles.itemCategories}>
         {faction && factionProgress && (
-          <div className={styles.vendorRow}>
+          <div>
             <h3 className={styles.categoryTitle}>{t('Vendors.Engram')}</h3>
             <div className={styles.vendorItems}>
               {factionProgress &&
@@ -89,7 +90,7 @@ export default function VendorItems({
             categoryIndex !== undefined &&
             vendor.def.displayCategories[categoryIndex] &&
             !ignoreCategories.includes(vendor.def.displayCategories[categoryIndex].identifier) && (
-              <div className={styles.vendorRow} key={categoryIndex}>
+              <div key={categoryIndex}>
                 <h3 className={styles.categoryTitle}>
                   <RichDestinyText
                     text={

--- a/src/app/vendors/Vendors.m.scss
+++ b/src/app/vendors/Vendors.m.scss
@@ -1,8 +1,7 @@
 @use '../variables' as *;
 
 .buttons {
-  display: flex;
-  flex-direction: column;
+  composes: flexColumn from '../dim-ui/common.m.scss';
   margin: 8px 0;
   gap: 8px;
 


### PR DESCRIPTION
A bunch of relatively subtle improvements to the vendor styling. Adjusting alignments and sizes, allowing things to get a little closer together or take up more of the space, etc.

Before:
<img width="1226" alt="Screenshot 2023-11-09 at 10 07 23 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/d6c808fe-845a-48b6-a6b6-64acd4f35732">

After:
<img width="1220" alt="Screenshot 2023-11-09 at 10 07 36 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/d858abd3-8ed3-44b7-bea9-118b4f690638">