### PR TITLE
Run "pnpm test" not "pnpm jest"

### DIFF
--- a/.github/workflows/pr-test-and-lint.yml
+++ b/.github/workflows/pr-test-and-lint.yml
@@ -35,7 +35,7 @@ jobs:
           key: destiny-manifest
 
       - name: Jest Test
-        run: pnpm jest
+        run: pnpm test
         env:
           CLEAN_MANIFEST_CACHE: true
 


### PR DESCRIPTION
#10068 didn't have the intended effect because we were actually running `pnpm jest` in GHA, not `pnpm test` - so it was running `jest` directly without precaching or environment variables.