### PR TITLE
Fix issue with item columns not being set on load

### DIFF
--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -39,6 +39,7 @@ export function createThemeObserver(): StoreObserver<{ theme: string; isPhonePor
 export function createTilesPerCharColumnObserver(): StoreObserver<number> {
   return {
     id: 'tiles-per-char-column-observer',
+    runInitially: true,
     getObserved: (rs) =>
       isPhonePortraitSelector(rs)
         ? settingsSelector(rs).charColMobile


### PR DESCRIPTION
## Overview

As per the discussion on discord the recent changes to add the observer middleware have introduced a bug where the mobile columns css variable is not set on initial load.

This PR fixes that by introducing a `runInitially` flag in the observer config to make the `sideEffect` get run when it is initially loaded up by the middleware.

### Before

<img width="305" alt="Screenshot 2024-01-04 at 10 02 52 pm" src="https://github.com/DestinyItemManager/DIM/assets/7344652/da7c0f52-514d-45eb-b355-42a9e63ddff0">

### After

<img width="303" alt="Screenshot 2024-01-04 at 10 03 10 pm" src="https://github.com/DestinyItemManager/DIM/assets/7344652/681d3ec9-d0a9-4ae3-9ae4-6a698b78c34e">

