### PR TITLE
Always include Sentry, just disable reporting

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -10,7 +10,7 @@ const SELF = "'self'";
 export default function csp(
   env: 'release' | 'beta' | 'dev' | 'pr',
   featureFlags: FeatureFlags,
-  version: string | undefined
+  version: string | undefined,
 ) {
   const baseCSP: Record<string, string[] | string | boolean> = {
     defaultSrc: ["'none'"],

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -15,7 +15,7 @@ import store from './store/store';
 import { isNativeDragAndDropSupported } from './utils/browsers';
 
 // Wrap App with Sentry profiling
-const WrappedApp = $featureFlags.sentry ? withProfiler(App) : App;
+const ProfiledApp = withProfiler(App);
 
 function Root() {
   const options: MultiBackendOptions = {
@@ -41,7 +41,7 @@ function Root() {
       <Provider store={store}>
         <LocationSwitcher />
         <DndProvider options={options}>
-          <WrappedApp />
+          <ProfiledApp />
         </DndProvider>
       </Provider>
     </Router>

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -20,7 +20,6 @@ import { bungieErrorToaster } from '../bungie-api/error-toaster';
 import { D2ManifestDefinitions, getDefinitions } from '../destiny2/d2-definitions';
 import { bungieNetPath } from '../dim-ui/BungieImage';
 import { showNotification } from '../notifications/notifications';
-import { loadingTracker } from '../shell/loading-tracker';
 import { reportException } from '../utils/sentry';
 import {
   CharacterInfo,
@@ -255,9 +254,7 @@ function loadStoresData(
         return;
       }
 
-      const transaction = $featureFlags.sentry
-        ? startTransaction({ name: 'loadStoresD2' })
-        : undefined;
+      const transaction = startTransaction({ name: 'loadStoresD2' });
       // set the transaction on the scope so it picks up any errors
       getCurrentHub()?.configureScope((scope) => scope.setSpan(transaction));
 
@@ -356,8 +353,6 @@ function loadStoresData(
         transaction?.finish();
       }
     })();
-    loadingTracker.addPromise(promise);
-    return promise;
   };
 }
 

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -9,6 +9,7 @@ import { processInGameLoadouts } from 'app/loadout-drawer/loadout-type-converter
 import { inGameLoadoutLoaded } from 'app/loadout/ingame/actions';
 import { loadCoreSettings } from 'app/manifest/actions';
 import { d2ManifestSelector, manifestSelector } from 'app/manifest/selectors';
+import { loadingTracker } from 'app/shell/loading-tracker';
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
 import { convertToError, errorMessage } from 'app/utils/errors';
@@ -353,6 +354,8 @@ function loadStoresData(
         transaction?.finish();
       }
     })();
+    loadingTracker.addPromise(promise);
+    return promise;
   };
 }
 

