### PR TITLE
Try to make manifest cache work across runs

### DIFF
--- a/.github/workflows/pr-test-and-lint.yml
+++ b/.github/workflows/pr-test-and-lint.yml
@@ -32,7 +32,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: manifest-cache
-          key: destiny-manifest
+          key: destiny-manifest-${{ github.run_id }}
+          restore-keys: |
+            destiny-manifest
 
       - name: Jest Test
         run: pnpm test


### PR DESCRIPTION
The docs for https://github.com/actions/cache are just vague enough that I can't figure out exactly why it's not working:

<img width="532" alt="Screenshot 2023-11-09 at 11 54 07 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/623cf29e-7428-4523-926e-e67a06432a74">

I'm trying the technique at https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache to make it go better.