### PR TITLE
rank progress circles: remove extraneous div and styling

### DIFF
--- a/src/app/progress/ReputationRank.m.scss
+++ b/src/app/progress/ReputationRank.m.scss
@@ -19,7 +19,6 @@
 .crucibleRankIcon {
   margin: 2px 10px -2px 2px;
   position: relative;
-  display: inline-block;
   width: 64px;
   height: 64px;
 }
@@ -35,7 +34,7 @@
       flex-direction: column;
     }
     .crucibleRankIcon {
-      margin: 0;
+      margin: 0 0 4px 0;
     }
   }
 }

--- a/src/app/progress/ReputationRank.tsx
+++ b/src/app/progress/ReputationRank.tsx
@@ -40,9 +40,7 @@ export function ReputationRank({
       className={clsx(factionClass, styles.activityRank, { [styles.gridLayout]: isProgressRanks })}
       title={replacer(progressionDef.displayProperties.description)}
     >
-      <div>
-        <ReputationRankIcon progress={progress} />
-      </div>
+      <ReputationRankIcon progress={progress} />
       <div className={styles.factionInfo}>
         <div className={styles.factionLevel}>
           {t('Progress.Rank', {


### PR DESCRIPTION
just documenting the change.

there was an extraneous and unstyled div wrapper here.
it didn't provide anything but a way for inline-block to kick in on the child element, causing a line-height-based, nearly-accidental bottom margin for the circle on mobile.

this removes some unnecessary stuff and makes the bottom margin explicit.