### PR TITLE
Don't show half tiers if auto stat mods is on

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -160,6 +160,7 @@ export default memo(function GeneratedSet({
         boostedStats={boostedStats}
         existingLoadoutName={overlappingLoadout?.name}
         equippedHashes={equippedHashes}
+        autoStatMods={autoStatMods}
       />
       <div className={styles.build}>
         <div className={styles.items}>

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -8,7 +8,7 @@ import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
 import { ArmorStatHashes, ArmorStats, ModStatChanges, ResolvedStatConstraint } from '../types';
-import { remEuclid, statTier, statTierWithHalf } from '../utils';
+import { remEuclid, statTierWithHalf } from '../utils';
 import styles from './SetStats.m.scss';
 import { calculateTotalTier, sumEnabledStats } from './utils';
 
@@ -121,7 +121,7 @@ function Stat({
         })}
       >
         {t('LoadoutBuilder.TierNumber', {
-          tier: showHalfStat ? statTierWithHalf(value) : statTier(value),
+          tier: statTierWithHalf(value),
         })}
       </span>
     </span>

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -8,7 +8,7 @@ import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
 import { ArmorStatHashes, ArmorStats, ModStatChanges, ResolvedStatConstraint } from '../types';
-import { remEuclid, statTierWithHalf } from '../utils';
+import { remEuclid, statTier, statTierWithHalf } from '../utils';
 import styles from './SetStats.m.scss';
 import { calculateTotalTier, sumEnabledStats } from './utils';
 
@@ -25,6 +25,7 @@ export function SetStats({
   className,
   existingLoadoutName,
   equippedHashes,
+  autoStatMods,
 }: {
   stats: ArmorStats;
   getStatsBreakdown: () => ModStatChanges;
@@ -34,6 +35,7 @@ export function SetStats({
   className?: string;
   existingLoadoutName?: string;
   equippedHashes: Set<number>;
+  autoStatMods: boolean;
 }) {
   const defs = useD2Definitions()!;
   const totalTier = calculateTotalTier(stats);
@@ -72,6 +74,7 @@ export function SetStats({
               isBoosted={boostedStats.has(statHash)}
               stat={statDef}
               value={value}
+              showHalfStat={!autoStatMods}
             />
           </PressTip>
         );
@@ -95,13 +98,15 @@ function Stat({
   isActive,
   isBoosted,
   value,
+  showHalfStat,
 }: {
   stat: DestinyStatDefinition;
   isActive: boolean;
   isBoosted: boolean;
   value: number;
+  showHalfStat: boolean;
 }) {
-  const isHalfTier = isActive && remEuclid(value, 10) >= 5;
+  const isHalfTier = showHalfStat && isActive && remEuclid(value, 10) >= 5;
   return (
     <span
       className={clsx(styles.statSegment, {
@@ -116,7 +121,7 @@ function Stat({
         })}
       >
         {t('LoadoutBuilder.TierNumber', {
-          tier: statTierWithHalf(value),
+          tier: showHalfStat ? statTierWithHalf(value) : statTier(value),
         })}
       </span>
     </span>


### PR DESCRIPTION
Fixes #10111. The rationale is that half stats are not actionable when auto stat mods are enabled - if they were, we would've already added a stat mod for them.