### PR TITLE
D2EventInfo stuff

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -28,7 +28,7 @@ import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { getItemYear } from 'app/utils/item-utils';
 import clsx from 'clsx';
-import { D2EventInfo } from 'data/d2/d2-event-info';
+import { D2EventInfo } from 'data/d2/d2-event-info-v2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { useSelector } from 'react-redux';
 import AllWishlistRolls from './AllWishlistRolls';
@@ -138,7 +138,7 @@ export default function Armory({
                   season: season.seasonNumber,
                   year: getItemYear(item) ?? '?',
                 })}
-                ){event && <span> - {D2EventInfo[getEvent(item)].name}</span>}
+                ){Boolean(event) && <span> - {D2EventInfo[getEvent(item)!].name}</span>}
               </div>
             )}
           </div>

--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -18,7 +18,7 @@ import {
 } from 'app/utils/item-utils';
 import { getDisplayedItemSockets, getSocketsByIndexes } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { D2EventInfo } from 'data/d2/d2-event-info';
+import { D2EventInfo } from 'data/d2/d2-event-info-v2';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import D2MissingSources from 'data/d2/missing-source-info';
 import D2Sources from 'data/d2/source-info';

--- a/src/app/inventory/store/season-d2ai.d.ts
+++ b/src/app/inventory/store/season-d2ai.d.ts
@@ -10,16 +10,17 @@ declare module 'data/d2/seasons_backup.json' {
   const x: { readonly [itemHash: number]: number | undefined };
   export default x;
 }
-declare module 'data/d2/watermark-to-event.json' {
-  const x: { readonly [watermark: string]: number | undefined };
-  export default x;
-}
 declare module 'data/d2/watermark-to-season.json' {
   const x: { readonly [watermark: string]: number | undefined };
   export default x;
 }
 
+declare type D2EventIndex = keyof typeof import('data/d2/d2-event-info-v2').D2EventInfo;
+declare module 'data/d2/watermark-to-event.json' {
+  const x: { readonly [watermark: string]: D2EventIndex | undefined };
+  export default x;
+}
 declare module 'data/d2/events.json' {
-  const x: { readonly [itemHash: number]: number | undefined };
+  const x: { readonly [itemHash: number]: D2EventIndex | undefined };
   export default x;
 }

