### PR TITLE
Allow sharing loadouts even if their parameters are empty

### DIFF
--- a/src/app/loadout/LoadoutsRow.tsx
+++ b/src/app/loadout/LoadoutsRow.tsx
@@ -7,7 +7,6 @@ import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { Loadout } from 'app/loadout-drawer/loadout-types';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import _ from 'lodash';
 import { ReactNode, memo, useMemo } from 'react';
 import LoadoutView from './LoadoutView';
 
@@ -56,13 +55,11 @@ export default memo(function LoadoutRow({
       </button>,
     );
 
-    if (loadout.parameters && !_.isEmpty(loadout.parameters)) {
-      actionButtons.push(
-        <button key="share" type="button" className="dim-button" onClick={handleShare}>
-          {t('Loadouts.ShareLoadout')}
-        </button>,
-      );
-    }
+    actionButtons.push(
+      <button key="share" type="button" className="dim-button" onClick={handleShare}>
+        {t('Loadouts.ShareLoadout')}
+      </button>,
+    );
 
     if (saved) {
       actionButtons.push(


### PR DESCRIPTION
This might be a holdover from when we shared loadout parameters only, not full loadouts? 