### PR TITLE
Fix crash in loadout analyzer, catch exceptions so task doesn't get stuck

### DIFF
--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -141,7 +141,7 @@ export async function analyzeLoadout(
     let allLegendariesMasterworked = true;
     let exoticNotMasterworked = false;
     for (const armorItem of loadoutArmor) {
-      if (armorItem.energy!.energyCapacity < MAX_ARMOR_ENERGY_CAPACITY) {
+      if (armorItem.energy && armorItem.energy.energyCapacity < MAX_ARMOR_ENERGY_CAPACITY) {
         if (armorItem.isExotic) {
           exoticNotMasterworked = true;
         } else {


### PR DESCRIPTION
Who on earth still uses Armor 1.0/1.5 in loadouts... Fixes [DIM-1NYZ](https://destiny-item-manager.sentry.io/issues/4604776176/).