### PR TITLE
Replace energy w/ base stat

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -43,9 +43,7 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   // For vendor armor that reports stats (thus often randomized),
   // show the total points as a means to indicate whether it's worth picking up
   const totalArmorStat =
-    item.bucket?.inArmor &&
-    item.vendor &&
-    item.stats?.find((stat) => stat.statHash === TOTAL_STAT_HASH);
+    item.bucket?.inArmor && item.stats?.find((stat) => stat.statHash === TOTAL_STAT_HASH);
 
   const hideBadge = Boolean(
     item.location.hash === BucketHashes.Subclass ||
@@ -62,7 +60,6 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const badgeContent =
     (isBounty && `${Math.floor(100 * item.percentComplete)}%`) ||
     (isStackable && item.amount.toString()) ||
-    (totalArmorStat && totalArmorStat.value.toString()) ||
     (isGeneric && item.primaryStat?.value.toString()) ||
     (item.classified && <ClassifiedNotes item={item} />);
 
@@ -95,8 +92,8 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
         </div>
       )}
       {summaryIcon}
-      {item.energy ? (
-        <span className={styles.energyCapacity}>{item.energy.energyCapacity}</span>
+      {totalArmorStat && totalArmorStat.base > 0 ? (
+        <span className={styles.energyCapacity}>{totalArmorStat.base.toString()}</span>
       ) : (
         item.element &&
         !(item.bucket.inWeapons && item.element.enumValue === DamageType.Kinetic) && (


### PR DESCRIPTION
This replaces the "energy capacity" number on armor tiles with their base total stat.

This is a relatively disruptive change but one we've talked about. I'm not sure if it's too much for the entire app, though at first look I prefer it. Interested in feedback - I don't want to get into a position where there's a setting for what shows on the polaroid.

I suppose this also opens the possibility of a "sort by armor base stat" item sort.

<img width="576" alt="Screenshot 2024-01-03 at 11 22 02 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/9d3f15a0-edaa-4eea-b8cd-fd268582143f">