--- a/src/app/inventory/store/season-d2ai.d.ts
+++ b/src/app/inventory/store/season-d2ai.d.ts
@@ -1,0 +1,20 @@
+declare module 'data/d2/season-to-source.json' {
+  const x: { readonly [season: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/seasons.json' {
+  const x: { readonly [itemHash: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/seasons_backup.json' {
+  const x: { readonly [itemHash: number]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/watermark-to-event.json' {
+  const x: { readonly [watermark: string]: number | undefined };
+  export default x;
+}
+declare module 'data/d2/watermark-to-season.json' {
+  const x: { readonly [watermark: string]: number | undefined };
+  export default x;
+}

--- a/src/app/inventory/store/season-d2ai.d.ts
+++ b/src/app/inventory/store/season-d2ai.d.ts
@@ -18,3 +18,8 @@ declare module 'data/d2/watermark-to-season.json' {
   const x: { readonly [watermark: string]: number | undefined };
   export default x;
 }
+
+declare module 'data/d2/events.json' {
+  const x: { readonly [itemHash: number]: number | undefined };
+  export default x;
+}

--- a/src/app/inventory/store/season.ts
+++ b/src/app/inventory/store/season.ts
@@ -107,10 +107,8 @@ export function getEvent(item: DimItem): D2EventIndex {
   // hiddenOverlay has precedence for event
   const overlay = item.hiddenOverlay || item.iconOverlay;
   const D2EventBackup = item.source
-    ? D2SourcesToEvent[item.source] || (D2Events as Record<number, D2EventIndex>)[item.hash]
-    : (D2Events as Record<number, D2EventIndex>)[item.hash];
+    ? D2SourcesToEvent[item.source] || D2Events[item.hash]
+    : D2Events[item.hash];
 
-  return overlay
-    ? (D2EventFromOverlay as Record<string, D2EventIndex>)[overlay] || D2EventBackup
-    : D2EventBackup;
+  return overlay ? D2EventFromOverlay[overlay] || D2EventBackup : D2EventBackup;
 }

--- a/src/app/inventory/store/season.ts
+++ b/src/app/inventory/store/season.ts
@@ -1,6 +1,6 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
-import { D2EventEnum, D2EventInfo } from 'data/d2/d2-event-info-v2';
+import { D2EventInfo } from 'data/d2/d2-event-info-v2';
 import { D2CalculatedSeason } from 'data/d2/d2-season-info';
 import D2Events from 'data/d2/events.json';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
@@ -14,34 +14,11 @@ import { DimItem } from '../item-types';
 /** The Destiny season (D2) that a specific item belongs to. */
 // TODO: load this lazily with import(). Requires some rework of the filters code.
 
-export type D2EventIndex = keyof typeof D2EventInfo;
-
-const D2SourcesToEvent: Record<number, D2EventIndex> = {};
-
-for (const [, eventAttrs] of Object.entries(D2EventInfo)) {
-  for (const source of eventAttrs.sources) {
-    switch (eventAttrs.name.replace('The ', '').toUpperCase().split(' ').join('_')) {
-      case 'DAWNING':
-        D2SourcesToEvent[source] = D2EventEnum.DAWNING;
-        break;
-      case 'CRIMSON_DAYS':
-        D2SourcesToEvent[source] = D2EventEnum.CRIMSON_DAYS;
-        break;
-      case 'SOLSTICE_OF_HEROES':
-        D2SourcesToEvent[source] = D2EventEnum.SOLSTICE_OF_HEROES;
-        break;
-      case 'FESTIVAL_OF_THE_LOST':
-        D2SourcesToEvent[source] = D2EventEnum.FESTIVAL_OF_THE_LOST;
-        break;
-      case 'REVELRY':
-        D2SourcesToEvent[source] = D2EventEnum.REVELRY;
-        break;
-      case 'GUARDIAN_GAMES':
-        D2SourcesToEvent[source] = D2EventEnum.GUARDIAN_GAMES;
-        break;
-    }
-  }
-}
+const D2SourcesToEvent = Object.fromEntries(
+  Object.entries(D2EventInfo).flatMap(([index, event]) =>
+    event.sources.map((source) => [source, Number(index) as D2EventIndex]),
+  ),
+);
 
 export function getSeason(
   item: DimItem | DestinyInventoryItemDefinition,
@@ -103,12 +80,16 @@ function getSeasonFromOverlayAndSource(
 }
 
 /** The Destiny event (D2) that a specific item belongs to. */
-export function getEvent(item: DimItem): D2EventIndex {
+export function getEvent(item: DimItem): D2EventIndex | undefined {
   // hiddenOverlay has precedence for event
   const overlay = item.hiddenOverlay || item.iconOverlay;
-  const D2EventBackup = item.source
-    ? D2SourcesToEvent[item.source] || D2Events[item.hash]
-    : D2Events[item.hash];
+  if (overlay && D2EventFromOverlay[overlay]) {
+    return D2EventFromOverlay[overlay]!;
+  }
 
-  return overlay ? D2EventFromOverlay[overlay] || D2EventBackup : D2EventBackup;
+  if (item.source && D2SourcesToEvent[item.source]) {
+    return D2SourcesToEvent[item.source];
+  }
+
+  return D2Events[item.hash];
 }

--- a/src/app/inventory/store/season.ts
+++ b/src/app/inventory/store/season.ts
@@ -14,8 +14,6 @@ import { DimItem } from '../item-types';
 /** The Destiny season (D2) that a specific item belongs to. */
 // TODO: load this lazily with import(). Requires some rework of the filters code.
 
-const SourceToD2Season: Record<number, number> = D2SeasonFromSource.sources;
-
 export type D2EventIndex = keyof typeof D2EventInfo;
 
 const D2SourcesToEvent: Record<number, D2EventIndex> = {};
@@ -91,14 +89,17 @@ function getSeasonFromOverlayAndSource(
   source: number | undefined,
   hash: number,
 ) {
-  if (source && SourceToD2Season[source] && !overlay) {
-    return SourceToD2Season[source];
+  if (overlay && D2SeasonFromOverlay[overlay]) {
+    return D2SeasonFromOverlay[overlay]!;
   }
 
-  return overlay
-    ? Number((D2SeasonFromOverlay as Record<string, number>)[overlay]) ||
-        (D2SeasonBackup as Record<number, number>)[hash]
-    : (D2Season as Record<number, number>)[hash] || D2CalculatedSeason;
+  if (source && D2SeasonFromSource[source]) {
+    return D2SeasonFromSource[source]!;
+  }
+
+  // D2Season and D2SeasonBackup have the same structure, but some of the hashes
+  // in D2SeasonBackup are not in D2Season.
+  return D2Season[hash] || D2SeasonBackup[hash] || D2CalculatedSeason;
 }
 
 /** The Destiny event (D2) that a specific item belongs to. */

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -61,7 +61,7 @@ import {
 import { LookupTable } from 'app/utils/util-types';
 import { InventoryWishListRoll } from 'app/wishlists/wishlists';
 import clsx from 'clsx';
-import { D2EventInfo } from 'data/d2/d2-event-info';
+import { D2EventInfo } from 'data/d2/d2-event-info-v2';
 import { PlugCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import shapedOverlay from 'images/shapedOverlay.png';
 import _ from 'lodash';

--- a/src/app/search/search-filters/known-values.ts
+++ b/src/app/search/search-filters/known-values.ts
@@ -4,9 +4,9 @@ import { tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { getEvent } from 'app/inventory/store/season';
 import { getItemDamageShortName } from 'app/utils/item-utils';
-import { LookupTable, StringLookup } from 'app/utils/util-types';
+import { LookupTable } from 'app/utils/util-types';
 import { DestinyAmmunitionType, DestinyClass, DestinyRecordState } from 'bungie-api-ts/destiny2';
-import { D2EventEnum } from 'data/d2/d2-event-info-v2';
+import { D2EventInfo } from 'data/d2/d2-event-info-v2';
 import focusingOutputs from 'data/d2/focusing-item-outputs.json';
 import { BreakerTypeHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import missingSources from 'data/d2/missing-source-info';
@@ -22,16 +22,12 @@ import {
 import { FilterDefinition } from '../filter-types';
 import { cosmeticTypes, damageTypeNames } from '../search-filter-values';
 
-const D2EventPredicateLookup = {
-  dawning: D2EventEnum.DAWNING,
-  crimsondays: D2EventEnum.CRIMSON_DAYS,
-  solstice: D2EventEnum.SOLSTICE_OF_HEROES,
-  fotl: D2EventEnum.FESTIVAL_OF_THE_LOST,
-  revelry: D2EventEnum.REVELRY,
-  games: D2EventEnum.GUARDIAN_GAMES,
-};
-
-const d2EventPredicates: StringLookup<D2EventEnum> = D2EventPredicateLookup;
+const D2EventPredicateLookup = Object.fromEntries(
+  Object.entries(D2EventInfo).map(([index, event]) => [
+    event.shortname,
+    Number(index) as D2EventIndex,
+  ]),
+);
 
 // filters relying on curated known values (class names, rarities, elements)
 
@@ -261,8 +257,8 @@ const knownValuesFilters: FilterDefinition[] = [
           (item.source && sourceInfo.sourceHashes.includes(item.source)) ||
           sourceInfo.itemHashes.includes(item.hash) ||
           missingSource?.includes(item.hash);
-      } else if (d2EventPredicates[filterValue]) {
-        const predicate = d2EventPredicates[filterValue];
+      } else if (D2EventPredicateLookup[filterValue]) {
+        const predicate = D2EventPredicateLookup[filterValue];
         return (item: DimItem) => getEvent(item) === predicate;
       } else {
         throw new Error(`Unknown item source ${filterValue}`);

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -105,11 +105,12 @@ export function toVendor(
     ),
   );
 
-  const destinationDef =
+  const destinationHash =
     typeof vendor?.vendorLocationIndex === 'number' && vendor.vendorLocationIndex >= 0
-      ? defs.Destination.get(vendorDef.locations[vendor.vendorLocationIndex].destinationHash)
-      : undefined;
-  const placeDef = destinationDef && defs.Place.get(destinationDef.placeHash);
+      ? vendorDef.locations[vendor.vendorLocationIndex].destinationHash
+      : 0;
+  const destinationDef = destinationHash ? defs.Destination.get(destinationHash) : undefined;
+  const placeDef = destinationDef?.placeHash ? defs.Place.get(destinationDef.placeHash) : undefined;
 
   const vendorCurrencyHashes = new Set<number>();
   gatherVendorCurrencies(defs, vendorDef, vendorsResponse, sales, vendorCurrencyHashes);


### PR DESCRIPTION
This was a bit more what I was thinking - the idea behind dropping the generated maps was that we could save code by generating them at runtime. With this we can drop the `D2EventEnum` too, since it isn't used.

Though, if it were incorporated into the keys, it could replace `D2EventIndex`, e.g.:

```ts
export const D2EventInfo = {
 [D2EventEnum.DAWNING]: {
    name: 'The Dawning',
    shortname: 'dawning',
    sources: [464727567, 547767158, 629617846, 2364515524, 3092212681, 3952847349, 4054646289],
    engram: [1170720694, 2648089539, 3151770741, 3488374611],
  },
  [D2EventEnum.CRIMSON_DAYS]: {
    name: 'Crimson Days',
    shortname: 'crimsondays',
    sources: [2502262376],
    engram: [191363032, 3373123597],
  },
  ...
}
```