### PR TITLE
Add is:vendor search

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -319,6 +319,7 @@
     "UnlockAllFailed": "Failed to unlock items",
     "UnlockAllSuccess": "Unlocked {{num}} items",
     "Vendor": "Item is available from a specific vendor.",
+    "VendorItem": "Item is from a vendor, not in your inventory. Useful for excluding vendor items from Loadout Optimizer.",
     "WeaponType": "Shows weapons based on their weapon type.",
     "WeaponLevel": "Shows weapons based on their Weapon Level.",
     "Wishlist": "Shows items that match your wish list.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Next
 
+* Added `is:vendor` search that is useful for excluding vendor items from Loadout Optimizer (enter `-is:vendor` in the search box).
+
 ## 7.95.0 <span class="changelog-date">(2023-11-19)</span>
 
-* Added an "exactperk:" search that matches a perk name exactly. No more mixing up "Frenzy" with "Feeding Frenzy".
+* Added an `exactperk:` search that matches a perk name exactly. No more mixing up "Frenzy" with "Feeding Frenzy".
 * Fixed a bug where in-game loadouts would be marked as matching a DIM loadout incorrectly.
 
 ## 7.94.1 <span class="changelog-date">(2023-11-13)</span>

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -127,6 +127,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "uncommon",
   "unlocked",
   "vehicle",
+  "vendor",
   "void",
   "warlock",
   "weapon",

--- a/src/app/search/search-filters/simple.ts
+++ b/src/app/search/search-filters/simple.ts
@@ -90,6 +90,12 @@ const simpleFilters: FilterDefinition[] = [
     description: tl('Filter.IsCrafted'),
     filter: () => (item) => item.crafted,
   },
+  {
+    keywords: ['vendor'],
+    destinyVersion: 2,
+    description: tl('Filter.VendorItem'),
+    filter: () => (item) => Boolean(item.vendor),
+  },
 ];
 
 export default simpleFilters;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -317,6 +317,7 @@
     "UnlockAllFailed": "Failed to unlock items",
     "UnlockAllSuccess": "Unlocked {{num}} items",
     "Vendor": "Item is available from a specific vendor.",
+    "VendorItem": "Item is from a vendor, not in your inventory. Useful for excluding vendor items from Loadout Optimizer.",
     "Weapon": "Shows items that are weapons.",
     "WeaponLevel": "Shows weapons based on their Weapon Level.",
     "WeaponType": "Shows weapons based on their weapon type.",


### PR DESCRIPTION
Fixes #10113.

The alternative would be `is:ininventory` which is more awkward imo.