### PR TITLE
use itemValueVisibility to filter item rewards

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * Loadouts with only armor mods, or only fashion (shaders & ornaments), now display a symbol in the equip dropdown, and can be filtered from among other loadouts.
+* BRAVE bounties now display correct rewards instead of all possible rewards.
 
 ## 8.15.0 <span class="changelog-date">(2024-04-07)</span>
 

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "@textcomplete/core": "^0.1.13",
     "@textcomplete/textarea": "^0.1.13",
     "@textcomplete/utils": "^0.1.13",
-    "bungie-api-ts": "^5.0.0",
+    "bungie-api-ts": "^5.1.0",
     "caniuse-lite": "^1.0.30001588",
     "clsx": "^2.1.0",
     "comlink": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ dependencies:
     specifier: ^0.1.13
     version: 0.1.13
   bungie-api-ts:
-    specifier: ^5.0.0
-    version: 5.0.0
+    specifier: ^5.1.0
+    version: 5.1.0
   caniuse-lite:
     specifier: ^1.0.30001588
     version: 1.0.30001588
@@ -4502,8 +4502,8 @@ packages:
       run-applescript: 7.0.0
     dev: true
 
-  /bungie-api-ts@5.0.0:
-    resolution: {integrity: sha512-MpEP37GmYN5klyrcpFtFezFqSK4KNmiXx7yqmCV15eJim37w7d7GpjH3jgKe3XP1uruLCmzGbf56q5pRf3ktaQ==}
+  /bungie-api-ts@5.1.0:
+    resolution: {integrity: sha512-q+DCazUsgq34Q54vpHcR3WKifEPAqalTTddW4za8JxdlZF0JaNwvqNBEEa0YMPOUhbGMcJtR09dvcwjtI/ojcw==}
     engines: {node: '>=13.2.0'}
     dev: false
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -28,6 +28,7 @@ import {
   DestinyItemTooltipNotification,
   DestinyObjectiveProgress,
   DestinyProfileResponse,
+  DestinyVendorSaleItemComponent,
   DictionaryComponentResponse,
   ItemBindStatus,
   ItemLocation,
@@ -142,6 +143,8 @@ export function makeFakeItem(
   itemInstanceId = '0',
   quantity = 1,
   allowWishList = false,
+  /** if available, this should be passed in from a vendor saleItem (DestinyVendorSaleItemComponent) */
+  itemValueVisibility?: DestinyVendorSaleItemComponent['itemValueVisibility'],
 ): DimItem | undefined {
   const item = makeItem(
     context,
@@ -153,7 +156,7 @@ export function makeFakeItem(
       location: ItemLocation.Vendor,
       bucketHash: 0,
       transferStatus: TransferStatuses.NotTransferrable,
-      itemValueVisibility: [],
+      itemValueVisibility,
       lockable: false,
       state: ItemState.None,
       isWrapper: false,
@@ -781,7 +784,12 @@ function buildPursuitInfo(
   item: DestinyItemComponent,
   itemDef: DestinyInventoryItemDefinition,
 ) {
-  const rewards = itemDef.value ? itemDef.value.itemValue.filter((v) => v.itemHash) : [];
+  const rewards = itemDef.value
+    ? itemDef.value.itemValue.filter(
+        (v, i) => v.itemHash && (item.itemValueVisibility?.[i] ?? true),
+      )
+    : [];
+
   const questLine = getQuestLineInfo(itemDef);
   const expiration = getExpirationInfo(item, itemDef);
 

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -111,6 +111,7 @@ function makeVendorItem(
       vendorItemDef ? vendorItemDef.quantity : 1,
       // vendor items are wish list enabled!
       true,
+      saleItem?.itemValueVisibility,
     ),
   };
 


### PR DESCRIPTION
we weren't doing this before. it really only seems in use on these new BRAVE bounties

before:
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/46063a11-0728-4dbe-b1d1-83753f2f558d)

after:
![image](https://github.com/DestinyItemManager/DIM/assets/68782081/57f6bd2c-b5a4-435f-bffd-1d42c8c7916a)
