### PR TITLE
Use power-levels instead of d2-season-info directly

### DIFF
--- a/src/app/progress/engrams.ts
+++ b/src/app/progress/engrams.ts
@@ -1,5 +1,5 @@
+import { powerLevelByKeyword } from 'app/search/power-levels';
 import { HashLookup } from 'app/utils/util-types';
-import { D2CalculatedSeason, D2SeasonInfo } from 'data/d2/d2-season-info';
 import _ from 'lodash';
 
 /**
@@ -67,14 +67,16 @@ export function getEngramPowerBonus(itemHash: number, maxPower?: number, parentI
 
   maxPower ||= 0;
   maxPower = Math.floor(maxPower);
-  const season = D2SeasonInfo[D2CalculatedSeason];
-  const powerfulCap = season.powerfulCap;
+  const powerfulCap = powerLevelByKeyword.powerfulcap;
   if (engramInfo.cap === PowerCap.Powerful) {
     // Powerful engrams can't go above the powerful cap
     return _.clamp(powerfulCap - maxPower, 0, engramInfo.bonus);
   } else if (engramInfo.cap === PowerCap.Pinnacle) {
     // Once you're at or above the powerful cap, pinnacles only give +2, up to the hard cap
-    const pinnacleCap = Math.min(season.pinnacleCap, Math.max(maxPower, powerfulCap) + 2);
+    const pinnacleCap = Math.min(
+      powerLevelByKeyword.pinnaclecap,
+      Math.max(maxPower, powerfulCap) + 2,
+    );
     return _.clamp(pinnacleCap - maxPower, 0, engramInfo.bonus);
   }
 }


### PR DESCRIPTION
If it doesn't already, I think this will help Terser almost entirely eliminate the d2-season-info import by inlining the few values we actually need.