### PR TITLE
Dynamic search dropdown

### DIFF
--- a/src/app/search/SearchBar.m.scss
+++ b/src/app/search/SearchBar.m.scss
@@ -2,6 +2,7 @@
 
 .searchBar {
   position: relative;
+  font-size: 13px;
 }
 
 .open {

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -188,6 +188,8 @@ export interface SearchFilterRef {
   clearFilter: () => void;
 }
 
+const resultItemHeight = 32;
+
 /**
  * A reusable, autocompleting item search input. This is an uncontrolled input that
  * announces its query has changed only after some delay. This is the new version of the component
@@ -286,6 +288,13 @@ function SearchBar(
     dispatch(saveSearch({ query: liveQuery, saved: !saved }));
   };
 
+  // Try to fill up the screen with search results
+  const maxResults = isPhonePortrait
+    ? 7 // TODO: do this dynamically on mobile too, but the timing of when the virtual keyboard shows up is a nightmare
+    : menuMaxHeight
+      ? Math.floor((0.7 * menuMaxHeight) / resultItemHeight)
+      : 10;
+
   const caretPosition = inputElement.current?.selectionStart || liveQuery.length;
   const items = useMemo(
     () =>
@@ -294,8 +303,9 @@ function SearchBar(
         caretPosition,
         recentSearches,
         /* includeArmory */ Boolean(mainSearchBar),
+        maxResults,
       ),
-    [autocompleter, caretPosition, liveQuery, mainSearchBar, recentSearches],
+    [autocompleter, caretPosition, liveQuery, mainSearchBar, recentSearches, maxResults],
   );
 
   // useCombobox from Downshift manages the state of the dropdown
@@ -376,8 +386,6 @@ function SearchBar(
       const { height: viewportHeight } = window.visualViewport;
       // pixels remaining in viewport minus offset minus 10px for padding
       const pxAvailable = viewportHeight - y - height - 10;
-      const resultItemHeight = 30;
-
       // constrain to size that would allow only whole items to be seen
       setMenuMaxHeight(Math.floor(pxAvailable / resultItemHeight) * resultItemHeight);
     }

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -96,6 +96,7 @@ export default function createAutocompleter<I, FilterCtx, SuggestionsCtx>(
     caretIndex: number,
     recentSearches: Search[],
     includeArmory?: boolean,
+    maxResults = 7,
   ): SearchItem[] => {
     // If there's a query, it's always the first entry
     const queryItem: SearchItem | undefined = query
@@ -140,7 +141,7 @@ export default function createAutocompleter<I, FilterCtx, SuggestionsCtx>(
           _.compact([queryItem, ...filterSuggestions, ...recentSearchItems]),
           (i) => i.query.fullText,
         ),
-        7,
+        maxResults,
       ),
       ...armorySuggestions,
       helpItem,

--- a/src/app/search/search-filter.scss
+++ b/src/app/search/search-filter.scss
@@ -33,7 +33,7 @@
     flex: 1;
     width: 0;
     padding: 7px 0;
-    font-size: 13px;
+    font-size: inherit;
     font-family: inherit;
     color: inherit;
     caret-color: var(--theme-accent-primary);

--- a/src/app/shell/Header.m.scss
+++ b/src/app/shell/Header.m.scss
@@ -241,7 +241,6 @@ $header-height: 44px;
 
 .searchLink {
   flex: 1;
-  font-size: 13px;
   margin: 0 8px;
 
   @include phone-portrait {


### PR DESCRIPTION
Fixes #8622. This grows the search menu to occupy roughly 70% of the screen height, instead of being locked at 7 items. There's a tradeoff - the menu now obscures more of your inventory - but I suspect most folks will want to select from the menu which closes it.

I also fixed a silly style bug that made the search menu in sheets (e.g. pull item) 1px smaller than normal. I really need to rework the header styles...