### PR TITLE
`inloadoutcount` search filter

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -248,7 +248,7 @@
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "Infusable": "Shows items that can be infused.",
-    "InLoadoutCount": "Shows items based on the number of DIM loadouts they are included in.",
+    "InLoadoutCount": "Shows items based on the number of loadouts they are included in.",
     "IsAdept": "Shows weapons compatible with Adept mods.",
     "IsCrafted": "Shows weapons that have been crafted.",
     "IsSunset": "Shows items that have been sunset and can no longer be infused to max power.",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -248,6 +248,7 @@
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "Infusable": "Shows items that can be infused.",
+    "InLoadoutCount": "Shows items based on the number of DIM loadouts they are included in.",
     "IsAdept": "Shows weapons compatible with Adept mods.",
     "IsCrafted": "Shows weapons that have been crafted.",
     "IsSunset": "Shows items that have been sunset and can no longer be infused to max power.",

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -158,6 +158,7 @@ exports[`buildSearchConfig generates a reasonable filter map: key-value filters 
   "holdsmod",
   "id",
   "inloadout",
+  "inloadoutcount",
   "keyword",
   "kills",
   "light",

--- a/src/app/search/search-filters/loadouts.ts
+++ b/src/app/search/search-filters/loadouts.ts
@@ -74,7 +74,7 @@ const loadoutFilters: FilterDefinition[] = [
     filter:
       ({ loadoutsByItem, compare }) =>
       (item) =>
-        compare!(loadoutsByItem[item.id]?.filter((l) => !isInGameLoadout(l.loadout)).length || 0),
+        compare!(loadoutsByItem[item.id]?.length || 0),
   },
 ];
 

--- a/src/app/search/search-filters/loadouts.ts
+++ b/src/app/search/search-filters/loadouts.ts
@@ -67,6 +67,15 @@ const loadoutFilters: FilterDefinition[] = [
       (item) =>
         Boolean(loadoutsByItem[item.id]?.some((l) => !isInGameLoadout(l.loadout))),
   },
+  {
+    keywords: 'inloadoutcount',
+    description: tl('Filter.InLoadoutCount'),
+    format: 'range',
+    filter:
+      ({ loadoutsByItem, compare }) =>
+      (item) =>
+        compare!(loadoutsByItem[item.id]?.filter((l) => !isInGameLoadout(l.loadout)).length || 0),
+  },
 ];
 
 export default loadoutFilters;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -246,6 +246,7 @@
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
+    "InLoadoutCount": "Shows items based on the number of DIM loadouts they are included in.",
     "Infusable": "Shows items that can be infused.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",
     "IsAdept": "Shows weapons compatible with Adept mods.",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -246,7 +246,7 @@
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
-    "InLoadoutCount": "Shows items based on the number of DIM loadouts they are included in.",
+    "InLoadoutCount": "Shows items based on the number of loadouts they are included in.",
     "Infusable": "Shows items that can be infused.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",
     "IsAdept": "Shows weapons compatible with Adept mods.",


### PR DESCRIPTION
Refs: https://github.com/DestinyItemManager/DIM/issues/10025

Just specifically the second piece of [Discord feedback](https://discord.com/channels/316217202766512130/1147798597539213343/1147798597539213343) in that issue: Adds a new range-type search filter for `inloadoutcount`.

This works how you'd expect. It counts both in-game and DIM loadouts.

<img width="1039" alt="image" src="https://github.com/DestinyItemManager/DIM/assets/407639/59e621ba-c611-466b-b67f-7e9979037e2a">

(This was split out of https://github.com/DestinyItemManager/DIM/pull/10383)
