### PR TITLE
Show records menu on mobile

### DIFF
--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -110,21 +110,25 @@
   align-items: center;
   margin-bottom: 4px;
   min-height: 24px;
+  gap: 4px;
 
-  @media (hover: hover) {
-    &:hover {
+  @include phone-portrait {
+    padding: 6px 10px;
+    font-size: 16px;
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: var(--theme-accent-primary);
+
+    :global(.app-icon) {
       color: var(--theme-accent-primary);
-
-      :global(.app-icon) {
-        color: var(--theme-accent-primary);
-      }
     }
   }
 
   img {
     height: 24px;
     width: 24px;
-    margin-right: 4px;
   }
   > span:not(:global(.app-icon)) {
     flex: 1;

--- a/src/app/records/Records.m.scss
+++ b/src/app/records/Records.m.scss
@@ -10,6 +10,6 @@
   gap: 8px;
 
   @include phone-portrait {
-    padding: 8px var(--inventory-column-padding);
+    padding: 8px 10px;
   }
 }

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -117,15 +117,11 @@ export default function Records({ account }: Props) {
   return (
     <PageWithMenu className="d2-vendors">
       <PageWithMenu.Menu>
-        {!isPhonePortrait && (
-          <>
-            {menuItems.map((menuItem) => (
-              <PageWithMenu.MenuButton key={menuItem.id} anchor={menuItem.id}>
-                <span>{menuItem.title}</span>
-              </PageWithMenu.MenuButton>
-            ))}
-          </>
-        )}
+        {menuItems.map((menuItem) => (
+          <PageWithMenu.MenuButton key={menuItem.id} anchor={menuItem.id}>
+            <span>{menuItem.title}</span>
+          </PageWithMenu.MenuButton>
+        ))}
         <div className={styles.presentationNodeOptions}>
           <CheckButton
             name="hide-completed"

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -8,7 +8,7 @@ import { destiny2CoreSettingsSelector, useD2Definitions } from 'app/manifest/sel
 import { TrackedTriumphs } from 'app/progress/TrackedTriumphs';
 import { searchFilterSelector } from 'app/search/search-filter';
 import { useSetting } from 'app/settings/hooks';
-import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
+import { querySelector } from 'app/shell/selectors';
 import { filterMap } from 'app/utils/collections';
 import { usePageTitle } from 'app/utils/hooks';
 import _ from 'lodash';
@@ -34,7 +34,6 @@ interface Props {
  * The records screen shows account-wide things like Triumphs and Collections.
  */
 export default function Records({ account }: Props) {
-  const isPhonePortrait = useIsPhonePortrait();
   useLoadStores(account);
   const [searchParams] = useSearchParams();
   usePageTitle(t('Records.Title'));


### PR DESCRIPTION
The records page is pretty huge - it's not bad to use the menu on desktop, but on mobile it's just all scrolling. This brings the menu into mobile so you can jump to whatever you want. You can always click the status bar on your phone to scroll back up to the top.