### PR TITLE
Fix invalid eslint config.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -372,22 +372,6 @@
       "rules": {
         "no-restricted-imports": "off"
       }
-    },
-    {
-      "files": ["src/app/i18next-t.ts"],
-      "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "patterns": [
-              {
-                "group": ["testing/*"],
-                "message": "You cannot use test helpers in regular code."
-              }
-            ]
-          }
-        ]
-      }
     }
   ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -151,7 +151,9 @@
           {
             "group": ["testing/*"],
             "message": "You cannot use test helpers in regular code."
-          },
+          }
+        ],
+        "paths": [
           {
             "name": "i18next",
             "importNames": ["t"],
@@ -369,6 +371,22 @@
       "files": ["*.test.ts"],
       "rules": {
         "no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": ["src/app/i18next-t.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["testing/*"],
+                "message": "You cannot use test helpers in regular code."
+              }
+            ]
+          }
+        ]
       }
     }
   ]

--- a/src/app/i18next-t.ts
+++ b/src/app/i18next-t.ts
@@ -1,4 +1,5 @@
 import type { ParseKeys } from 'i18next';
+// eslint-disable-next-line no-restricted-imports
 import { t as originalT } from 'i18next';
 
 export type I18nKey = ParseKeys;


### PR DESCRIPTION
I was getting an infinite startup failure loop caused by eslint throwing an error.

TLDR from the [no-restricted-import docs](https://eslint.org/docs/latest/rules/no-restricted-imports) is that you cannot mix and match path and pattern config in the same object.