### PR TITLE
Fix loadout dnd for stream deck

### DIFF
--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -107,3 +107,7 @@
 .artifactMods {
   --item-size: 40px;
 }
+
+.disableEvents > div {
+  pointer-events: none;
+}

--- a/src/app/loadout/LoadoutView.m.scss.d.ts
+++ b/src/app/loadout/LoadoutView.m.scss.d.ts
@@ -5,6 +5,7 @@ interface CssExports {
   'artifactMods': string;
   'classIcon': string;
   'contents': string;
+  'disableEvents': string;
   'fadeIn': string;
   'finding': string;
   'findings': string;

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -20,6 +20,7 @@ import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { addDividers } from 'app/utils/react';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
+import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { ReactNode, useMemo } from 'react';
@@ -129,7 +130,11 @@ export default function LoadoutView({
     : undefined;
 
   return (
-    <div className={styles.loadout} id={loadout.id} {...selectionProps}>
+    <div
+      className={clsx(styles.loadout, selectionProps?.ref && styles.disableEvents)}
+      id={loadout.id}
+      {...selectionProps}
+    >
       <div className={styles.title}>
         <h2>
           {loadout.classType === DestinyClass.Unknown && (


### PR DESCRIPTION
A small change for the loadout view, since I think many, while selecting the loadout for the stream deck, drag items/mods or other draggable elements inside the view.