### PR TITLE
Remove pointer events from presstips

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -23,6 +23,7 @@ $horizontal-padding: 11px;
   white-space: pre-wrap;
   box-sizing: border-box;
   user-select: none;
+  pointer-events: none;
 
   // The top 'ribbon' in tooltips that's tinted in different contexts (exotic perks, sub-class details)
   // Note: We don't use border-top-color or 'box-shadow: inset' to color the ribbon


### PR DESCRIPTION
We have never intended for you to be able to mouse onto press tips and have them stay open, but they sorta do support that sometimes now just by virtue of the pointer leave event not firing. This fixes that by explicitly making the tooltip transparent to pointer events. This should make it far less annoying as you move your mouse around on things like the stat constraint editor.