### PR TITLE
Fix eqiupped long titel to unnecessarily push power number off

### DIFF
--- a/src/app/character-tile/CharacterTile.m.scss
+++ b/src/app/character-tile/CharacterTile.m.scss
@@ -70,6 +70,8 @@
 .bottom {
   composes: smallText;
   grid-area: bottom;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 // The emblem is only shown for D1 and the vault - D2 bakes it into the


### PR DESCRIPTION
Fixes #10289.

Add text-overflow and overflow properties to .bottom class