### PR TITLE
Restore per-stat quality info to D1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Restore per-stat quality ratings to D1 armor popups.
+
 ## 8.17.0 <span class="changelog-date">(2024-04-21)</span>
 
 * Fixed max stat constraints sometimes being not shown in Loadout parameters.

--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -71,11 +71,8 @@
 }
 
 .quality {
-  display: none;
+  display: inline;
   margin-left: 4px;
-  :global(.itemQuality) & {
-    display: inline;
-  }
 }
 
 // Colors for the stat bars

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -1,4 +1,4 @@
-import { customStatsSelector } from 'app/dim-api/selectors';
+import { customStatsSelector, settingSelector } from 'app/dim-api/selectors';
 import AnimatedNumber from 'app/dim-ui/AnimatedNumber';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { CustomStatWeightsFromHash } from 'app/dim-ui/CustomStatWeights';
@@ -39,6 +39,7 @@ const statLabels: LookupTable<StatHashes, I18nKey> = {
  * A single stat line.
  */
 export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem }) {
+  const showQuality = useSelector(settingSelector('itemQuality'));
   const customStatsList = useSelector(customStatsSelector);
   const customStatHashes = customStatsList.map((c) => c.statHash);
   const armor2MasterworkSockets =
@@ -122,7 +123,8 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
         </div>
       )}
 
-      {item &&
+      {showQuality &&
+        item &&
         isD1Stat(item, stat) &&
         stat.qualityPercentage &&
         stat.qualityPercentage.min !== 0 && (


### PR DESCRIPTION
Fixes #10323. It broke when item popups moved out from under `App` and into the `temp-container`.

<img width="379" alt="Screenshot 2024-04-24 at 10 01 21 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/85bc75c0-6cb1-41a2-b838-9ba893f63a74">
