### PR TITLE
Protect tags

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -187,19 +187,10 @@ function loadProfile(
       // TODO: need to make sure we still load at the right frequency / for manual cache busts?
       cachedProfileMintedDate = new Date(cachedProfileResponse.responseMintedTimestamp ?? 0);
       const profileAge = Date.now() - cachedProfileMintedDate.getTime();
+      infoLog('d2-stores', `Cached profile is ${profileAge / 1000}s old.`);
       if (!storesLoadedSelector(getState()) && profileAge > 0 && profileAge < BUNGIE_CACHE_TTL) {
-        warnLog(
-          'd2-stores',
-          'Cached profile is within Bungie.net cache time, skipping remote load.',
-          profileAge,
-        );
+        warnLog('d2-stores', 'Cached profile is new enough, skipping remote load.', profileAge);
         return { profile: cachedProfileResponse, live: false };
-      } else {
-        infoLog(
-          'd2-stores',
-          `Cached profile is older (${profileAge / 1000}s) than Bungie.net cache time (${BUNGIE_CACHE_TTL / 1000})s, proceeding.`,
-          profileAge,
-        );
       }
     }
 
@@ -207,22 +198,12 @@ function loadProfile(
       const remoteProfileResponse = await getStores(account);
       const remoteProfileMintedDate = new Date(remoteProfileResponse.responseMintedTimestamp ?? 0);
       const remoteProfileAgeSecs = (Date.now() - remoteProfileMintedDate.getTime()) / 1000;
-      infoLog(
-        'd2-stores',
-        `Profile from Bungie.net is ${remoteProfileAgeSecs}s newer than cached profile, using it.`,
-      );
+      infoLog('d2-stores', `Profile from Bungie.net is ${remoteProfileAgeSecs}s old.`);
 
       // compare new response against cached response, toss if it's not newer!
       if (cachedProfileResponse) {
         if (remoteProfileMintedDate.getTime() <= cachedProfileMintedDate.getTime()) {
-          const ageSecs =
-            (cachedProfileMintedDate.getTime() - remoteProfileMintedDate.getTime()) / 1000;
-          warnLog(
-            'd2-stores',
-            `Profile from Bungie.net was ${ageSecs}s older than cached profile, discarding.`,
-            remoteProfileMintedDate,
-            cachedProfileMintedDate,
-          );
+          warnLog('d2-stores', 'Profile from Bungie.net is older than cached profile, discarding.');
           // Clear the error since we did load correctly
           dispatch(profileError(undefined));
           // undefined means skip processing, in case we already have computed stores
@@ -234,15 +215,7 @@ function loadProfile(
             minimumCacheAge,
             remoteProfileMintedDate.getTime() - cachedProfileMintedDate.getTime(),
           );
-          const ageSecs =
-            (remoteProfileMintedDate.getTime() - cachedProfileMintedDate.getTime()) / 1000;
-          infoLog(
-            'd2-stores',
-            `Profile from Bungie.net was ${ageSecs} newer than cached profile, using it.`,
-            minimumCacheAge,
-            remoteProfileMintedDate,
-            cachedProfileMintedDate,
-          );
+          infoLog('d2-stores', `Profile from Bungie.net is newer than cached profile, using it.`);
         }
       }
 

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -132,36 +132,47 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
   };
 }
 
-// time in milliseconds after which we could expect Bnet to return an updated response
+/** time in milliseconds after which we could expect Bnet to return an updated response */
 const BUNGIE_CACHE_TTL = 15_000;
