### PR TITLE
rekindled ornament stat display awareness

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -7,7 +7,7 @@ import { PressTip } from 'app/dim-ui/PressTip';
 import { I18nKey, t, tl } from 'app/i18next-t';
 import { D1Item, D1Stat, DimItem, DimSocket, DimStat } from 'app/inventory/item-types';
 import { statsMs } from 'app/inventory/store/stats';
-import { TOTAL_STAT_HASH, armorStats } from 'app/search/d2-known-values';
+import { TOTAL_STAT_HASH, armorStats, statfulOrnaments } from 'app/search/d2-known-values';
 import { getColor, percent } from 'app/shell/formatters';
 import { AppIcon, helpIcon } from 'app/shell/icons';
 import { userGuideUrl } from 'app/shell/links';
@@ -28,9 +28,6 @@ const modItemCategoryHashes = new Set([
   ItemCategoryHashes.ArmorModsGameplay, // armor mods (pre-2.0)
   ItemCategoryHashes.ArmorMods, // armor 2.0 mods
 ]);
-
-// a weird set of 3 solstice ornaments that provide a single resilience stat point
-const statfulOrnaments = new Set([4245469491, 2978747767, 2287277682]);
 
 // Some stat labels are long. This lets us replace them with i18n
 const statLabels: LookupTable<StatHashes, I18nKey> = {

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -289,7 +289,7 @@ function getNonReusableModSockets(item: DimItem) {
       !socketContainsIntrinsicPlug(s) &&
       !s.plugged.plugDef.plug.plugCategoryIdentifier.includes('masterwork') &&
       (s.plugged.plugDef.itemCategoryHashes?.some((h) => modItemCategoryHashes.has(h)) ||
-        statfulOrnaments.has(s.plugged.plugDef.hash)),
+        statfulOrnaments.includes(s.plugged.plugDef.hash)),
   );
 }
 

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -41,7 +41,7 @@ export const DEFAULT_ORNAMENTS: number[] = [
 ];
 
 /** a weird set of 3 solstice ornaments that provide a single resilience stat point */
-export const statfulOrnaments = new Set([4245469491, 2978747767, 2287277682]);
+export const statfulOrnaments = [4245469491, 2978747767, 2287277682];
 
 /** if a socket contains these, consider it empty */
 export const emptySocketHashes = [

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -40,6 +40,9 @@ export const DEFAULT_ORNAMENTS: number[] = [
   702981643, // InventoryItem "Default Ornament" Restores your armor to its default appearance.
 ];
 
+/** a weird set of 3 solstice ornaments that provide a single resilience stat point */
+export const statfulOrnaments = new Set([4245469491, 2978747767, 2287277682]);
+
 /** if a socket contains these, consider it empty */
 export const emptySocketHashes = [
   2323986101, // InventoryItem "Empty Mod Socket"


### PR DESCRIPTION
a few ornaments weirdly provide a point of resilience.
currently, DIM correctly includes these in the stat total as it adds up all plugs,
but the stat segment display and equation display don't know to call these plugs out. this fixes it

before: (note neither of these add up)
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/6ca6af13-78a3-4974-98df-17c24533ef59)
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/4d540b04-aaf3-4066-9a77-347d2e01896c)

after:
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/972c558d-747e-4682-80c1-29d84dde7329)
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/ecc69f57-7f97-4a51-b167-a4aef01bc573)
