### PR TITLE
Ensure visibility of materials svg on black background

### DIFF
--- a/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.m.scss
@@ -59,6 +59,9 @@
           margin-right: 8px;
         }
       }
+      > img {
+        filter: invert(1);
+      }
     }
 
     .fashionIcon {


### PR DESCRIPTION
Fixes #10393 : mobile vault dropdown: "material counts" lost its icon color inversion

Simple change to styles applied to LoadoutPopups so that svgs like the materials icon are not invisible against same color background when opened on a mobile device/small viewport.