### PR TITLE
Update minimum browser compat for Chrome and iOS

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Minimum browser version for DIM has been raised to Chrome 109+ (or equivalent Chromium-based browsers) and iOS 16+.
+
 ## 8.18.1 <span class="changelog-date">(2024-04-30)</span>
 
 * Fix vault tile display on mobile.

--- a/package.json
+++ b/package.json
@@ -63,14 +63,14 @@
   },
   "homepage": "https://destinyitemmanager.com",
   "browserslist": [
-    "Chrome >= 85",
+    "Chrome >= 109",
+    "Edge >= 109",
     "last 2 ChromeAndroid versions",
     "last 2 FirefoxAndroid versions",
     "last 2 Firefox versions",
     "Firefox ESR",
     "last 2 Safari versions",
-    "iOS >= 14.5",
-    "last 2 Edge versions",
+    "iOS >= 16",
     "last 2 Opera versions"
   ],
   "resolutions": {


### PR DESCRIPTION
Steam's built-in browser has been upgraded to Chromium 109. Previously this was the "long pole" that held back DIM's browser support. This PR updates to support Chrome 109+ from 85+ (to preserve compatibility with Steam) and also increases the minimum iOS version to 16+ from 14.5+.

Chrome 109 was released on January 10, 2023, and iOS 16 was released on September 12, 2022. 

Chrome 85 was released on August 25, 2020, and iOS 14.5 was released on April 26, 2021.

There are a handful of things that we gain access to that we wouldn't otherwise have good fallbacks for, but the major ones are CSS Layers (to start addressing precedence issues) and Origin Private File System. Oh, and un-polyfilled `<dialog>`.