### PR TITLE
Fix overflowing title

### DIFF
--- a/src/app/character-tile/CharacterTile.m.scss
+++ b/src/app/character-tile/CharacterTile.m.scss
@@ -11,11 +11,17 @@
   display: grid;
   grid-template-areas:
     'emblem class power'
-    'emblem bottom maxTotalPower';
+    'emblem bottom bottom';
   grid-template-columns: 36px 1fr min-content;
   grid-template-rows: min-content 1fr;
   gap: 0 6px;
   padding: 0 6px;
+
+  @include phone-portrait {
+    grid-template-areas:
+      'emblem class power'
+      'emblem bottom maxTotalPower';
+  }
 
   // Use the emblem as a background
   background-size: $emblem-width $emblem-height;
@@ -70,8 +76,9 @@
 .bottom {
   composes: smallText;
   grid-area: bottom;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  min-width: 0; // prevents expanding beyond the grid cell with long contents
+  display: flex;
+  align-items: stretch;
 }
 
 // The emblem is only shown for D1 and the vault - D2 bakes it into the
@@ -95,6 +102,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   color: white;
+  min-width: 0; // prevents expanding beyond the grid cell with long contents
 
   .vault & {
     margin-top: 0;
@@ -140,11 +148,20 @@
 
 // The currently equipped title (from a seal)
 .title {
+  display: flex;
+  flex-direction: row;
   font-style: italic;
   color: $sealtitle;
   text-shadow:
     1px 1px 1px rgba(0, 0, 0, 0.5),
     0 0 10px rgba(0, 0, 0, 0.5);
+  width: 100%;
+
+  > *:first-child {
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .gildedCurrentSeason {

--- a/src/app/character-tile/CharacterTile.tsx
+++ b/src/app/character-tile/CharacterTile.tsx
@@ -71,7 +71,7 @@ function Title({ titleInfo }: { titleInfo: DimTitle }) {
     <span
       className={clsx(styles.title, { [styles.gildedCurrentSeason]: isGildedForCurrentSeason })}
     >
-      {title}
+      <span>{title}</span>
       {gildedNum > 0 && (
         <>
           <span className={styles.gildedIcon}>{gildedIcon}</span>


### PR DESCRIPTION
#10295 was a bit naive in how it "fixed" long titles, as it didn't take into account the gilded icon, which ended up either cut off vertically, or pushed out of the title area altogether. This fixes that.

Before:
<img width="278" alt="Screenshot 2024-04-24 at 10 32 58 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/656065e8-0a80-42e3-ba61-2f01f11af7e6">
<img width="274" alt="Screenshot 2024-04-24 at 10 32 50 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/38ec5cab-620d-4289-9e59-16d15b9e5849">

After:
<img width="273" alt="Screenshot 2024-04-24 at 10 32 29 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/dd0c5c98-01b8-46aa-8702-a7caf919c01b">

And then as a bonus, on desktop allow the title to stretch across the full area of the bottom of the tile (since we don't show max light like we do on mobile):
<img width="271" alt="Screenshot 2024-04-24 at 10 38 02 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/a7cc492c-1851-4de6-9d26-0788f35cc7bc">

