### PR TITLE
Clean up season calculation a bit

### DIFF
--- a/src/app/inventory/store/season-d2ai.d.ts
+++ b/src/app/inventory/store/season-d2ai.d.ts
@@ -1,0 +1,20 @@
+declare module 'data/d2/season-to-source.json' {
+  const x: { readonly [season: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/seasons.json' {
+  const x: { readonly [itemHash: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/seasons_backup.json' {
+  const x: { readonly [itemHash: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/watermark-to-event.json' {
+  const x: { readonly [watermark: string]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/watermark-to-season.json' {
+  const x: { readonly [watermark: string]: number | undefined };
+  export default x;
+}

--- a/src/app/inventory/store/season.ts
+++ b/src/app/inventory/store/season.ts
@@ -14,8 +14,6 @@ import { DimItem } from '../item-types';
 /** The Destiny season (D2) that a specific item belongs to. */
 // TODO: load this lazily with import(). Requires some rework of the filters code.
 
-const SourceToD2Season: Record<number, number> = D2SeasonFromSource.sources;
-
 export function getSeason(
   item: DimItem | DestinyInventoryItemDefinition,
   defs?: D2ManifestDefinitions,
@@ -62,14 +60,17 @@ function getSeasonFromOverlayAndSource(
   source: number | undefined,
   hash: number,
 ) {
-  if (source && SourceToD2Season[source] && !overlay) {
-    return SourceToD2Season[source];
+  if (overlay && D2SeasonFromOverlay[overlay]) {
+    return D2SeasonFromOverlay[overlay]!;
   }
 
-  return overlay
-    ? Number((D2SeasonFromOverlay as Record<string, number>)[overlay]) ||
-        (D2SeasonBackup as Record<number, number>)[hash]
-    : (D2Season as Record<number, number>)[hash] || D2CalculatedSeason;
+  if (source && D2SeasonFromSource[source]) {
+    return D2SeasonFromSource[source]!;
+  }
+
+  // D2Season and D2SeasonBackup have the same structure, but some of the hashes
+  // in D2SeasonBackup are not in D2Season.
+  return D2Season[hash] || D2SeasonBackup[hash] || D2CalculatedSeason;
 }
 
 /** The Destiny event (D2) that a specific item belongs to. */


### PR DESCRIPTION
While researching https://github.com/DestinyItemManager/d2-additional-info/issues/471 I saw an opportunity to clean up the season calculation code a bit. This does change the semantics, though it doesn't seem to change the output any (since the spreadsheet test still passes!)

The major changes are:

1. We will now fall back from looking at overlay to looking at source, instead of failing immediately if we have an overlay but it doesn't exist in `D2SeasonFromOverlay`.
2. If we can't find a mapping in `D2SeasonFromSource` we'll fall back to `D2Season`, and then to `D2SeasonBackup`. Previously we only used `D2Season` if there was no overlay and the source wasn't found in `D2SeasonFromSource`, and we only used `D2SeasonBackup` if an overlay wasn't found in `D2SeasonFromOverlay`.