### PR TITLE
Fix lint workflow to actually fail on lint errors

### DIFF
--- a/.github/workflows/pr-test-and-lint.yml
+++ b/.github/workflows/pr-test-and-lint.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Annotate ESLint Results
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: ataylorme/eslint-annotate-action@v2
-        continue-on-error: true
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: "eslint.results.json"


### PR DESCRIPTION
The lint workflow was set to always succeed for non-forked repositories. This restores it to fail when there are lint issues.