--- a/src/app/register-service-worker.ts
+++ b/src/app/register-service-worker.ts
@@ -115,12 +115,10 @@ export default function registerServiceWorker() {
           if (registration.waiting) {
             infoLog('SW', 'New content is available; please refresh. (from update)');
 
-            if ($featureFlags.sentry) {
-              // Disable Sentry error logging if this user is on an older version
-              const sentryOptions = getCurrentHub()?.getClient()?.getOptions();
-              if (sentryOptions) {
-                sentryOptions.enabled = false;
-              }
+            // Disable Sentry error logging if this user is on an older version
+            const sentryOptions = getCurrentHub()?.getClient()?.getOptions();
+            if (sentryOptions) {
+              sentryOptions.enabled = false;
             }
 
             return true;

--- a/src/app/utils/sentry.ts
+++ b/src/app/utils/sentry.ts
@@ -14,19 +14,6 @@ import { HashLookupFailure } from 'app/destiny2/definitions';
 import { defaultLanguage } from 'app/i18n';
 import { PlatformErrorCodes } from 'bungie-api-ts/user';
 import { DimError } from './dim-error';
-import { errorLog } from './log';
-
-/** Sentry.io exception reporting */
-export let reportException = (name: string, e: any, errorInfo?: Record<string, unknown>) => {
-  errorLog(
-    'exception',
-    name,
-    e,
-    errorInfo,
-    e instanceof DimError && e.code,
-    e instanceof DimError && e.cause,
-  );
-};
 
 // DIM error codes to ignore and not report. This works regardless of language.
 const ignoreDimErrors: (string | PlatformErrorCodes)[] = [
@@ -40,106 +27,106 @@ const ignoreDimErrors: (string | PlatformErrorCodes)[] = [
   PlatformErrorCodes.DestinyCannotPerformActionAtThisLocation,
 ];
 
-if ($featureFlags.sentry) {
-  const options: BrowserOptions = {
-    dsn: 'https://1367619d45da481b8148dd345c1a1330@sentry.io/279673',
-    release: $DIM_VERSION,
-    environment: $DIM_FLAVOR,
-    ignoreErrors: [],
-    sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
-    attachStacktrace: true,
-    integrations: [
-      new BrowserTracing({
-        // Only send trace headers to our own server
-        tracePropagationTargets: ['api.destinyitemmanager.com'],
-        beforeNavigate: (context) => ({
-          ...context,
-          // We could use the React-Router integration but it's annoying
-          name: window.location.pathname
-            .replace(/\/\d+\/d(1|2)/g, '/profileMembershipId/d$1')
-            .replace(/\/vendors\/\d+/g, '/vendors/vendorId')
-            .replace(/index\.html/, ''),
-        }),
+const options: BrowserOptions = {
+  enabled: $featureFlags.sentry,
+  dsn: 'https://1367619d45da481b8148dd345c1a1330@sentry.io/279673',
+  release: $DIM_VERSION,
+  environment: $DIM_FLAVOR,
+  ignoreErrors: [],
+  sampleRate: $DIM_VERSION === 'beta' ? 0.5 : 0.01, // Sample Beta at 50%, Prod at 1%
+  attachStacktrace: true,
+  integrations: [
+    new BrowserTracing({
+      // Only send trace headers to our own server
+      tracePropagationTargets: ['api.destinyitemmanager.com'],
+      beforeNavigate: (context) => ({
+        ...context,
+        // We could use the React-Router integration but it's annoying
+        name: window.location.pathname
+          .replace(/\/\d+\/d(1|2)/g, '/profileMembershipId/d$1')
+          .replace(/\/vendors\/\d+/g, '/vendors/vendorId')
+          .replace(/index\.html/, ''),
       }),
-    ],
-    tracesSampleRate: 0.001, // Performance traces at 0.1%
-    beforeSend: (event, hint) => {
-      const e = hint?.originalException;
-      const underlyingError = e instanceof DimError ? e.cause : undefined;
+    }),
+  ],
+  tracesSampleRate: 0.001, // Performance traces at 0.1%
+  beforeSend: (event, hint) => {
+    const e = hint?.originalException;
+    const underlyingError = e instanceof DimError ? e.cause : undefined;
 
-      const code =
-        underlyingError instanceof BungieError
-          ? underlyingError.code
-          : e instanceof DimError
-            ? e.code
-            : undefined;
-      if (code && ignoreDimErrors.includes(code)) {
-        return null; // drop report
-      }
-      if (e instanceof HashLookupFailure) {
-        // Add the ID to the fingerprint so we don't collapse different errors
-        event.fingerprint = ['{{ default }}', String(e.table), String(e.id)];
-      }
-      if (e instanceof DimError) {
-        // Replace the (localized) message with our code
-        event.message = e.code;
-        // TODO: it might be neat to be able to pass attachments here too - such as the entire profile response!
+    const code =
+      underlyingError instanceof BungieError
+        ? underlyingError.code
+        : e instanceof DimError
+          ? e.code
+          : undefined;
+    if (code && ignoreDimErrors.includes(code)) {
+      return null; // drop report
+    }
+    if (e instanceof HashLookupFailure) {
+      // Add the ID to the fingerprint so we don't collapse different errors
+      event.fingerprint = ['{{ default }}', String(e.table), String(e.id)];
+    }
+    if (e instanceof DimError) {
+      // Replace the (localized) message with our code
+      event.message = e.code;
+      // TODO: it might be neat to be able to pass attachments here too - such as the entire profile response!
 
-        // Do deeper surgery to overwrite the localized message with the code
-        if (event.exception?.values) {
-          for (const ex of event.exception.values) {
-            if (ex.value === e.message) {
-              ex.value = e.code;
-            }
+      // Do deeper surgery to overwrite the localized message with the code
+      if (event.exception?.values) {
+        for (const ex of event.exception.values) {
+          if (ex.value === e.message) {
+            ex.value = e.code;
           }
         }
+      }
 
+      event.tags = {
+        ...event.tags,
+        code: e.code,
+      };
+      if (underlyingError instanceof BungieError) {
         event.tags = {
           ...event.tags,
-          code: e.code,
+          bungieErrorCode: underlyingError.code,
         };
-        if (underlyingError instanceof BungieError) {
-          event.tags = {
-            ...event.tags,
-            bungieErrorCode: underlyingError.code,
-          };
-        }
-
-        if (underlyingError) {
-          event.extra = {
-            ...event.extra,
-            cause: underlyingError,
-          };
-        }
       }
 
-      return event;
-    },
-  };
-
-  // TODO: There's a redux integration but I'm worried it'd be too much trouble to trim out all the stuff we wouldn't want to report (by default it sends the whole action & state.
-  // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/redux/
-  addTracingExtensions();
-  init(options);
-
-  // Set user ID (membership ID) to help debug and to better count affected users
-  const token = getToken();
-  if (token?.bungieMembershipId) {
-    setUser({ id: token.bungieMembershipId });
-  }
-
-  // Capture locale
-  setTag('lang', defaultLanguage());
-
-  reportException = (name: string, e: any, errorInfo?: Record<string, unknown>) => {
-    // TODO: we can also do this in some situations to gather more feedback from users
-    // Sentry.showReportDialog();
-    withScope((scope) => {
-      setTag('context', name);
-      if (errorInfo) {
-        scope.setExtras(errorInfo);
+      if (underlyingError) {
+        event.extra = {
+          ...event.extra,
+          cause: underlyingError,
+        };
       }
-      captureException(e);
-    });
-  };
+    }
+
+    return event;
+  },
+};
+
+// TODO: There's a redux integration but I'm worried it'd be too much trouble to trim out all the stuff we wouldn't want to report (by default it sends the whole action & state.
+// https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/redux/
+addTracingExtensions();
+init(options);
+
+// Set user ID (membership ID) to help debug and to better count affected users
+const token = getToken();
+if (token?.bungieMembershipId) {
+  setUser({ id: token.bungieMembershipId });
 }
+
+// Capture locale
+setTag('lang', defaultLanguage());
+
+/** Sentry.io exception reporting */
+export const reportException = (name: string, e: any, errorInfo?: Record<string, unknown>) => {
+  // TODO: we can also do this in some situations to gather more feedback from users
+  // Sentry.showReportDialog();
+  withScope((scope) => {
+    setTag('context', name);
+    if (errorInfo) {
+      scope.setExtras(errorInfo);
+    }
+    captureException(e);
+  });
+};


### PR DESCRIPTION
This fixes the RelativeCI reporting - the problem is that the baseline (master) had Sentry code, but the PR build didn't. Now the code is always there, it's just disabled if Sentry is disabled.