### PR TITLE
Unify strict upgrade merging logic

### DIFF
--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -261,7 +261,9 @@ export async function analyzeLoadout(
           await delay(0);
 
           existingLoadoutStatsAsStatConstraints = statConstraints.map((c) => ({
-            ...c,
+            statHash: c.statHash,
+            ignored: c.ignored,
+            maxTier: 10,
             minTier: statTier(assumedLoadoutStats[c.statHash]!.value),
           }));
           const { mergedConstraints, mergedConstraintsImplyStrictUpgrade } =

--- a/src/app/loadout-analyzer/utils.ts
+++ b/src/app/loadout-analyzer/utils.ts
@@ -1,0 +1,37 @@
+import { ResolvedStatConstraint } from 'app/loadout-builder/types';
+
+/**
+ * Loadout Analysis (and the corresponding LO mode) sometimes are interested in strictly better tiers.
+ * This takes (assumed) loadout stats and the user-selected stat constraints and merges them so that a
+ * set satisfying the merged constraints always satisfies both the input constraint sets.
+ *
+ * Returns `mergedConstraintsImplyStrictUpgrade` iff every valid set in the merged constraints is also
+ * always a strict upgrade, so that we don't have to ask the process worker for strict upgrades on top of that.
+ */
+export function mergeStrictUpgradeStatConstraints(
+  existingLoadoutStatsAsStatConstraints: ResolvedStatConstraint[] | undefined,
+  parameterStatConstraints: ResolvedStatConstraint[],
+): {
+  mergedConstraints: ResolvedStatConstraint[];
+  mergedConstraintsImplyStrictUpgrade: boolean;
+} {
+  // If a user-selected stat tier ends up higher than the corresponding existing loadout tier,
+  // then every valid process set already is a strict upgrade (since effective stat constraints
+  // are always >= existing constraints and there's one constraint that's higher than
+  // the existing tier, satisfying the definition of "strict upgrade").
+  let mergedConstraintsImplyStrictUpgrade = false;
+  const mergedConstraints = parameterStatConstraints.map((constraint) => {
+    const strictUpgradeConstraint = existingLoadoutStatsAsStatConstraints?.find(
+      (c) => c.statHash === constraint.statHash,
+    );
+    if (strictUpgradeConstraint && !constraint.ignored) {
+      mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > strictUpgradeConstraint.minTier;
+      return {
+        ...constraint,
+        minTier: Math.max(constraint.minTier, strictUpgradeConstraint.minTier),
+      };
+    }
+    return constraint;
+  });
+  return { mergedConstraints, mergedConstraintsImplyStrictUpgrade };
+}

--- a/src/app/loadout-analyzer/utils.ts
+++ b/src/app/loadout-analyzer/utils.ts
@@ -21,14 +21,15 @@ export function mergeStrictUpgradeStatConstraints(
   // the existing tier, satisfying the definition of "strict upgrade").
   let mergedConstraintsImplyStrictUpgrade = false;
   const mergedConstraints = parameterStatConstraints.map((constraint) => {
-    const strictUpgradeConstraint = existingLoadoutStatsAsStatConstraints?.find(
+    const existingLoadoutTier = existingLoadoutStatsAsStatConstraints?.find(
       (c) => c.statHash === constraint.statHash,
     );
-    if (strictUpgradeConstraint && !constraint.ignored) {
-      mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > strictUpgradeConstraint.minTier;
+    if (existingLoadoutTier && !constraint.ignored) {
+      const effectiveLoadoutTier = Math.min(constraint.maxTier, existingLoadoutTier.minTier);
+      mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > effectiveLoadoutTier;
       return {
         ...constraint,
-        minTier: Math.max(constraint.minTier, strictUpgradeConstraint.minTier),
+        minTier: Math.max(constraint.minTier, effectiveLoadoutTier),
       };
     }
     return constraint;

--- a/src/app/loadout-analyzer/utils.ts
+++ b/src/app/loadout-analyzer/utils.ts
@@ -25,7 +25,8 @@ export function mergeStrictUpgradeStatConstraints(
       (c) => c.statHash === constraint.statHash,
     );
     if (existingLoadoutTier && !constraint.ignored) {
-      const effectiveLoadoutTier = Math.min(constraint.maxTier, existingLoadoutTier.minTier);
+      const existingTierValue = existingLoadoutTier.ignored ? 0 : existingLoadoutTier.minTier;
+      const effectiveLoadoutTier = Math.min(constraint.maxTier, existingTierValue);
       mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > effectiveLoadoutTier;
       return {
         ...constraint,

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -10,6 +10,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { getStore } from 'app/inventory/stores-helpers';
 import { useHideItemPicker, useItemPicker } from 'app/item-picker/item-picker';
+import { mergeStrictUpgradeStatConstraints } from 'app/loadout-analyzer/utils';
 import { LoadoutUpdateFunction } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { newLoadoutFromEquipped, resolveLoadoutModHashes } from 'app/loadout-drawer/loadout-utils';
@@ -243,31 +244,10 @@ export default memo(function LoadoutBuilder({
     [classType, defs, includeRuntimeStatBenefits, modsToAssign, subclass],
   );
 
-  // If we're in "strict upgrades only" mode from hitting the "Optimize Armor" mode,
-  // our effective stat constraints are the union of loadout/selected stat constraints
-  // and existing armor set constraints (element-wise max of min tiers).
-  // If a user-selected stat tier ends up higher than the corresponding existing loadout tier,
-  // then every valid process set already is a strict upgrade (since effective stat constraints
-  // are always >= existing constraints and there's one constraint that's higher than
-  // the existing tier, satisfying the definition of "strict upgrade") and we don't need
-  // to ask the process worker to return strict upgrades on top of that, as it'd exclude valid sets.
-  const [effectiveStatConstraints, effectiveStatConstraintsImplyStrictUpgrade] = useMemo(() => {
-    let impliesStrictUpgrade = false;
-    const constraints = resolvedStatConstraints.map((constraint) => {
-      const strictUpgradeConstraint = strictUpgradesStatConstraints?.find(
-        (c) => c.statHash === constraint.statHash,
-      );
-      if (strictUpgradeConstraint && !constraint.ignored) {
-        impliesStrictUpgrade ||= constraint.minTier > strictUpgradeConstraint.minTier;
-        return {
-          ...constraint,
-          minTier: Math.max(constraint.minTier, strictUpgradeConstraint.minTier),
-        };
-      }
-      return constraint;
-    });
-    return [constraints, impliesStrictUpgrade];
-  }, [resolvedStatConstraints, strictUpgradesStatConstraints]);
+  const { mergedConstraints, mergedConstraintsImplyStrictUpgrade } = useMemo(
+    () => mergeStrictUpgradeStatConstraints(strictUpgradesStatConstraints, resolvedStatConstraints),
+    [resolvedStatConstraints, strictUpgradesStatConstraints],
+  );
 
   // Run the actual loadout generation process in a web worker
   const { result, processing } = useProcess({
@@ -276,12 +256,10 @@ export default memo(function LoadoutBuilder({
     lockedModMap,
     modStatChanges,
     armorEnergyRules,
-    resolvedStatConstraints: effectiveStatConstraints,
+    resolvedStatConstraints: mergedConstraints,
     anyExotic: lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC,
     autoStatMods,
-    strictUpgrades: Boolean(
-      strictUpgradesStatConstraints && !effectiveStatConstraintsImplyStrictUpgrade,
-    ),
+    strictUpgrades: Boolean(strictUpgradesStatConstraints && !mergedConstraintsImplyStrictUpgrade),
   });
 
   const resultSets = result?.sets;


### PR DESCRIPTION
A small refactoring, with the one intended behavioral change that if a saved loadout does not satisfy its stat constraints but there are sets that do AND are strictly better, the loadout will now reliably show "better stats available" instead of only sometimes.