### PR TITLE
Update Node in workflows, simplify release version bump

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install SSH key

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,42 +41,13 @@ jobs:
           private-key-name: dim.rsa
           known-hosts: ${{ secrets.REMOTE_HOST }}
 
-      - name: get-npm-version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.3.1
-
-      - name: set feature
-        if: ${{ !github.event.inputs.patch }}
-        run: |
-          echo "build_level=feature" >> $GITHUB_ENV
-
-      - name: set bug
-        if: ${{ github.event.inputs.patch }}
-        run: |
-          echo "build_level=bug" >> $GITHUB_ENV
-
-      - name: Bump release version
-        id: bump_version
-        uses: christian-draeger/increment-semantic-version@1.1.0
-        with:
-          current-version: ${{ steps.package-version.outputs.current-version }}
-          version-fragment: ${{ env.build_level }}
-
-      - name: set version
-        run: |
-          echo "VERSION=${{ steps.bump_version.outputs.next-version }}" >> $GITHUB_ENV
-
-      - name: Update Version in package.json
-        uses: dmikey/package-json-version@master
-        with:
-          version: ${{ env.VERSION }}
-
       - name: Install
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build and deploy
         run: ./build/deploy-prod.sh
         env:
+          PATCH: ${{ github.event.inputs.patch }}
           NODE_OPTIONS: "--max_old_space_size=8192"
           WEB_API_KEY: ${{ secrets.BUNGIE_API_KEY }}
           WEB_OAUTH_CLIENT_ID: ${{ secrets.OAUTH_CLIENT_ID }}
@@ -96,6 +67,12 @@ jobs:
           CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
           APP_DOMAIN: app.destinyitemmanager.com
 
+      - name: get-npm-version
+        id: package-version
+        shell: bash
+        run: |
+          echo "current-version=$(node -p 'const pkg = require("./web-console/package.json"); pkg.version')" >> $GITHUB_OUTPUT
+
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -104,5 +81,5 @@ jobs:
           SENTRY_PROJECT: dim
         with:
           environment: release
-          version: ${{ env.VERSION }}
+          version: ${{ steps.package-version.outputs.current-version }}
           ignore_missing: true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install SSH key

--- a/.github/workflows/i18n-bot-download.yml
+++ b/.github/workflows/i18n-bot-download.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install

--- a/.github/workflows/i18n-update.yml
+++ b/.github/workflows/i18n-update.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install

--- a/.github/workflows/pr-test-and-lint.yml
+++ b/.github/workflows/pr-test-and-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Cache ESLint

--- a/build/deploy-prod.sh
+++ b/build/deploy-prod.sh
@@ -3,6 +3,12 @@
 git config --global user.email "destinyitemmanager@gmail.com"
 git config --global user.name "DIM Release Bot"
 
+if [ "$PATCH" = 'true' ]; then
+  VERSION=$(npm version patch --no-git-tag-version)
+else
+  VERSION=$(npm version minor --no-git-tag-version)
+fi
+
 awk '/## Next/{flag=1;next}/##/{flag=0}flag' docs/CHANGELOG.md >release-notes.txt
 
 # update changelog

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 import { pathsToModuleNameMapper } from 'ts-jest';
-import tsconfig from './tsconfig.json' assert { type: 'json' };
+import tsconfig from './tsconfig.json' with { type: 'json' };
 
 export default {
   testEnvironment: 'jsdom',


### PR DESCRIPTION
Avoiding some external actions so we don't have to keep them up to date. `npm version` should be able to do it for us.