### PR TITLE
Check for and error if the profile has no characters

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -15,10 +15,11 @@
     "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingAccountWarning": "If you don't see your account here, you may not have logged in to the right Bungie.net account, or Bungie.net may be down for maintenance.",
     "MissingTitle": "Account Not Found",
-    "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
+    "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile. Select one of your accounts below.",
     "ErrorLoadInventory": "Unable to load your Destiny {{version}} characters and inventory",
     "ErrorLoadManifest": "Unable to load Destiny info database from Bungie",
-    "SwitchAccounts": "You can switch accounts later from the menu in the header."
+    "SwitchAccounts": "You can switch accounts later from the menu in the header.",
+    "NoCharactersTitle": "No Characters Found"
   },
   "Activities": {
     "Activities": "Activities",

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -5,6 +5,7 @@ import { getPlatforms } from 'app/accounts/platforms';
 import { currentAccountSelector } from 'app/accounts/selectors';
 import { loadClarity } from 'app/clarity/descriptions/loadDescriptions';
 import { customStatsSelector } from 'app/dim-api/selectors';
+import { t } from 'app/i18next-t';
 import { processInGameLoadouts } from 'app/loadout-drawer/loadout-type-converters';
 import { inGameLoadoutLoaded } from 'app/loadout/ingame/actions';
 import { loadCoreSettings } from 'app/manifest/actions';
@@ -12,6 +13,7 @@ import { d2ManifestSelector, manifestSelector } from 'app/manifest/selectors';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
+import { DimError } from 'app/utils/dim-error';
 import { convertToError, errorMessage } from 'app/utils/errors';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
 import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
@@ -37,6 +39,7 @@ import { DimStore } from './store-types';
 import { getCharacterStatsData as getD1CharacterStatsData } from './store/character-utils';
 import { buildStores, getCharacterStatsData } from './store/d2-store-factory';
 import { resetItemIndexGenerator } from './store/item-index';
+import { getCurrentStore } from './stores-helpers';
 
 /**
  * Update the high level character information for all the stores
@@ -317,6 +320,19 @@ function loadStoresData(
 
         // If we switched account since starting this, give up before saving
         if (account !== currentAccountSelector(getState())) {
+          return;
+        }
+
+        if (!getCurrentStore(stores)) {
+          errorLog('d2-stores', 'No characters in profile');
+          dispatch(
+            error(
+              new DimError(
+                'Accounts.NoCharactersTitle',
+                t('Accounts.NoCharacters'),
+              ).withNoSocials(),
+            ),
+          );
           return;
         }
 

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -168,7 +168,7 @@ export const profileErrorSelector = (state: RootState) => state.inventory.profil
 
 /** A variant of profileErrorSelector which returns undefined if we still have a valid profile to use despite the error. */
 export const blockingProfileErrorSelector = (state: RootState) =>
-  state.inventory.profileResponse ? undefined : state.inventory.profileError;
+  currentStoreSelector(state) ? undefined : state.inventory.profileError;
 
 /** Whether DIM will automatically refresh on a schedule */
 export const autoRefreshEnabledSelector = (state: RootState) =>

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -1,4 +1,5 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
+import SelectAccount from 'app/accounts/SelectAccount';
 import { getPlatforms, setActivePlatform } from 'app/accounts/platforms';
 import {
   accountsLoadedSelector,
@@ -161,6 +162,7 @@ export default function Destiny() {
             title={t('Accounts.MissingTitle')}
             fallbackMessage={t('Accounts.MissingDescription')}
           />
+          <SelectAccount path="/" />
         </div>
       );
     }
@@ -272,8 +274,8 @@ function GlobalEffects() {
   // Badge the app icon with the number of postmaster items
   useEffect(() => {
     if (stores.length > 0 && badgePostmaster) {
-      const activeStore = getCurrentStore(stores)!;
-      setAppBadge(totalPostmasterItems(activeStore));
+      const activeStore = getCurrentStore(stores);
+      activeStore && setAppBadge(totalPostmasterItems(activeStore));
     }
   }, [badgePostmaster, stores]);
 

--- a/src/app/shell/ErrorPanel.tsx
+++ b/src/app/shell/ErrorPanel.tsx
@@ -51,6 +51,7 @@ export default function ErrorPanel({
   frameless?: boolean;
 }) {
   const underlyingError = error instanceof DimError ? error.cause : undefined;
+  showSocials = showSocials ? !(error instanceof DimError) || error.showSocials : false;
 
   let code: string | number | undefined = error instanceof DimError ? error.code : undefined;
   if (underlyingError) {

--- a/src/app/utils/dim-error.ts
+++ b/src/app/utils/dim-error.ts
@@ -13,6 +13,8 @@ export class DimError extends Error {
   code?: string;
   // The error that caused this error, if there is one. Naming it 'cause' makes it automatically chain in Sentry.
   cause?: Error;
+  // Whether to show social links in the error report dialog
+  showSocials = true;
 
   /** Pass in just a message key to set the message to the localized version of that key, or override with the second parameter. */
   constructor(messageKey: I18nKey, message?: string) {
@@ -23,6 +25,11 @@ export class DimError extends Error {
 
   public withError(error: unknown): DimError {
     this.cause = convertToError(error);
+    return this;
+  }
+
+  public withNoSocials(): DimError {
+    this.showSocials = false;
     return this;
   }
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -13,9 +13,10 @@
     "ErrorLoadManifest": "Unable to load Destiny info database from Bungie",
     "ErrorLoading": "Unable to load Destiny accounts from Bungie.net",
     "MissingAccountWarning": "If you don't see your account here, you may not have logged in to the right Bungie.net account, or Bungie.net may be down for maintenance.",
-    "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile.",
+    "MissingDescription": "The account you're trying to view is not an account linked to your Bungie.net profile. Select one of your accounts below.",
     "MissingTitle": "Account Not Found",
     "NoCharacters": "You have no Destiny characters associated with this Bungie.net account. Try logging into a different account.",
+    "NoCharactersTitle": "No Characters Found",
     "SwitchAccounts": "You can switch accounts later from the menu in the header.",
     "Title": "Accounts"
   },


### PR DESCRIPTION
1. Handles the case where there is no "current" character in the profile and errors out with a helpful message rather than failing with a TypeError later on.
2. Fixes some other cases where we assumed current character.
3. When the user lands on a URL for an account that's not theirs, offer the profile selector to help them get out of it. Fixes https://github.com/DestinyItemManager/DIM/issues/10241