### PR TITLE
Stackable 2

### DIFF
--- a/src/app/dim-ui/TileGrid.m.scss
+++ b/src/app/dim-ui/TileGrid.m.scss
@@ -19,12 +19,16 @@
 }
 
 .tile {
-  composes: flexRow from '../dim-ui/common.m.scss';
+  display: grid;
+  grid-template-columns: min-content auto min-content;
+  grid-template-rows: max-content auto;
+  grid-template-areas:
+    'icon title corner'
+    'details details details';
   border: 1px solid transparent;
   cursor: pointer;
   padding: 8px;
   gap: 8px;
-  height: 100%;
   box-sizing: border-box;
   position: relative;
   &:hover {
@@ -37,11 +41,10 @@
 }
 
 .details {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  width: 0;
+  grid-column-end: span 3;
 }
 
 .selected {
@@ -54,7 +57,12 @@
 }
 
 .title {
+  align-self: center;
   color: var(--theme-text);
   font-weight: bold;
   font-size: 14px;
+  grid-column-end: span 2;
+  &.withCorner {
+    grid-column-end: span 1;
+  }
 }

--- a/src/app/dim-ui/TileGrid.m.scss
+++ b/src/app/dim-ui/TileGrid.m.scss
@@ -60,7 +60,7 @@
   align-self: center;
   color: var(--theme-text);
   font-weight: bold;
-  font-size: 14px;
+  font-size: 18px;
   grid-column-end: span 2;
   &.withCorner {
     grid-column-end: span 1;

--- a/src/app/dim-ui/TileGrid.m.scss.d.ts
+++ b/src/app/dim-ui/TileGrid.m.scss.d.ts
@@ -8,6 +8,7 @@ interface CssExports {
   'selected': string;
   'tile': string;
   'title': string;
+  'withCorner': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/dim-ui/TileGrid.tsx
+++ b/src/app/dim-ui/TileGrid.tsx
@@ -32,6 +32,7 @@ export function TileGridTile({
   children,
   icon,
   title,
+  corner,
   selected,
   disabled,
   onClick,
@@ -40,6 +41,7 @@ export function TileGridTile({
   children: React.ReactNode;
   icon: React.ReactNode;
   title: React.ReactNode;
+  corner?: React.ReactElement;
   selected?: boolean;
   disabled?: boolean;
   onClick: React.MouseEventHandler<HTMLElement>;
@@ -58,10 +60,9 @@ export function TileGridTile({
     >
       <>
         {icon}
-        <div className={styles.details}>
-          <div className={styles.title}>{title}</div>
-          {children}
-        </div>
+        <div className={clsx(styles.title, corner ? styles.withCorner : undefined)}>{title}</div>
+        {corner || null}
+        <div className={styles.details}>{children}</div>
       </>
     </div>
   );

--- a/src/app/dim-ui/TileGrid.tsx
+++ b/src/app/dim-ui/TileGrid.tsx
@@ -60,7 +60,7 @@ export function TileGridTile({
     >
       <>
         {icon}
-        <div className={clsx(styles.title, corner ? styles.withCorner : undefined)}>{title}</div>
+        <div className={clsx(styles.title, { [styles.withCorner]: corner })}>{title}</div>
         {corner || null}
         <div className={styles.details}>{children}</div>
       </>

--- a/src/app/dim-ui/TileGrid.tsx
+++ b/src/app/dim-ui/TileGrid.tsx
@@ -61,7 +61,7 @@ export function TileGridTile({
       <>
         {icon}
         <div className={clsx(styles.title, { [styles.withCorner]: corner })}>{title}</div>
-        {corner || null}
+        {corner}
         <div className={styles.details}>{children}</div>
       </>
     </div>

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss
@@ -19,9 +19,15 @@
 .buttons {
   composes: flexRow from '../../dim-ui/common.m.scss';
   align-items: center;
+  gap: 6px;
+}
+
+.volumeRocker {
+  composes: flexColumn from '../../dim-ui/common.m.scss';
   gap: 4px;
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 4px;
+  :global(.dim-button) {
+    padding-bottom: 0;
+    padding-top: 0;
+    height: calc(calc(var(--item-size) / 2) - 2px);
+  }
 }

--- a/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
+++ b/src/app/loadout/plug-drawer/SelectablePlug.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'buttons': string;
   'clarityDescription': string;
   'stack': string;
+  'volumeRocker': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -5,7 +5,7 @@ import { t } from 'app/i18next-t';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { PlugStats } from 'app/item-popup/PlugTooltip';
-import { minusIcon, plusIcon } from 'app/shell/icons';
+import { banIcon, minusIcon, plusIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { getPlugDefStats, usePlugDescriptions } from 'app/utils/plug-descriptions';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -71,6 +71,37 @@ export default function SelectablePlug({
       onPlugRemoved(plug);
     });
 
+  const corner =
+    handleIncrease || handleDecrease || stackable ? (
+      <div className={styles.buttons}>
+        {stackable && <div className={styles.stack}>{stack}×</div>}
+        {(handleIncrease || handleDecrease) && (
+          <div className={styles.volumeRocker}>
+            {handleIncrease && (
+              <button
+                type="button"
+                className="dim-button"
+                onClick={handleIncrease}
+                title={t('LB.AddStack')}
+              >
+                <AppIcon icon={plusIcon} />
+              </button>
+            )}
+            {handleDecrease && (
+              <button
+                type="button"
+                className="dim-button"
+                onClick={handleDecrease}
+                title={t('LB.RemoveStack')}
+              >
+                <AppIcon icon={stack === 1 ? banIcon : minusIcon} />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    ) : undefined;
+
   return (
     <TileGridTile
       selected={selected}
@@ -88,33 +119,9 @@ export default function SelectablePlug({
         </div>
       }
       onClick={handleClick}
+      corner={corner}
     >
       {plugDetails}
-      {(handleIncrease || handleDecrease || stackable) && (
-        <div className={styles.buttons}>
-          {stackable && <div className={styles.stack}>{stack}x</div>}
-          {handleIncrease && (
-            <button
-              type="button"
-              className="dim-button"
-              onClick={handleIncrease}
-              title={t('LB.AddStack')}
-            >
-              <AppIcon icon={plusIcon} />
-            </button>
-          )}
-          {handleDecrease && (
-            <button
-              type="button"
-              className="dim-button"
-              onClick={handleDecrease}
-              title={t('LB.RemoveStack')}
-            >
-              <AppIcon icon={minusIcon} />
-            </button>
-          )}
-        </div>
-      )}
     </TileGridTile>
   );
 }


### PR DESCRIPTION
a proposed redesign for tilegrid element layout
+ better integrate the +/- buttons without positioning workarounds
+ design ideas for new features in the stackable pr
+ fix some text overlap problems with existing pr

![image](https://github.com/DestinyItemManager/DIM/assets/68782081/ff7841a7-dc8f-4179-acc5-0db183b09e01)

- setup +/- as volume rockers, calc their combined heights to match the item tile
- use a real multiplication x
- show `-` as 🚫 when it will remove the last copy (helped a *lot*, personally)
- bigger tile title text! (text-wrap:balance is soooo cool. though it doesn't usually wrap until a volume rocker appears)

this affects the exotic picker too, which takes a bit of a hit in compactness (because it had conveniently short everything that squeezed together well), but still at least has much larger item names, a positive imo