### PR TITLE
BCP47LanguageTag -> UnicodeBCP47LocaleIdentifier to fix TS breakage

### DIFF
--- a/src/app/utils/intl.ts
+++ b/src/app/utils/intl.ts
@@ -10,7 +10,7 @@ import { LookupTable } from './util-types';
 const dimLangToBrowserLang: LookupTable<DimLanguage, string> = _.invert(browserLangToDimLang);
 
 /** Map DIM's locale values to a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646) */
-function mapLocale(language: DimLanguage): Intl.BCP47LanguageTag {
+function mapLocale(language: DimLanguage): Intl.UnicodeBCP47LocaleIdentifier {
   return dimLangToBrowserLang[language] ?? language;
 }
 


### PR DESCRIPTION
TS 5.4 renamed this without a deprecation period, which causes a failure in #10315 /shrug

https://github.com/microsoft/TypeScript/pull/52996/files#r1409630068