### PR TITLE
Add range search to `inloadout:`

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -250,7 +250,7 @@
     "HasShader": "Shows items that have a shader applied.",
     "HasOrnament": "Shows items that have an ornament applied.",
     "Harrowed": "\\(Harrowed\\)",
-    "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
+    "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes. When used with a range, it shows items that are in that many loadouts.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "Infusable": "Shows items that can be infused.",

--- a/src/app/search/search-filters/loadouts.ts
+++ b/src/app/search/search-filters/loadouts.ts
@@ -21,12 +21,16 @@ export function loadoutToSuggestions(loadout: Loadout) {
 const loadoutFilters: FilterDefinition[] = [
   {
     keywords: 'inloadout',
-    format: ['simple', 'freeform'],
-
+    format: ['simple', 'range', 'freeform'],
     suggestionsGenerator: ({ loadouts }) => loadouts?.flatMap(loadoutToSuggestions),
-
     description: tl('Filter.InLoadout'),
-    filter: ({ lhs, filterValue, loadoutsByItem }) => {
+    filter: ({ lhs, filterValue, loadoutsByItem, compare }) => {
+      // the range search for how many loadouts an item is in:
+      // inloadout:>=3
+      if (compare) {
+        return (item) => compare(loadoutsByItem[item.id]?.length ?? 0);
+      }
+
       // the default search:
       // is:inloadout
       if (lhs === 'is') {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -245,7 +245,7 @@
     "HoldsMod": "Shows armor compatible with a specific type of Seasonal Mod.",
     "InDimLoadout": "is:indimloadout shows items that are included in any DIM loadout.",
     "InInGameLoadout": "is:iningameloadout shows items that are included in any in-game loadout.",
-    "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes.",
+    "InLoadout": "is:inloadout shows items that are included in any loadout. Searching with inloadout: shows items that are included in loadouts with matching titles. When used with a hashtag, inloadout: shows items whose loadouts have the hashtag in the title or notes. When used with a range, it shows items that are in that many loadouts.",
     "Infusable": "Shows items that can be infused.",
     "InfusionFodder": "Shows items that could be infused into lower-power versions of the same item for only glimmer.",
     "IsAdept": "Shows weapons compatible with Adept mods.",


### PR DESCRIPTION
I did this mostly to see if it would work, but it's an alternative to @bjacobel's PR #10399. Instead of introducing a new `inloadoutcount:` search, it overloads `inloadout:` to accept a range, e.g. `inloadout:>=2`.