### PR TITLE
Fix sheet height locking too early for filter help

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -327,7 +327,7 @@ export default function Sheet({
   );
 }
 
-function tryWithBackoff(callback: () => boolean, timeout: number = 500, limit: number = 5_000) {
+function tryWithBackoff(callback: () => boolean, timeout = 500, limit = 5_000) {
   if (timeout > limit) {
     return;
   }

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -13,6 +13,7 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
+import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
 import { AnimatePresence, LayoutGroup, Variants, motion } from 'framer-motion';
@@ -545,7 +546,13 @@ function SearchBar(
         </LayoutGroup>
 
         {filterHelpOpen && (
-          <Suspense fallback={<Loading message={t('Loading.FilterHelp')} />}>
+          <Suspense
+            fallback={
+              <Portal>
+                <Loading message={t('Loading.FilterHelp')} />
+              </Portal>
+            }
+          >
             {/* Because FilterHelp suspends, the entire sheet will suspend while it is loaded.
              * This stops us having issues with incorrect frozen initial heights as it will
              * get locked to the fallback height if we don't do this.

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -545,21 +545,25 @@ function SearchBar(
         </LayoutGroup>
 
         {filterHelpOpen && (
-          <Sheet
-            onClose={() => setFilterHelpOpen(false)}
-            header={
-              <>
-                <h1>{t('Header.Filters')}</h1>
-                <UserGuideLink topic="Item-Search" />
-              </>
-            }
-            freezeInitialHeight
-            sheetClassName={styles.filterHelp}
-          >
-            <Suspense fallback={<Loading message={t('Loading.FilterHelp')} />}>
+          <Suspense fallback={<Loading message={t('Loading.FilterHelp')} />}>
+            {/* Because FilterHelp suspends, the entire sheet will suspend while it is loaded.
+             * This stops us having issues with incorrect frozen initial heights as it will
+             * get locked to the fallback height if we don't do this.
+             */}
+            <Sheet
+              onClose={() => setFilterHelpOpen(false)}
+              header={
+                <>
+                  <h1>{t('Header.Filters')}</h1>
+                  <UserGuideLink topic="Item-Search" />
+                </>
+              }
+              freezeInitialHeight
+              sheetClassName={styles.filterHelp}
+            >
               <LazyFilterHelp />
-            </Suspense>
-          </Sheet>
+            </Sheet>
+          </Suspense>
         )}
 
         {autocompleteMenu}

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -555,8 +555,7 @@ function SearchBar(
           >
             {/* Because FilterHelp suspends, the entire sheet will suspend while it is loaded.
              * This stops us having issues with incorrect frozen initial heights as it will
-             * get locked to the fallback height if we don't do this.
-             */}
+             * get locked to the fallback height if we don't do this. */}
             <Sheet
               onClose={() => setFilterHelpOpen(false)}
               header={


### PR DESCRIPTION
Based on comments in the thread it should fix it. It works fine on desktop so it doesn't introduce anything unexpected in the filters help component as far as I can see.

Related to #10346 #9240 

Edit: Confirmed this fixes it by installing a local dev version of the PWA. I couldn't reproduce on mobile websites, only when installing the PWA. The specific behaviour I was seeing was on first open of filter help it would be a really short sheet, and it would be fine on second open. After fixing it was the correct height first time.