+/** How old the profile can be and still trigger cleanup of tags. */
+const FRESH_ENOUGH_TO_CLEAN_INFOS = 90_000; // 90 seconds
 
 let minimumCacheAge = Number.MAX_SAFE_INTEGER;
 
 function loadProfile(
   account: DestinyAccount,
   firstTime: boolean,
-): ThunkResult<DestinyProfileResponse | undefined> {
+): ThunkResult<
+  | {
+      profile: DestinyProfileResponse;
+      /** Whether the data is from a "live", remote Bungie.net response. false if this is cached data. */
+      live: boolean;
+      readOnly?: boolean;
+    }
+  | undefined
+> {
   return async (dispatch, getState) => {
     const mockProfileData = getState().inventory.mockProfileData;
     if (mockProfileData) {
-      // TODO: can/should we replace this with profileResponse plus the readOnly flag?
-      return mockProfileData;
+      return { profile: mockProfileData, live: false, readOnly: true };
     }
 
     // First try loading from IndexedDB
-    let profileResponse = getState().inventory.profileResponse;
-    if (!profileResponse) {
+    let cachedProfileResponse = getState().inventory.profileResponse;
+    if (!cachedProfileResponse) {
       try {
-        profileResponse = await get<DestinyProfileResponse>(`profile-${account.membershipId}`);
+        cachedProfileResponse = await get<DestinyProfileResponse>(
+          `profile-${account.membershipId}`,
+        );
         // Check to make sure the profile hadn't been loaded in the meantime
         if (getState().inventory.profileResponse) {
-          profileResponse = getState().inventory.profileResponse;
+          cachedProfileResponse = getState().inventory.profileResponse;
         } else {
           infoLog('d2-stores', 'Loaded cached profile from IndexedDB');
-          dispatch(profileLoaded({ profile: profileResponse, live: false }));
+          dispatch(profileLoaded({ profile: cachedProfileResponse, live: false }));
           // The first time we load, just use the IDB version if we can, to speed up loading
           if (firstTime) {
-            return profileResponse;
+            return { profile: cachedProfileResponse, live: false };
           }
         }
       } catch (e) {
@@ -172,9 +183,9 @@ function loadProfile(
     let cachedProfileMintedDate = new Date(0);
 
     // If our cached profile is up to date
-    if (profileResponse) {
+    if (cachedProfileResponse) {
       // TODO: need to make sure we still load at the right frequency / for manual cache busts?
-      cachedProfileMintedDate = new Date(profileResponse.responseMintedTimestamp ?? 0);
+      cachedProfileMintedDate = new Date(cachedProfileResponse.responseMintedTimestamp ?? 0);
       const profileAge = Date.now() - cachedProfileMintedDate.getTime();
       if (!storesLoadedSelector(getState()) && profileAge > 0 && profileAge < BUNGIE_CACHE_TTL) {
         warnLog(
@@ -182,11 +193,11 @@ function loadProfile(
           'Cached profile is within Bungie.net cache time, skipping remote load.',
           profileAge,
         );
-        return profileResponse;
+        return { profile: cachedProfileResponse, live: false };
       } else {
-        warnLog(
+        infoLog(
           'd2-stores',
-          'Cached profile is older than Bungie.net cache time, proceeding.',
+          `Cached profile is older (${profileAge / 1000}s) than Bungie.net cache time (${BUNGIE_CACHE_TTL / 1000})s, proceeding.`,
           profileAge,
         );
       }
@@ -195,29 +206,39 @@ function loadProfile(
     try {
       const remoteProfileResponse = await getStores(account);
       const remoteProfileMintedDate = new Date(remoteProfileResponse.responseMintedTimestamp ?? 0);
+      const remoteProfileAgeSecs = (Date.now() - remoteProfileMintedDate.getTime()) / 1000;
+      infoLog(
+        'd2-stores',
+        `Profile from Bungie.net is ${remoteProfileAgeSecs}s newer than cached profile, using it.`,
+      );
 
       // compare new response against cached response, toss if it's not newer!
-      if (profileResponse) {
+      if (cachedProfileResponse) {
         if (remoteProfileMintedDate.getTime() <= cachedProfileMintedDate.getTime()) {
+          const ageSecs =
+            (cachedProfileMintedDate.getTime() - remoteProfileMintedDate.getTime()) / 1000;
           warnLog(
             'd2-stores',
-            'Profile from Bungie.net was not newer than cached profile, discarding.',
+            `Profile from Bungie.net was ${ageSecs}s older than cached profile, discarding.`,
             remoteProfileMintedDate,
             cachedProfileMintedDate,
           );
           // Clear the error since we did load correctly
           dispatch(profileError(undefined));
           // undefined means skip processing, in case we already have computed stores
-          return storesLoadedSelector(getState()) ? undefined : profileResponse;
+          return storesLoadedSelector(getState())
+            ? undefined
+            : { profile: cachedProfileResponse, live: false };
         } else {
           minimumCacheAge = Math.min(
             minimumCacheAge,
             remoteProfileMintedDate.getTime() - cachedProfileMintedDate.getTime(),
           );
+          const ageSecs =
+            (remoteProfileMintedDate.getTime() - cachedProfileMintedDate.getTime()) / 1000;
           infoLog(
             'd2-stores',
-            'Profile from Bungie.net was newer than cached profile, using it.',
-            remoteProfileMintedDate.getTime() - cachedProfileMintedDate.getTime(),
+            `Profile from Bungie.net was ${ageSecs} newer than cached profile, using it.`,
             minimumCacheAge,
             remoteProfileMintedDate,
             cachedProfileMintedDate,
@@ -225,21 +246,22 @@ function loadProfile(
         }
       }
 
-      profileResponse = remoteProfileResponse;
-      set(`profile-${account.membershipId}`, profileResponse); // don't await
-      dispatch(profileLoaded({ profile: profileResponse, live: true }));
-      return profileResponse;
+      set(`profile-${account.membershipId}`, remoteProfileResponse); // don't await
+      dispatch(profileLoaded({ profile: remoteProfileResponse, live: true }));
+      return { profile: remoteProfileResponse, live: true };
     } catch (e) {
       dispatch(handleAuthErrors(e));
       dispatch(profileError(convertToError(e)));
-      if (profileResponse) {
+      if (cachedProfileResponse) {
         errorLog(
           'd2-stores',
           'Error loading profile from Bungie.net, falling back to cached profile',
           e,
         );
         // undefined means skip processing, in case we already have computed stores
-        return storesLoadedSelector(getState()) ? undefined : profileResponse;
+        return storesLoadedSelector(getState())
+          ? undefined
+          : { profile: cachedProfileResponse, live: false };
       }
       // rethrow
       throw e;
@@ -265,9 +287,7 @@ function loadStoresData(
       resetItemIndexGenerator();
 
       try {
-        const { readOnly } = getState().inventory;
-
-        const [defs, profileResponse] = await Promise.all([
+        const [defs, profileInfo] = await Promise.all([
           dispatch(getDefinitions()),
           dispatch(loadProfile(account, firstTime)),
         ]);
@@ -277,9 +297,11 @@ function loadStoresData(
           return;
         }
 
-        if (!defs || !profileResponse) {
+        if (!defs || !profileInfo) {
           return;
         }
+
+        const { profile: profileResponse, live, readOnly } = profileInfo;
 
         const stopTimer = timer('Process inventory');
 
@@ -336,9 +358,14 @@ function loadStoresData(
           return;
         }
 
-        // First-time loads can come from IDB, which can be VERY outdated,
-        // so don't remove item tags/notes based on that
-        if (!firstTime) {
+        // Cached loads can come from IDB, which can be VERY outdated, so don't
+        // remove item tags/notes based on that. We also refuse to clean tags if
+        // the profile is too old in wall-clock time. Technically we could do
+        // this *only* based on the minted timestamp, but there's no real point
+        // in cleaning items for cached loads since they presumably were cleaned
+        // already.
+        const profileMintedDate = new Date(profileResponse.responseMintedTimestamp ?? 0);
+        if (live && Date.now() - profileMintedDate.getTime() < FRESH_ENOUGH_TO_CLEAN_INFOS) {
           dispatch(cleanInfos(stores));
         }
         dispatch(update({ stores, currencies }));

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -197,8 +197,8 @@ function loadProfile(
     try {
       const remoteProfileResponse = await getStores(account);
       const remoteProfileMintedDate = new Date(remoteProfileResponse.responseMintedTimestamp ?? 0);
-      const remoteProfileAgeSecs = (Date.now() - remoteProfileMintedDate.getTime()) / 1000;
-      infoLog('d2-stores', `Profile from Bungie.net is ${remoteProfileAgeSecs}s old.`);
+      const remoteProfileAgeSec = (Date.now() - remoteProfileMintedDate.getTime()) / 1000;
+      infoLog('d2-stores', `Profile from Bungie.net is ${remoteProfileAgeSec}s old.`);
 
       // compare new response against cached response, toss if it's not newer!
       if (cachedProfileResponse) {

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -160,8 +160,8 @@ export function cleanInfos(stores: DimStore[]): ThunkResult {
           cleanupIds.delete(item.id);
         } else if (item.craftedInfo?.craftedDate) {
           // Double-check crafted items - we may have them under a different ID.
-          // If so, patch up the data by re-tagging them under the new ID. We'll
-          // delete the old item's info, but the new infos will be saved.
+          // If so, patch up the data by re-tagging them under the new ID.
+          // We'll delete the old item's info, but the new infos will be saved.
           const craftedInfo = infosByCraftedDate[item.craftedInfo.craftedDate];
           if (craftedInfo) {
             if (craftedInfo.tag) {

--- a/src/app/inventory/dim-item-info.ts
+++ b/src/app/inventory/dim-item-info.ts
@@ -3,6 +3,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { I18nKey, tl } from 'app/i18next-t';
 import { ThunkResult } from 'app/store/types';
 import { filterMap } from 'app/utils/collections';
+import { infoLog, warnLog } from 'app/utils/log';
 import _ from 'lodash';
 import { archiveIcon, banIcon, boltIcon, heartIcon, tagIcon } from '../shell/icons';
 import { setItemNote, setItemTag, tagCleanup } from './actions';
@@ -142,18 +143,25 @@ export function cleanInfos(stores: DimStore[]): ThunkResult {
     const infosWithCraftedDate = Object.values(infos).filter((i) => i.craftedDate);
     const infosByCraftedDate = _.keyBy(infosWithCraftedDate, (i) => i.craftedDate!);
 
+    let maxItemId = 0n;
+
     // Tags/notes are stored keyed by instance ID. Start with all the keys of the
     // existing tags and notes and remove the ones that are still here, and the rest
     // should be cleaned up because they refer to deleted items.
     const cleanupIds = new Set(Object.keys(infos));
     for (const store of stores) {
       for (const item of store.items) {
+        const itemId = BigInt(item.id);
+        if (itemId > maxItemId) {
+          maxItemId = itemId;
+        }
         const info = infos[item.id];
         if (info && (info.tag !== undefined || info.notes?.length)) {
           cleanupIds.delete(item.id);
         } else if (item.craftedInfo?.craftedDate) {
-          // Double-check crafted items - we may have them under a different ID. If so,
-          // patch up the data by re-tagging them under the new ID.
+          // Double-check crafted items - we may have them under a different ID.
+          // If so, patch up the data by re-tagging them under the new ID. We'll
+          // delete the old item's info, but the new infos will be saved.
           const craftedInfo = infosByCraftedDate[item.craftedInfo.craftedDate];
           if (craftedInfo) {
             if (craftedInfo.tag) {
@@ -180,7 +188,15 @@ export function cleanInfos(stores: DimStore[]): ThunkResult {
     }
 
     if (cleanupIds.size > 0) {
-      dispatch(tagCleanup(Array.from(cleanupIds)));
+      const eligibleCleanupIds = Array.from(cleanupIds).filter((id) => BigInt(id) < maxItemId);
+      if (cleanupIds.size > eligibleCleanupIds.length) {
+        warnLog(
+          'cleanInfos',
+          `${cleanupIds.size - eligibleCleanupIds.length} infos have IDs newer than the newest ID in inventory`,
+        );
+      }
+      infoLog('cleanInfos', `Purging tag/notes from ${eligibleCleanupIds.length} deleted items`);
+      dispatch(tagCleanup(eligibleCleanupIds));
     }
   };
 }

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -44,13 +44,6 @@ export interface InventoryState {
   readonly newItemsLoaded: boolean;
 
   /**
-   * indicates this isn't really "your" inventory,
-   * or should otherwise disallow modifications such as
-   * moving, locking, plugging, etc
-   */
-  readonly readOnly: boolean;
-
-  /**
    * An API profile response. If this is present,
    * we use it instead of talking to the Bungie API.
    */
@@ -64,7 +57,6 @@ const initialState: InventoryState = {
   currencies: [],
   newItems: new Set(),
   newItemsLoaded: false,
-  readOnly: false,
 };
 
 export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction> = (
@@ -143,7 +135,6 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
     case getType(actions.setMockProfileResponse):
       return produce(state, (draft) => {
         draft.mockProfileData = action.payload;
-        draft.readOnly = true;
       });
 
     default:


### PR DESCRIPTION
This implements a few more protections for tags:

1. Don't clean infos if the profile wasn't loaded remotely from Bungie.net. Any cached response, we won't clean infos.
2. Don't clean infos if the profile from Bungie.net was minted >90s ago. This shouldn't really be necessary (and in some cases may delay cleaning if B.net is struggling) but also seems like a safe backstop.
3. Don't clean any info for an item ID that's newer than the newest item ID in the store. This is to protect against theoretical issues if a profile response were to suddenly start sending outdated info but claiming it was recently minted.

This is maybe overkill but none of them seem unsafe. I'm still not sure it'll fix whatever people are seeing - my leading theory is that Bungie has re-issued some items from Into The Light with new item IDs, and this wouldn't really fix that since those would actually be new IDs.

While I was in there I also clarified the logging around how profiles are loaded, to make more sense out of it when people send logs screenshots.