### PR TITLE
Open subclass/exotic editor on click

### DIFF
--- a/src/app/loadout-builder/filter/LoadoutOptimizerExotic.m.scss
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerExotic.m.scss
@@ -5,6 +5,7 @@
   composes: flexRow from '../../dim-ui/common.m.scss';
   gap: 8px;
   margin-bottom: 8px;
+  cursor: pointer;
 
   > :first-child {
     flex-shrink: 0;

--- a/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
@@ -1,4 +1,3 @@
-import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
@@ -153,13 +152,7 @@ function ChosenExoticOption({
 
   return (
     <div className={styles.infoCard} onClick={onClick}>
-      {lockedExoticHash === undefined ? (
-        icon
-      ) : (
-        <ClosableContainer showCloseIconOnHover onClose={handleRemove}>
-          {icon}
-        </ClosableContainer>
-      )}
+      {icon}
       <div className={styles.details}>
         <div className={styles.title}>{title}</div>
         {description}

--- a/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
@@ -56,6 +56,8 @@ const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
     }
   };
 
+  const handleClickEdit = () => setShowExoticPicker(true);
+
   return (
     <LoadoutEditSection
       title={t('LoadoutBuilder.Exotic')}
@@ -64,8 +66,8 @@ const LoadoutOptimizerExotic = memo(function LoadoutOptimizerExotic({
       onSyncFromEquipped={handleSyncFromEquipped}
       onRandomize={handleRandomize}
     >
-      <ChosenExoticOption lockedExoticHash={lockedExoticHash} onRemove={handleClear} />
-      <button type="button" className="dim-button" onClick={() => setShowExoticPicker(true)}>
+      <ChosenExoticOption lockedExoticHash={lockedExoticHash} onClick={handleClickEdit} />
+      <button type="button" className="dim-button" onClick={handleClickEdit}>
         {t('LB.SelectExotic')}
       </button>
       {showExoticPicker && (
@@ -85,10 +87,10 @@ export default LoadoutOptimizerExotic;
 
 function ChosenExoticOption({
   lockedExoticHash,
-  onRemove,
+  onClick,
 }: {
   lockedExoticHash: number | undefined;
-  onRemove: () => void;
+  onClick: () => void;
 }) {
   const defs = useD2Definitions()!;
   const itemCreationContext = useSelector(createItemContextSelector);
@@ -150,11 +152,11 @@ function ChosenExoticOption({
   const { icon, title, description } = info!;
 
   return (
-    <div className={styles.infoCard}>
+    <div className={styles.infoCard} onClick={onClick}>
       {lockedExoticHash === undefined ? (
         icon
       ) : (
-        <ClosableContainer showCloseIconOnHover onClose={onRemove}>
+        <ClosableContainer showCloseIconOnHover onClose={handleRemove}>
           {icon}
         </ClosableContainer>
       )}

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -203,6 +203,7 @@ export function LoadoutEditSubclassSection({
   const handleSyncSubclassFromEquipped = useDefsStoreUpdater(setLoadoutSubclassFromEquipped);
   const handleRandomizeSubclass = useDefsStoreUpdater(randomizeLoadoutSubclass);
   const handleClearSubclass = useDefsUpdater(clearSubclass);
+  const handleOpenPlugDrawer = () => setPlugDrawerOpen(true);
 
   return (
     <LoadoutEditSection
@@ -217,13 +218,13 @@ export function LoadoutEditSubclassSection({
         classType={loadout.classType}
         storeId={store.id}
         power={power}
-        onRemove={handleClearSubclass}
+        onClick={handleOpenPlugDrawer}
         onPick={handleAddItem}
       />
       {subclass && (
         <div className={styles.buttons}>
           {subclass.item.sockets ? (
-            <button type="button" className="dim-button" onClick={() => setPlugDrawerOpen(true)}>
+            <button type="button" className="dim-button" onClick={handleOpenPlugDrawer}>
               {t('LB.SelectSubclassOptions')}
             </button>
           ) : (

--- a/src/app/loadout/loadout-edit/LoadoutEditSection.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditSection.m.scss
@@ -19,6 +19,10 @@
     }
     flex: 1;
   }
+
+  :global(.app-icon) {
+    font-size: 14px;
+  }
 }
 
 .clear {

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.m.scss
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.m.scss
@@ -9,6 +9,7 @@
       var(--item-icon-size) + (var(--loadout-edit-subclass-columns, 3) - 1) * 4px
   );
   gap: var(--item-margin);
+  cursor: pointer;
 }
 
 .subclass {

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -1,4 +1,3 @@
-import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
@@ -28,14 +27,14 @@ export default function LoadoutEditSubclass({
   classType,
   storeId,
   power,
-  onRemove,
   onPick,
+  onClick,
 }: {
   subclass?: ResolvedLoadoutItem;
   classType: DestinyClass;
   storeId: string;
   power: number;
-  onRemove: () => void;
+  onClick: () => void;
   onPick: (item: DimItem) => void;
 }) {
   const defs = useD2Definitions()!;
@@ -82,6 +81,7 @@ export default function LoadoutEditSubclass({
         [styles.isOver]: isOverEquipped,
         [styles.canDrop]: canDropEquipped,
       })}
+      onClick={subclass ? onClick : undefined}
     >
       {!subclass && subclassItems.length > 0 && (
         <>
@@ -100,9 +100,7 @@ export default function LoadoutEditSubclass({
       )}
       {subclass && (
         <div className={styles.subclass}>
-          <ClosableContainer
-            onClose={onRemove}
-            showCloseIconOnHover
+          <div
             className={clsx({
               [styles.missingItem]: subclass?.missing,
             })}
@@ -118,7 +116,7 @@ export default function LoadoutEditSubclass({
                 />
               )}
             </ItemPopupTrigger>
-          </ClosableContainer>
+          </div>
           {power !== 0 && (
             <div className={styles.power}>
               <AppIcon icon={powerActionIcon} />


### PR DESCRIPTION
This makes a few minor tweaks:

1. Clicking anywhere on the subclass or exotic will open its editor (rather than having to click the button.
2. ClosableContainer was removed from these in favor of the clear button on the loadout section container.
3. Increase the size of the clear button and kebab button in the loadout section.