### PR TITLE
Remove dialog polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,6 @@
     "clsx": "^2.1.1",
     "comlink": "^4.4.1",
     "core-js": "^3.37.0",
-    "dialog-polyfill": "^0.5.6",
     "dnd-core": "^16.0.1",
     "downshift": "^9.0.4",
     "fast-copy": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ dependencies:
   core-js:
     specifier: ^3.37.0
     version: 3.37.0
-  dialog-polyfill:
-    specifier: ^0.5.6
-    version: 0.5.6
   dnd-core:
     specifier: ^16.0.1
     version: 16.0.1
@@ -5268,10 +5265,6 @@ packages:
   /detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
     dev: true
-
-  /dialog-polyfill@0.5.6:
-    resolution: {integrity: sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==}
-    dev: false
 
   /diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}

--- a/src/app/dim-ui/useDialog.tsx
+++ b/src/app/dim-ui/useDialog.tsx
@@ -1,10 +1,8 @@
-import dialogPolyfill from 'dialog-polyfill';
-import 'dialog-polyfill/dist/dialog-polyfill.css';
 import styles from './useDialog.m.scss';
 
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import ClickOutsideRoot from './ClickOutsideRoot';
 
 // Redecalare forwardRef
@@ -83,14 +81,6 @@ const Dialog = forwardRef(function Dialog<Args = [], Result = void>(
   );
 
   useImperativeHandle(ref, () => ({ showDialog }), [showDialog]);
-
-  // Need to polyfill dialog, which only arrived in Safari 15.4
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (dialog) {
-      dialogPolyfill.registerDialog(dialog);
-    }
-  }, [dialogRef]);
 
   // We block click event propagation or else it'll trigger click handlers of the parent.
   return (


### PR DESCRIPTION
This is no longer needed now that our minimum browser support includes native `dialog`. I won't merge this for a while to give folks a bit of a chance to see the deprecation.