### PR TITLE
reserve an "equipped item" area even when missing an item

### DIFF
--- a/src/app/destiny1/d1-buckets.ts
+++ b/src/app/destiny1/d1-buckets.ts
@@ -78,6 +78,8 @@ export function getBuckets(defs: D1ManifestDefinitions) {
       description: 'Unknown items. DIM needs a manifest update.',
       name: 'Unknown',
       hash: -1,
+      // default to false. an equipped item existing, will override this in inv display
+      equippable: false,
       hasTransferDestination: false,
       category: BucketCategory.Item,
       capacity: Number.MAX_SAFE_INTEGER,
@@ -97,6 +99,7 @@ export function getBuckets(defs: D1ManifestDefinitions) {
         description: def.bucketDescription,
         name: def.bucketName,
         hash: def.hash,
+        equippable: def.category === BucketCategory.Equippable,
         hasTransferDestination: def.hasTransferDestination,
         capacity: def.itemCount,
         accountWide: false,

--- a/src/app/destiny2/d2-buckets.ts
+++ b/src/app/destiny2/d2-buckets.ts
@@ -73,6 +73,8 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       description: 'Unknown items. DIM needs a manifest update.',
       name: 'Unknown',
       hash: -1,
+      // default to false. an equipped item existing, will override this in inv display
+      equippable: false,
       hasTransferDestination: false,
       capacity: Number.MAX_SAFE_INTEGER,
       sort: 'Unknown',
@@ -91,6 +93,7 @@ export function getBuckets(defs: D2ManifestDefinitions) {
       description: def.displayProperties.description,
       name: def.displayProperties.name,
       hash: def.hash,
+      equippable: def.category === BucketCategory.Equippable,
       hasTransferDestination: def.hasTransferDestination,
       capacity: def.itemCount,
       accountWide: def.scope === 1,

--- a/src/app/inventory-page/StoreBucket.tsx
+++ b/src/app/inventory-page/StoreBucket.tsx
@@ -105,11 +105,11 @@ const StoreBucketInner = memo(function StoreBucketInner({
           storeId={storeId}
           storeClassType={storeClassType}
         >
-          {equippedItem ? (
+          {equippedItem && (
             <div className="equipped-item">
               <StoreInventoryItem key={equippedItem.index} item={equippedItem} />
             </div>
-          ) : null}
+          )}
           {bucket.hasTransferDestination && (
             <a
               onClick={pickEquipItem}

--- a/src/app/inventory-page/StoreBucket.tsx
+++ b/src/app/inventory-page/StoreBucket.tsx
@@ -92,9 +92,12 @@ const StoreBucketInner = memo(function StoreBucketInner({
       ? groupWeapons(sortItems(items))
       : sortItems(items.filter((i) => !i.equipped));
 
+  // represents whether there's *supposed* to be an equipped item here, aka armor/weapon/artifact, etc
+  const isEquippable = Boolean(equippedItem || bucket.equippable);
+
   return (
     <>
-      {equippedItem && (
+      {(equippedItem || isEquippable) && !isVault && (
         <StoreBucketDropTarget
           grouped={false}
           equip={true}
@@ -102,9 +105,11 @@ const StoreBucketInner = memo(function StoreBucketInner({
           storeId={storeId}
           storeClassType={storeClassType}
         >
-          <div className="equipped-item">
-            <StoreInventoryItem key={equippedItem.index} item={equippedItem} />
-          </div>
+          {equippedItem ? (
+            <div className="equipped-item">
+              <StoreInventoryItem key={equippedItem.index} item={equippedItem} />
+            </div>
+          ) : null}
           {bucket.hasTransferDestination && (
             <a
               onClick={pickEquipItem}
@@ -125,7 +130,8 @@ const StoreBucketInner = memo(function StoreBucketInner({
         bucket={bucket}
         storeId={storeId}
         storeClassType={storeClassType}
-        className={clsx({ 'not-equippable': !isVault && !equippedItem })}
+        // class representing a *character* bucket area that's not equippable
+        className={clsx({ 'not-equippable': !isVault && !isEquippable })}
       >
         {unequippedItems.map((groupOrItem) =>
           'id' in groupOrItem ? (

--- a/src/app/inventory/inventory-buckets.ts
+++ b/src/app/inventory/inventory-buckets.ts
@@ -12,6 +12,7 @@ export type InventoryBucket = {
   readonly description: string;
   readonly name: string;
   readonly hash: number;
+  readonly equippable: boolean;
   readonly hasTransferDestination: boolean;
   readonly capacity: number;
   readonly accountWide: boolean;


### PR DESCRIPTION
when there's an equipping slot, but nothing is equipped,
dim doesn't provide a drag target, and doesn't make the section "look" equippable.

for equippable buckets, this PR makes the "equipped" area appear even without a current item

confirmed d1 manifest has this same info and category in the bucket defs
<hr/>

before
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/39cda598-18b9-4291-9476-378effa72dc4)
<hr/>

after
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/6bd2fd77-73a1-4d8e-a049-9a4d361ac544)
