### PR TITLE
Handle zero destination hash

### DIFF
--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -105,11 +105,12 @@ export function toVendor(
     ),
   );
 
-  const destinationDef =
+  const destinationHash =
     typeof vendor?.vendorLocationIndex === 'number' && vendor.vendorLocationIndex >= 0
-      ? defs.Destination.get(vendorDef.locations[vendor.vendorLocationIndex].destinationHash)
-      : undefined;
-  const placeDef = destinationDef && defs.Place.get(destinationDef.placeHash);
+      ? vendorDef.locations[vendor.vendorLocationIndex].destinationHash
+      : 0;
+  const destinationDef = destinationHash ? defs.Destination.get(destinationHash) : undefined;
+  const placeDef = destinationDef?.placeHash ? defs.Place.get(destinationDef.placeHash) : undefined;
 
   const vendorCurrencyHashes = new Set<number>();
   gatherVendorCurrencies(defs, vendorDef, vendorsResponse, sales, vendorCurrencyHashes);


### PR DESCRIPTION
I noticed this a lot in Sentry, even though it doesn't repro for me. Maybe this happens when users haven't unlocked a new vendor yet? Regardless it's good hygiene to handle this.