### PR TITLE
Allow shift-clicking on stat bars to set maximums

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -632,6 +632,7 @@
     "SaveAs": "Save as",
     "SpeedReport": "Generated {{combos, number}} combinations in {{time}} seconds",
     "StatConstraints": "Stat Tier Priorities & Ranges",
+    "StatMax": "Max",
     "TierNumber": "T{{tier}}",
     "UnableToAddAllMods": "Unable to add all mods.",
     "UnableToAddAllModsBody": "There weren't enough mod slots available to fit {{mods}}.",

--- a/src/app/loadout-analyzer/analysis.test.ts
+++ b/src/app/loadout-analyzer/analysis.test.ts
@@ -57,8 +57,8 @@ function noopProcessWorkerMock(..._args: Parameters<typeof runProcess>): {
         armorStats.map((h) => [
           h,
           {
-            min: 10,
-            max: 0,
+            minTier: 10,
+            maxTier: 0,
           },
         ]),
       ) as StatRanges,
@@ -308,9 +308,8 @@ describe('basic loadout analysis finding tests', () => {
       mockProcess,
     );
     expect(mockProcess).toHaveBeenCalled();
-    const args = mockProcess.mock.calls[0][0].resolvedStatConstraints;
+    const args = mockProcess.mock.calls[0][0].desiredStatRanges;
     for (const c of args) {
-      expect(c.ignored).toBe(c.statHash === StatHashes.Mobility);
       if (c.statHash === StatHashes.Recovery) {
         // The loadout has no constraint for recovery, so it gets the existing loadout stats as the minimum
         expect(c.minTier).toBe(

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -289,7 +289,7 @@ export async function analyzeLoadout(
             maxTier: 10,
             minTier: statTier(assumedLoadoutStats[c.statHash]!.value),
           }));
-          const { mergedConstraints, mergedConstraintsImplyStrictUpgrade } =
+          const { mergedDesiredStatRanges, mergedConstraintsImplyStrictUpgrade } =
             mergeStrictUpgradeStatConstraints(
               existingLoadoutStatsAsStatConstraints,
               statConstraints,
@@ -304,7 +304,7 @@ export async function analyzeLoadout(
               filteredItems,
               lockedModMap: modMap,
               modStatChanges,
-              resolvedStatConstraints: mergedConstraints,
+              desiredStatRanges: mergedDesiredStatRanges,
               stopOnFirstSet: true,
               strictUpgrades: !mergedConstraintsImplyStrictUpgrade,
             });

--- a/src/app/loadout-analyzer/utils.ts
+++ b/src/app/loadout-analyzer/utils.ts
@@ -1,18 +1,23 @@
-import { ResolvedStatConstraint } from 'app/loadout-builder/types';
+import { DesiredStatRange, ResolvedStatConstraint } from 'app/loadout-builder/types';
 
 /**
- * Loadout Analysis (and the corresponding LO mode) sometimes are interested in strictly better tiers.
- * This takes (assumed) loadout stats and the user-selected stat constraints and merges them so that a
- * set satisfying the merged constraints always satisfies both the input constraint sets.
+ * Loadout Analysis (and the corresponding LO mode) sometimes are interested in
+ * strictly better tiers. This takes (assumed) loadout stats and the
+ * user-selected stat constraints and merges them so that a set satisfying the
+ * merged constraints always satisfies both the input constraint sets.
  *
- * Returns `mergedConstraintsImplyStrictUpgrade` iff every valid set in the merged constraints is also
- * always a strict upgrade, so that we don't have to ask the process worker for strict upgrades on top of that.
+ * Returns `mergedConstraintsImplyStrictUpgrade` iff every valid set in the
+ * merged constraints is also always a strict upgrade, so that we don't have to
+ * ask the process worker for strict upgrades on top of that.
+ *
+ * This also maps the stat constraints into the DesiredStatRange format, which
+ * folds the "ignored" bit into the maxTier by setting it to 0.
  */
 export function mergeStrictUpgradeStatConstraints(
   existingLoadoutStatsAsStatConstraints: ResolvedStatConstraint[] | undefined,
   parameterStatConstraints: ResolvedStatConstraint[],
 ): {
-  mergedConstraints: ResolvedStatConstraint[];
+  mergedDesiredStatRanges: DesiredStatRange[];
   mergedConstraintsImplyStrictUpgrade: boolean;
 } {
   // If a user-selected stat tier ends up higher than the corresponding existing loadout tier,
@@ -20,7 +25,7 @@ export function mergeStrictUpgradeStatConstraints(
   // are always >= existing constraints and there's one constraint that's higher than
   // the existing tier, satisfying the definition of "strict upgrade").
   let mergedConstraintsImplyStrictUpgrade = false;
-  const mergedConstraints = parameterStatConstraints.map((constraint) => {
+  const mergedDesiredStatRanges = parameterStatConstraints.map((constraint) => {
     const existingLoadoutTier = existingLoadoutStatsAsStatConstraints?.find(
       (c) => c.statHash === constraint.statHash,
     );
@@ -29,11 +34,16 @@ export function mergeStrictUpgradeStatConstraints(
       const effectiveLoadoutTier = Math.min(constraint.maxTier, existingTierValue);
       mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > effectiveLoadoutTier;
       return {
-        ...constraint,
+        statHash: constraint.statHash,
         minTier: Math.max(constraint.minTier, effectiveLoadoutTier),
+        maxTier: constraint.ignored ? 0 : constraint.maxTier,
       };
     }
-    return constraint;
+    return {
+      statHash: constraint.statHash,
+      minTier: constraint.minTier,
+      maxTier: constraint.ignored ? 0 : constraint.maxTier,
+    };
   });
-  return { mergedConstraints, mergedConstraintsImplyStrictUpgrade };
+  return { mergedDesiredStatRanges, mergedConstraintsImplyStrictUpgrade };
 }

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -244,10 +244,12 @@ export default memo(function LoadoutBuilder({
     [classType, defs, includeRuntimeStatBenefits, modsToAssign, subclass],
   );
 
-  const { mergedConstraints, mergedConstraintsImplyStrictUpgrade } = useMemo(
-    () => mergeStrictUpgradeStatConstraints(strictUpgradesStatConstraints, resolvedStatConstraints),
-    [resolvedStatConstraints, strictUpgradesStatConstraints],
-  );
+  const { mergedDesiredStatRanges: desiredStatRanges, mergedConstraintsImplyStrictUpgrade } =
+    useMemo(
+      () =>
+        mergeStrictUpgradeStatConstraints(strictUpgradesStatConstraints, resolvedStatConstraints),
+      [resolvedStatConstraints, strictUpgradesStatConstraints],
+    );
 
   // Run the actual loadout generation process in a web worker
   const { result, processing } = useProcess({
@@ -256,7 +258,7 @@ export default memo(function LoadoutBuilder({
     lockedModMap,
     modStatChanges,
     armorEnergyRules,
-    resolvedStatConstraints: mergedConstraints,
+    desiredStatRanges,
     anyExotic: lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC,
     autoStatMods,
     strictUpgrades: Boolean(strictUpgradesStatConstraints && !mergedConstraintsImplyStrictUpgrade),
@@ -265,8 +267,8 @@ export default memo(function LoadoutBuilder({
   const resultSets = result?.sets;
 
   const sortedSets = useMemo(
-    () => resultSets && sortGeneratedSets(resultSets, mergedConstraints),
-    [mergedConstraints, resultSets],
+    () => resultSets && sortGeneratedSets(resultSets, desiredStatRanges),
+    [desiredStatRanges, resultSets],
   );
 
   useEffect(() => hideItemPicker(), [hideItemPicker, selectedStore.classType]);
@@ -454,7 +456,7 @@ export default memo(function LoadoutBuilder({
             pinnedItems={pinnedItems}
             selectedStore={selectedStore}
             lbDispatch={lbDispatch}
-            resolvedStatConstraints={mergedConstraints}
+            desiredStatRanges={desiredStatRanges}
             modStatChanges={result.modStatChanges}
             loadouts={loadouts}
             armorEnergyRules={result.armorEnergyRules}

--- a/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
@@ -99,9 +99,13 @@
 }
 
 // Tiers that can't be reached given the currently selected minimums
-.maxed:not(.locked):not(.selectedStatBar) {
+.maxed:not(.selectedStatBar) {
   color: #666;
   background-color: rgba(255, 255, 255, 0.1);
+}
+.maxRestricted:not(.selectedStatBar) {
+  color: #666;
+  background-color: transparent;
 }
 
 .selectedStatBar {

--- a/src/app/loadout-builder/filter/StatConstraintEditor.m.scss.d.ts
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.m.scss.d.ts
@@ -8,7 +8,7 @@ interface CssExports {
   'iconStat': string;
   'ignored': string;
   'label': string;
-  'locked': string;
+  'maxRestricted': string;
   'maxed': string;
   'name': string;
   'row': string;

--- a/src/app/loadout-builder/filter/StatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.tsx
@@ -22,6 +22,7 @@ import {
   moveUpIcon,
 } from 'app/shell/icons';
 import StatTooltip from 'app/store-stats/StatTooltip';
+import { useShiftHeld } from 'app/utils/hooks';
 import { delay } from 'app/utils/promises';
 import clsx from 'clsx';
 import _ from 'lodash';
@@ -82,9 +83,13 @@ export default function StatConstraintEditor({
     });
   };
 
+  const shiftHeld = useShiftHeld();
+
   return (
     <LoadoutEditSection
-      title={t('LoadoutBuilder.StatConstraints')}
+      title={
+        t('LoadoutBuilder.StatConstraints') + (shiftHeld ? ` (${t('LoadoutBuilder.StatMax')})` : '')
+      }
       className={className}
       onClear={handleClear}
       onSyncFromEquipped={handleSyncFromEquipped}
@@ -134,11 +139,18 @@ function StatRow({
   const statHash = statConstraint.statHash as ArmorStatHashes;
   const statDef = defs.Stat.get(statHash);
   const handleIgnore = () => onTierChange({ ...statConstraint, ignored: !statConstraint.ignored });
-  const handleSelectTier = (tierNum: number) =>
-    onTierChange({
-      ...statConstraint,
-      minTier: tierNum,
-    });
+  const handleSelectTier = (tierNum: number, shift: boolean) =>
+    shift
+      ? onTierChange({
+          ...statConstraint,
+          maxTier: tierNum,
+          minTier: Math.min(statConstraint.minTier, tierNum),
+        })
+      : onTierChange({
+          ...statConstraint,
+          minTier: tierNum,
+          maxTier: Math.max(statConstraint.maxTier, tierNum),
+        });
 
   return (
     <Draggable draggableId={statHash.toString()} index={index}>
@@ -227,7 +239,7 @@ function StatTierBar({
 }: {
   statConstraint: ResolvedStatConstraint;
   statRange?: MinMax;
-  onSelected: (tierNum: number) => void;
+  onSelected: (tierNum: number, shift: boolean) => void;
   equippedHashes: Set<number>;
 }) {
   const defs = useD2Definitions()!;
@@ -247,7 +259,7 @@ function StatTierBar({
       case '_':
       case 'ArrowLeft': {
         if (tierNum > 0) {
-          onSelected(tierNum - 1);
+          onSelected(tierNum - 1, event.shiftKey);
         }
         focused.current = tierNum - 1;
         break;
@@ -256,7 +268,7 @@ function StatTierBar({
       case '+':
       case 'ArrowRight': {
         if (tierNum < 10) {
-          onSelected(tierNum + 1);
+          onSelected(tierNum + 1, event.shiftKey);
         }
         focused.current = tierNum + 1;
         break;
@@ -276,7 +288,7 @@ function StatTierBar({
         if (num === 0) {
           num = 10;
         }
-        onSelected(num);
+        onSelected(num, event.shiftKey);
         focused.current = num;
         break;
       }
@@ -312,9 +324,10 @@ function StatTierBar({
           key={tierNum}
           className={clsx(styles.statBarSegment, {
             [styles.selectedStatBar]: statConstraint.minTier >= tierNum,
+            [styles.maxRestricted]: tierNum > statConstraint.maxTier,
             [styles.maxed]: tierNum > (statRange?.max ?? 10),
           })}
-          onClick={() => onSelected(tierNum)}
+          onClick={(e) => onSelected(tierNum, e.shiftKey)}
           onKeyDown={handleKeyDown}
           data-tier={tierNum}
           aria-label={t('LoadoutBuilder.TierNumber', { tier: tierNum })}

--- a/src/app/loadout-builder/filter/StatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.tsx
@@ -28,7 +28,7 @@ import clsx from 'clsx';
 import _ from 'lodash';
 import React, { Dispatch, useEffect, useRef } from 'react';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
-import { ArmorStatHashes, MinMax, ResolvedStatConstraint, StatRanges } from '../types';
+import { ArmorStatHashes, MinMaxTier, ResolvedStatConstraint, StatRanges } from '../types';
 import { statTier } from '../utils';
 import styles from './StatConstraintEditor.m.scss';
 
@@ -130,7 +130,7 @@ function StatRow({
   equippedHashes,
 }: {
   statConstraint: ResolvedStatConstraint;
-  statRange?: MinMax;
+  statRange?: MinMaxTier;
   index: number;
   onTierChange: (constraint: ResolvedStatConstraint) => void;
   equippedHashes: Set<number>;
@@ -238,7 +238,7 @@ function StatTierBar({
   equippedHashes,
 }: {
   statConstraint: ResolvedStatConstraint;
-  statRange?: MinMax;
+  statRange?: MinMaxTier;
   onSelected: (tierNum: number, shift: boolean) => void;
   equippedHashes: Set<number>;
 }) {
@@ -325,7 +325,7 @@ function StatTierBar({
           className={clsx(styles.statBarSegment, {
             [styles.selectedStatBar]: statConstraint.minTier >= tierNum,
             [styles.maxRestricted]: tierNum > statConstraint.maxTier,
-            [styles.maxed]: tierNum > (statRange?.max ?? 10),
+            [styles.maxed]: tierNum > (statRange?.maxTier ?? 10),
           })}
           onClick={(e) => onSelected(tierNum, e.shiftKey)}
           onKeyDown={handleKeyDown}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -18,9 +18,9 @@ import {
   ArmorEnergyRules,
   ArmorSet,
   ArmorStatHashes,
+  DesiredStatRange,
   ModStatChanges,
   PinnedItems,
-  ResolvedStatConstraint,
 } from '../types';
 import { getPower } from '../utils';
 import styles from './GeneratedSet.m.scss';
@@ -38,7 +38,7 @@ export default memo(function GeneratedSet({
   selectedStore,
   lockedMods,
   pinnedItems,
-  resolvedStatConstraints,
+  desiredStatRanges,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -53,7 +53,7 @@ export default memo(function GeneratedSet({
   selectedStore: DimStore;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
-  resolvedStatConstraints: ResolvedStatConstraint[];
+  desiredStatRanges: DesiredStatRange[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -156,7 +156,7 @@ export default memo(function GeneratedSet({
         stats={set.stats}
         getStatsBreakdown={getStatsBreakdownOnce}
         maxPower={getPower(displayedItems)}
-        resolvedStatConstraints={resolvedStatConstraints}
+        desiredStatRanges={desiredStatRanges}
         boostedStats={boostedStats}
         existingLoadoutName={overlappingLoadout?.name}
         equippedHashes={equippedHashes}

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -13,9 +13,9 @@ import {
   ArmorEnergyRules,
   ArmorSet,
   ArmorStatHashes,
+  DesiredStatRange,
   ModStatChanges,
   PinnedItems,
-  ResolvedStatConstraint,
 } from '../types';
 import GeneratedSet, { containerClass } from './GeneratedSet';
 
@@ -28,7 +28,7 @@ export default function GeneratedSets({
   selectedStore,
   sets,
   equippedHashes,
-  resolvedStatConstraints,
+  desiredStatRanges,
   modStatChanges,
   loadouts,
   lbDispatch,
@@ -42,7 +42,7 @@ export default function GeneratedSets({
   equippedHashes: Set<number>;
   lockedMods: PluggableInventoryItemDefinition[];
   pinnedItems: PinnedItems;
-  resolvedStatConstraints: ResolvedStatConstraint[];
+  desiredStatRanges: DesiredStatRange[];
   modStatChanges: ModStatChanges;
   loadouts: Loadout[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -72,7 +72,7 @@ export default function GeneratedSets({
           lockedMods={lockedMods}
           pinnedItems={pinnedItems}
           lbDispatch={lbDispatch}
-          resolvedStatConstraints={resolvedStatConstraints}
+          desiredStatRanges={desiredStatRanges}
           modStatChanges={modStatChanges}
           loadouts={loadouts}
           halfTierMods={halfTierMods}

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -7,7 +7,13 @@ import StatTooltip from 'app/store-stats/StatTooltip';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import _ from 'lodash';
-import { ArmorStatHashes, ArmorStats, ModStatChanges, ResolvedStatConstraint } from '../types';
+import {
+  ArmorStatHashes,
+  ArmorStats,
+  DesiredStatRange,
+  ModStatChanges,
+  ResolvedStatConstraint,
+} from '../types';
 import { remEuclid, statTierWithHalf } from '../utils';
 import styles from './SetStats.m.scss';
 import { calculateTotalTier, sumEnabledStats } from './utils';
@@ -20,7 +26,7 @@ export function SetStats({
   stats,
   getStatsBreakdown,
   maxPower,
-  resolvedStatConstraints,
+  desiredStatRanges,
   boostedStats,
   className,
   existingLoadoutName,
@@ -29,7 +35,7 @@ export function SetStats({
   stats: ArmorStats;
   getStatsBreakdown: () => ModStatChanges;
   maxPower: number;
-  resolvedStatConstraints: ResolvedStatConstraint[];
+  desiredStatRanges: DesiredStatRange[];
   boostedStats: Set<ArmorStatHashes>;
   className?: string;
   existingLoadoutName?: string;
@@ -37,14 +43,14 @@ export function SetStats({
 }) {
   const defs = useD2Definitions()!;
   const totalTier = calculateTotalTier(stats);
-  const enabledTier = sumEnabledStats(stats, resolvedStatConstraints);
+  const enabledTier = sumEnabledStats(stats, desiredStatRanges);
 
   return (
     <div className={clsx(styles.container, className)}>
       <div className={styles.tierLightContainer}>
         <TotalTier enabledTier={enabledTier} totalTier={totalTier} />
       </div>
-      {resolvedStatConstraints.map((c) => {
+      {desiredStatRanges.map((c) => {
         const statHash = c.statHash as ArmorStatHashes;
         const statDef = defs.Stat.get(statHash);
         const value = stats[statHash];
@@ -65,7 +71,7 @@ export function SetStats({
             )}
           >
             <Stat
-              isActive={!c.ignored}
+              isActive={c.maxTier > 0}
               isBoosted={boostedStats.has(statHash)}
               stat={statDef}
               value={value}

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,14 +1,14 @@
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
 import _ from 'lodash';
-import { ArmorSet, ArmorStatHashes, ArmorStats, ResolvedStatConstraint } from '../types';
+import { ArmorSet, ArmorStatHashes, ArmorStats, DesiredStatRange } from '../types';
 import { statTier } from '../utils';
 
-function getComparatorsForMatchedSetSorting(statConstraints: ResolvedStatConstraint[]) {
+function getComparatorsForMatchedSetSorting(desiredStatRanges: DesiredStatRange[]) {
   const comparators: Comparator<ArmorSet>[] = [
-    compareBy((s) => -sumEnabledStats(s.stats, statConstraints)),
+    compareBy((s) => -sumEnabledStats(s.stats, desiredStatRanges)),
   ];
 
-  for (const constraint of statConstraints) {
+  for (const constraint of desiredStatRanges) {
     comparators.push(
       compareBy(
         (s) =>
@@ -26,9 +26,9 @@ function getComparatorsForMatchedSetSorting(statConstraints: ResolvedStatConstra
  */
 export function sortGeneratedSets(
   sets: ArmorSet[],
-  statConstraints: ResolvedStatConstraint[],
+  desiredStatRanges: DesiredStatRange[],
 ): ArmorSet[] {
-  return sets.sort(chainComparator(...getComparatorsForMatchedSetSorting(statConstraints)));
+  return sets.sort(chainComparator(...getComparatorsForMatchedSetSorting(desiredStatRanges)));
 }
 
 /**
@@ -39,8 +39,8 @@ export function calculateTotalTier(stats: ArmorStats) {
   return _.sum(Object.values(stats).map(statTier));
 }
 
-export function sumEnabledStats(stats: ArmorStats, statConstraints: ResolvedStatConstraint[]) {
-  return _.sumBy(statConstraints, (constraint) =>
+export function sumEnabledStats(stats: ArmorStats, desiredStatRanges: DesiredStatRange[]) {
+  return _.sumBy(desiredStatRanges, (constraint) =>
     Math.min(statTier(stats[constraint.statHash as ArmorStatHashes]), constraint.maxTier),
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -363,16 +363,10 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         };
       }
       case 'statConstraintChanged': {
-        const { constraint: newConstraint } = action;
-        const newStatConstraints = state.resolvedStatConstraints.map((c) => {
-          if (c.statHash === newConstraint.statHash) {
-            // Previously ignored stats' maxes need to be bumped up to T10 again
-            const maxTier = newConstraint.ignored ? 0 : c.ignored ? 10 : c.maxTier;
-            return { ...newConstraint, maxTier };
-          } else {
-            return c;
-          }
-        });
+        const { constraint } = action;
+        const newStatConstraints = state.resolvedStatConstraints.map((c) =>
+          c.statHash === constraint.statHash ? constraint : c,
+        );
         return updateStatConstraints(state, newStatConstraints);
       }
       case 'statConstraintReset': {

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -3,12 +3,12 @@ import { infoLog } from '../../utils/log';
 import {
   ArmorStatHashes,
   ArmorStats,
-  artificeStatBoost,
+  DesiredStatRange,
   LockableBucketHashes,
   LockableBuckets,
-  majorStatBoost,
-  ResolvedStatConstraint,
   StatRanges,
+  artificeStatBoost,
+  majorStatBoost,
 } from '../types';
 import {
   pickAndAssignSlotIndependentMods,
@@ -40,8 +40,8 @@ export function process(
   modStatTotals: ArmorStats,
   /** Mods to add onto the sets */
   lockedMods: LockedProcessMods,
-  /** The user's chosen stat constraints, including disabled stats */
-  resolvedStatConstraints: ResolvedStatConstraint[],
+  /** The user's chosen stat ranges, in priority order. */
+  desiredStatRanges: DesiredStatRange[],
   /** Ensure every set includes one exotic */
   anyExotic: boolean,
   /** Which artifice mods, large, and small stat mods are available */
@@ -55,10 +55,8 @@ export function process(
 ): ProcessResult {
   const pstart = performance.now();
 
-  const statOrder = resolvedStatConstraints.map(({ statHash }) => statHash as ArmorStatHashes);
-  const maxTierConstraints = resolvedStatConstraints.map(({ ignored, maxTier }) =>
-    ignored ? 0 : maxTier,
-  );
+  const statOrder = desiredStatRanges.map(({ statHash }) => statHash as ArmorStatHashes);
+  const maxTierConstraints = desiredStatRanges.map(({ maxTier }) => maxTier);
   const modStatsInStatOrder = statOrder.map((h) => modStatTotals[h]);
 
   // This stores the computed min and max value for each stat as we process all sets, so we
@@ -67,8 +65,8 @@ export function process(
     statOrder.map((h) => [
       h,
       {
-        min: 10,
-        max: 0,
+        minTier: 10,
+        maxTier: 0,
       },
     ]),
   ) as StatRanges;
@@ -236,11 +234,11 @@ export function process(
             let totalTier = 0;
             for (let index = 0; index < 6; index++) {
               const tier = tiers[index];
-              const filter = resolvedStatConstraints[index];
-              if (!filter.ignored) {
+              const filter = desiredStatRanges[index];
+              if (filter.maxTier > 0) {
                 const statRange = statRangesFilteredInStatOrder[index];
-                if (tier < statRange.min) {
-                  statRange.min = tier;
+                if (tier < statRange.minTier) {
+                  statRange.minTier = tier;
                 }
                 totalTier += tier;
                 if (filter.minTier > 0) {
@@ -301,7 +299,7 @@ export function process(
               stats,
               tiers,
               numArtifice,
-              resolvedStatConstraints,
+              desiredStatRanges,
               statRangesFilteredInStatOrder,
             );
 
@@ -324,8 +322,8 @@ export function process(
             const statPointsNeededForTiers: { index: number; pointsToNext: number }[] = [];
 
             for (let index = 0; index < 6; index++) {
-              const filter = resolvedStatConstraints[index];
-              if (!filter.ignored && stats[index] < filter.maxTier * 10) {
+              const filter = desiredStatRanges[index];
+              if (stats[index] < filter.maxTier * 10) {
                 statPointsNeededForTiers.push({
                   index,
                   pointsToNext: 10 - (stats[index] % 10),
@@ -368,8 +366,8 @@ export function process(
             for (let index = 0; index < 6; index++) {
               let tier = tiers[index];
               // Make each stat exactly one code unit so the string compares correctly
-              const filter = resolvedStatConstraints[index];
-              if (!filter.ignored) {
+              const filter = desiredStatRanges[index];
+              if (filter.maxTier > 0) {
                 // Predict the tier boost from general mods.
                 const boostAmount = Math.min(filter.maxTier - tier, numGeneralMods);
                 if (boostAmount > 0) {
@@ -409,7 +407,7 @@ export function process(
       precalculatedInfo,
       armor,
       stats,
-      resolvedStatConstraints,
+      desiredStatRanges,
     )!;
 
     const armorOnlyStats: Partial<ArmorStats> = {};
@@ -422,9 +420,9 @@ export function process(
       const value = stats[i] + bonusStats[i];
       fullStats[statHash] = value;
 
-      const statFilter = resolvedStatConstraints[i];
+      const statFilter = desiredStatRanges[i];
       if (
-        !statFilter.ignored &&
+        statFilter.maxTier > 0 &&
         strictUpgrades &&
         statFilter.minTier < statFilter.maxTier &&
         !hasStrictUpgrade

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -12,11 +12,11 @@ import {
   ArmorEnergyRules,
   ArmorSet,
   AutoModDefs,
+  DesiredStatRange,
   ItemGroup,
   ItemsByBucket,
   LockableBucketHash,
   ModStatChanges,
-  ResolvedStatConstraint,
 } from '../types';
 import {
   hydrateArmorSet,
@@ -46,7 +46,7 @@ export function runProcess({
   lockedModMap,
   modStatChanges,
   armorEnergyRules,
-  resolvedStatConstraints,
+  desiredStatRanges,
   anyExotic,
   autoStatMods,
   getUserItemTag,
@@ -58,7 +58,7 @@ export function runProcess({
   lockedModMap: ModMap;
   modStatChanges: ModStatChanges;
   armorEnergyRules: ArmorEnergyRules;
-  resolvedStatConstraints: ResolvedStatConstraint[];
+  desiredStatRanges: DesiredStatRange[];
   anyExotic: boolean;
   autoStatMods: boolean;
   getUserItemTag?: (item: DimItem) => TagValue | undefined;
@@ -100,7 +100,7 @@ export function runProcess({
 
     const groupedItems = mapItemsToGroups(
       items,
-      resolvedStatConstraints,
+      desiredStatRanges,
       armorEnergyRules,
       activityMods,
       bucketSpecificMods[bucketHash] || [],
@@ -113,17 +113,6 @@ export function runProcess({
     }
   }
 
-  // NB this looks like a no-op but what's sorted here aren't the array entries but the object keys.
-  // Ensuring all array members have properties in the same order helps the JIT keep the code monomorphic...
-  const sortedResolvedStatConstraints: ResolvedStatConstraint[] = resolvedStatConstraints.map(
-    (c) => ({
-      minTier: c.minTier,
-      maxTier: c.maxTier,
-      statHash: c.statHash,
-      ignored: c.ignored,
-    }),
-  );
-
   // TODO: could potentially partition the problem (split the largest item category maybe) to spread across more cores
 
   return {
@@ -135,7 +124,7 @@ export function runProcess({
           processItems,
           _.mapValues(modStatChanges, (stat) => stat.value),
           lockedProcessMods,
-          sortedResolvedStatConstraints,
+          desiredStatRanges,
           anyExotic,
           autoModsData,
           autoStatMods,
@@ -207,7 +196,7 @@ const groupComparator = (getTag?: (item: DimItem) => TagValue | undefined) =>
  */
 function mapItemsToGroups(
   items: readonly DimItem[],
-  resolvedStatConstraints: ResolvedStatConstraint[],
+  resolvedStatConstraints: DesiredStatRange[],
   armorEnergyRules: ArmorEnergyRules,
   activityMods: PluggableInventoryItemDefinition[],
   modsForSlot: PluggableInventoryItemDefinition[],

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -9,9 +9,9 @@ import { ProcessStatistics } from '../process-worker/types';
 import {
   ArmorEnergyRules,
   ArmorSet,
+  DesiredStatRange,
   ItemsByBucket,
   ModStatChanges,
-  ResolvedStatConstraint,
   StatRanges,
 } from '../types';
 import { getAutoMods } from './mappers';
@@ -50,7 +50,7 @@ export function useProcess({
   lockedModMap,
   modStatChanges,
   armorEnergyRules,
-  resolvedStatConstraints,
+  desiredStatRanges,
   anyExotic,
   autoStatMods,
   strictUpgrades,
@@ -60,7 +60,7 @@ export function useProcess({
   lockedModMap: ModMap;
   modStatChanges: ModStatChanges;
   armorEnergyRules: ArmorEnergyRules;
-  resolvedStatConstraints: ResolvedStatConstraint[];
+  desiredStatRanges: DesiredStatRange[];
   anyExotic: boolean;
   autoStatMods: boolean;
   strictUpgrades: boolean;
@@ -98,7 +98,7 @@ export function useProcess({
       lockedModMap,
       modStatChanges,
       armorEnergyRules,
-      resolvedStatConstraints,
+      desiredStatRanges,
       anyExotic,
       autoStatMods,
       getUserItemTag,
@@ -139,7 +139,7 @@ export function useProcess({
   }, [
     filteredItems,
     selectedStore.id,
-    resolvedStatConstraints,
+    desiredStatRanges,
     anyExotic,
     armorEnergyRules,
     autoStatMods,

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -4,14 +4,17 @@ import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { ProcessItem } from './process-worker/types';
 
-export interface MinMax {
-  min: number;
-  max: number;
+export interface MinMaxTier {
+  minTier: number;
+  maxTier: number;
 }
 
 /**
- * Normally stat constraints are simply missing if ignored - the resolved
- * version still exists but has an ignored flag. Also, values cannot be undefined.
+ * Resolved stat constraints take the compact form of the API stat constraints
+ * and expand them so that each stat has a corresponding constraint, the min and
+ * max are defined, and the ignored flag is set. In the API version, stat
+ * constraints are simply missing if ignored, and min-0/max-10 is omitted as
+ * implied.
  */
 export interface ResolvedStatConstraint extends Required<StatConstraint> {
   /**
@@ -20,6 +23,14 @@ export interface ResolvedStatConstraint extends Required<StatConstraint> {
    */
   ignored: boolean;
 }
+
+/**
+ * When a stat is ignored, we treat it as if it were effectively a constraint
+ * with a max desired tier of 0. ResolvedStatContraintRange is the same as
+ * DesiredStatRange, but with the ignored flag removed, and maxTier set to
+ * 0 for ignored sets.
+ */
+export type DesiredStatRange = Required<StatConstraint>;
 
 /** A map from bucketHash to the pinned item if there is one. */
 export interface PinnedItems {
@@ -104,7 +115,7 @@ export type ArmorStatHashes =
   | StatHashes.Intellect
   | StatHashes.Strength;
 
-export type StatRanges = { [statHash in ArmorStatHashes]: MinMax };
+export type StatRanges = { [statHash in ArmorStatHashes]: MinMaxTier };
 export type ArmorStats = { [statHash in ArmorStatHashes]: number };
 
 /**

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -681,6 +681,7 @@
     "SaveAs": "Save as",
     "SpeedReport": "Generated {{combos, number}} combinations in {{time}} seconds",
     "StatConstraints": "Stat Tier Priorities & Ranges",
+    "StatMax": "Max",
     "TierNumber": "T{{tier}}",
     "TierSelect": "Select minimum stat tier",
     "UnableToAddAllMods": "Unable to add all mods.",


### PR DESCRIPTION
This isn't very discoverable, but it *is* a way to set stat maximums. Shift-clicking on a stat number will set it as a max. This of course doesn't work on mobile but it's not meant to be the only way to set maxes. The title of the box changes to add "(Max)" when shift is held to try and hint that it's there.

<img width="327" alt="Screenshot 2023-12-21 at 11 30 55 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/bb509d8d-8995-4d27-a4eb-a4fc93631460">

After this I was thinking of one of a few approaches (which are not in this PR):

1. Put tabs at the top (Min and Max) and let you switch the entire entry from setting min to setting max.
2. On each row, add text like "T5-T10" and then you can click the upper bound to switch to editing max instead of min. See the mockup below.
3. Have some sort of drag handle to the right of the numbers that you can drag down to set maximum? But then I'd probably want to also have one on the left for minimum...

<img width="326" alt="Screenshot 2023-12-21 at 11 34 21 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/81bba99a-2925-4dcd-a7e9-70a368cb9e5a">

Maybe @guise or @ryan-rushton has an idea?