### PR TITLE
separate out vendor component calls

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -940,6 +940,7 @@
     },
     "Infuse": "Infuse",
     "InfuseTitle": "Open the infusion fuel finder",
+    "LoadingSockets": "Perk and stat details have not loaded yet for this item.",
     "LockUnlock": {
       "Lock": "Lock {{itemType}}",
       "Unlock": "Unlock {{itemType}}",

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -1,5 +1,5 @@
 import { PressTip } from 'app/dim-ui/PressTip';
-import { t } from 'app/i18next-t';
+import { t, tl } from 'app/i18next-t';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { moveItemTo } from 'app/inventory/move-item';
 import { currentStoreSelector, notesSelector } from 'app/inventory/selectors';
@@ -93,6 +93,11 @@ export default memo(function CompareItem({
     [isInitialItem, item, itemClick, pullItem, remove, itemNotes, isFindable],
   );
 
+  const missingSocketsMessage =
+    item.missingSockets === 'missing'
+      ? tl('MovePopup.MissingSockets')
+      : tl('MovePopup.LoadingSockets');
+
   return (
     <div className={styles.compareItem}>
       {itemHeader}
@@ -107,7 +112,7 @@ export default memo(function CompareItem({
       ))}
       {isD1Item(item) && item.talentGrid && <ItemTalentGrid item={item} perksOnly={true} />}
       {item.missingSockets && isInitialItem && (
-        <div className="item-details warning">{t('MovePopup.MissingSockets')}</div>
+        <div className="item-details warning">{t(missingSocketsMessage)}</div>
       )}
       {item.sockets && <ItemSockets item={item} minimal onPlugClicked={onPlugClicked} />}
     </div>

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -195,7 +195,7 @@ export interface DimItem {
   /** D2 items use sockets and plugs to represent everything from perks to mods to ornaments and shaders. */
   sockets: DimSockets | null;
   /** Sometimes the API doesn't return socket info. This tells whether the item *should* have socket info but doesn't. */
-  missingSockets: boolean;
+  missingSockets: false | 'missing' | 'not-loaded';
   /** Detailed stats for the item. */
   stats: DimStat[] | null;
   /** Any objectives associated with the item. */

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -227,7 +227,7 @@ export interface ItemCreationContext {
    * Sometimes comes from the profile response, but also sometimes from vendors response or mocked out.
    * If not present, the itemComponents from the DestinyProfileResponse should be used.
    */
-  itemComponents?: DestinyItemComponentSetOfint64;
+  itemComponents?: Partial<DestinyItemComponentSetOfint64>;
 }
 
 /**
@@ -239,7 +239,10 @@ export function makeItem(
   /** the ID of the owning store - can be undefined for fake collections items */
   owner: DimStore | undefined,
 ): DimItem | undefined {
-  itemComponents ??= profileResponse.itemComponents;
+  if (owner) {
+    // only makes sense to use the profile's itemComponents if it's a real item
+    itemComponents ??= profileResponse.itemComponents;
+  }
 
   const itemDef = defs.InventoryItem.get(item.itemHash);
 
@@ -249,7 +252,7 @@ export function makeItem(
     owner && !owner?.isVault ? profileResponse.characterProgressions?.data?.[owner.id] : undefined;
 
   const itemInstanceData: Partial<DestinyItemInstanceComponent> = item.itemInstanceId
-    ? itemComponents?.instances.data?.[item.itemInstanceId] ?? emptyObject()
+    ? itemComponents?.instances?.data?.[item.itemInstanceId] ?? emptyObject()
     : emptyObject();
 
   // Missing definition

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -57,7 +57,7 @@ import {
  */
 export function buildSockets(
   item: DestinyItemComponent,
-  itemComponents: DestinyItemComponentSetOfint64 | undefined,
+  itemComponents: Partial<DestinyItemComponentSetOfint64> | undefined,
   defs: D2ManifestDefinitions,
   itemDef: DestinyInventoryItemDefinition,
 ) {
@@ -76,6 +76,7 @@ export function buildSockets(
     (item.itemInstanceId &&
       itemComponents?.plugObjectives?.data?.[item.itemInstanceId]?.objectivesPerPlug) ||
     undefined;
+
   if (socketData) {
     sockets = buildInstancedSockets(
       defs,
@@ -91,7 +92,14 @@ export function buildSockets(
   // get sockets from the item definition.
   if (!sockets && itemDef.sockets) {
     // If this really *should* have live sockets, but didn't...
-    if (item.itemInstanceId && item.itemInstanceId !== '0' && !socketData) {
+    if (
+      item.itemInstanceId &&
+      // a nice long instanceId is a real one and "should" have this data
+      // (short is actually a vendor item index. we'll let that build from defs.)
+      item.itemInstanceId.length > 14 &&
+      item.itemInstanceId !== '0' &&
+      !socketData
+    ) {
       return { sockets: null, missingSockets: true };
     }
     sockets = buildDefinedSockets(defs, itemDef);

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -1,5 +1,5 @@
 import { DestinyTooltipText } from 'app/dim-ui/DestinyTooltipText';
-import { t } from 'app/i18next-t';
+import { t, tl } from 'app/i18next-t';
 import { createItemContextSelector, storesSelector } from 'app/inventory/selectors';
 import { isTrialsPassage } from 'app/inventory/store/objectives';
 import { applySocketOverrides, useSocketOverrides } from 'app/inventory/store/override-sockets';
@@ -65,6 +65,11 @@ export default function ItemDetails({
 
   const showVendor = useContext(SingleVendorSheetContext);
 
+  const missingSocketsMessage =
+    item.missingSockets === 'missing'
+      ? tl('MovePopup.MissingSockets')
+      : tl('MovePopup.LoadingSockets');
+
   return (
     <div id={id} role="tabpanel" aria-labelledby={`${id}-tab`} className={styles.itemDetailsBody}>
       {item.itemCategoryHashes.includes(ItemCategoryHashes.Shaders) && (
@@ -122,7 +127,7 @@ export default function ItemDetails({
       )}
 
       {item.missingSockets && (
-        <div className="item-details warning">{t('MovePopup.MissingSockets')}</div>
+        <div className="item-details warning">{t(missingSocketsMessage)}</div>
       )}
 
       {defs.isDestiny2() && item.energy && defs && <EnergyMeter item={item} />}

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -28,7 +28,7 @@ import { searchFilterSelector } from 'app/search/search-filter';
 import { useSetSetting } from 'app/settings/hooks';
 import { AppIcon, disabledIcon, redoIcon, refreshIcon, undoIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
-import { emptyObject } from 'app/utils/empty';
+import { emptyArray, emptyObject } from 'app/utils/empty';
 import { isClassCompatible, itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -170,8 +170,8 @@ export default memo(function LoadoutBuilder({
     [resolvedMods, autoStatMods],
   );
 
-  const { vendorItems } = useLoVendorItems(selectedStoreId);
-  const armorItems = useArmorItems(classType, vendorItems);
+  const { vendorItems, vendorItemsLoading } = useLoVendorItems(selectedStoreId);
+  const armorItems = useArmorItems(classType, vendorItemsLoading ? emptyArray() : vendorItems);
 
   const { modMap: lockedModMap, unassignedMods } = useMemo(
     () => categorizeArmorMods(modsToAssign, armorItems),

--- a/src/app/loadout-builder/loadout-builder-vendors.ts
+++ b/src/app/loadout-builder/loadout-builder-vendors.ts
@@ -22,7 +22,12 @@ const allowedVendorHashes = [
 
 export const loVendorItemsSelector = currySelector(
   createSelector(characterVendorItemsSelector, (allVendorItems) =>
-    allVendorItems.filter((item) => allowedVendorHashes.includes(item.vendor?.vendorHash ?? -1)),
+    allVendorItems.filter(
+      (item) =>
+        allowedVendorHashes.includes(item.vendor?.vendorHash ?? -1) &&
+        // filters out some dummy exotics
+        item.type !== 'Unknown',
+    ),
   ),
 );
 
@@ -34,7 +39,9 @@ export function useLoVendorItems(selectedStoreId: string) {
   useLoadVendors(account, selectedStoreId);
 
   return {
-    vendorItemsLoading: !vendors[selectedStoreId]?.vendorsResponse,
+    vendorItemsLoading:
+      !vendors[selectedStoreId]?.vendorsResponse ||
+      vendorItems.some((i) => i.missingSockets === 'not-loaded'),
     vendorItems,
     error: vendors[selectedStoreId]?.error,
   };

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -157,7 +157,6 @@ export default function Records({ account }: Props) {
         {nodeHashes
           .map((h) => defs.PresentationNode.get(h))
           .map((nodeDef) => (
-            // console.log(nodeDef)
             <section key={nodeDef.hash} id={`p_${nodeDef.hash}`}>
               <CollapsibleTitle
                 title={overrideTitles[nodeDef.hash] || nodeDef.displayProperties.name}

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -260,7 +260,9 @@ function filterSocketCategories(
       continue;
     }
     const categorySockets = getSocketsByIndexes(sockets, category.socketIndexes).filter(
-      (socketInfo) => socketInfo.plugged?.plugDef.displayProperties.name && allowSocket(socketInfo),
+      (socketInfo) =>
+        (socketInfo.plugged || socketInfo.plugOptions[0])?.plugDef.displayProperties.name &&
+        allowSocket(socketInfo),
     );
     if (categorySockets.length) {
       socketsByCategory.set(category, categorySockets);

--- a/src/app/vendors/Vendor.tsx
+++ b/src/app/vendors/Vendor.tsx
@@ -64,6 +64,8 @@ export default function Vendor({
         }
         extra={refreshTime && <Countdown endTime={refreshTime} className={styles.countdown} />}
         sectionId={`d2vendor-${vendor.def.hash}`}
+        // hi! this sectionId formatting matters for dispatching vendor detail api requests.
+        // please modify carefully and see how it's used in vendorsNeedingComponents in loadAllVendors
       >
         <VendorItems
           vendor={vendor}

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -1,13 +1,29 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { settingsSelector } from 'app/dim-api/selectors';
+import { manifestSelector } from 'app/manifest/selectors';
 import { ThunkResult } from 'app/store/types';
+import { filterMap } from 'app/utils/collections';
+import { chainComparator, compareBy } from 'app/utils/comparators';
 import { convertToError } from 'app/utils/errors';
-import { DestinyVendorsResponse } from 'bungie-api-ts/destiny2';
+import { infoLog } from 'app/utils/log';
+import { DestinyItemType, DestinyVendorResponse, TierType } from 'bungie-api-ts/destiny2';
 import { createAction } from 'typesafe-actions';
-import { getVendors as getVendorsApi } from '../bungie-api/destiny2-api';
+import {
+  LimitedDestinyVendorsResponse,
+  getVendorSaleComponents,
+  getVendors,
+} from '../bungie-api/destiny2-api';
 
 export const loadedAll = createAction('vendors/LOADED_ALL')<{
   characterId: string;
-  vendorsResponse: DestinyVendorsResponse;
+  vendorsResponse: LimitedDestinyVendorsResponse;
+}>();
+
+export const loadedSingle = createAction('vendors/LOADED_COMPONENT')<{
+  characterId: string;
+  vendorResponse: DestinyVendorResponse;
+  vendorHash: number;
 }>();
 
 export const loadedError = createAction('vendors/LOADED_ERROR')<{
@@ -23,22 +39,149 @@ export function loadAllVendors(
   force = false,
 ): ThunkResult {
   return async (dispatch, getState) => {
-    // Only load at most once per 30 seconds
-    if (
-      !force &&
-      Date.now() -
-        (getState().vendors.vendorsByCharacter[characterId]?.lastLoaded?.getTime() || 0) <
-        30 * 1000
-    ) {
+    const timeSinceLastLoad =
+      Date.now() - (getState().vendors.vendorsByCharacter[characterId]?.lastLoaded || 0);
+
+    // Only load "all vendors" at most once per 30 seconds
+    if (!force && timeSinceLastLoad < 30 * 1000) {
       return;
     }
 
+    const timings = { salesTime: 0, componentsNeeded: 0, componentsFetched: 0, componentsTime: 0 };
+    let start = Date.now();
     try {
-      const vendorsResponse = await getVendorsApi(account, characterId);
+      // https://github.com/Bungie-net/api/issues/1887 MAY 2024-ish: for perf reasons,
+      // bungie has decided not to send back item components for the "all vendors" endpoint.
+      // this request still lets us know which items are sold, by all available vendors.
+      // enough to make a reasonable-looking vendors page full of shiny icons.
+      const vendorsResponse = await getVendors(account, characterId);
+      timings.salesTime = Date.now() - start;
       dispatch(loadedAll({ vendorsResponse, characterId }));
+
+      const defs = manifestSelector(getState());
+      if (
+        // we're done if this is d1. or if defs aren't loaded?
+        // can this kick off before defs are loaded?? what if it does???
+        !defs?.isDestiny2() ||
+        // the most important thing that can change quickly in vendors is basic info like purchasableness
+        // itemComponents take so long to load, that it's not worth doing more than every few minutes
+        timeSinceLastLoad < 120 * 1000
+      ) {
+        return;
+      }
+
+      // hashes of vendors bungie explicitly recommends displaying
+      const topLevelVendors =
+        vendorsResponse.vendorGroups.data?.groups.flatMap((g) => g.vendorHashes) ?? [];
+
+      const displayVendors = getSubvendorHashes(topLevelVendors, defs);
+      // after getting all items for sale above, we'll do subsequent API fetches to
+      // fill in item details. but only some vendors need this, filtered here.
+      const vendorsNeedingComponents = filterMap(
+        Object.entries(vendorsResponse.sales.data!),
+        ([vendorHashKey, sales]) => {
+          const vendorHash = Number(vendorHashKey);
+          // if it's not one of the vendors the api says to include on the vendors page,
+          // we don't need its stats. right now this mainly serves to exclude yuna
+          if (!displayVendors.includes(vendorHash)) {
+            return;
+          }
+          // if we find an item that needs components, include this vendor
+          for (const { itemHash } of Object.values(sales.saleItems)) {
+            if (itemNeedsComponents(defs, itemHash)) {
+              return vendorHash;
+            }
+          }
+        },
+      );
+      timings.componentsNeeded = vendorsNeedingComponents.length;
+
+      const { collapsedSections } = settingsSelector(getState());
+
+      // decide the order of the single-vendor requests (false is earlier in sort than true)
+      vendorsNeedingComponents.sort(
+        chainComparator(
+          // prioritize vendors in groups (meaning top-level, not click-in sub-vendors)
+          compareBy((h) => !defs.Vendor.getOptional(h)?.groups.length),
+          // deprioritize vendors whose sections are collapsed on the vendors page
+          compareBy((h) => Boolean(collapsedSections[`d2vendor-${h}`])),
+          // sort by their position on the page lol
+          compareBy((h) => displayVendors.indexOf(h)),
+        ),
+      );
+
+      // TO-DO ↑: limit collapsedSections prioritization to when we're on vendors page?
+      // TO-DO ↑: if the current page is optimizer/loadouts:
+      //          prioritize armor? do all single-vendor fetches then submit their
+      //          itemComponents en-masse, to cause only one optimizer recalculation?
+
+      for (const vendorHash of vendorsNeedingComponents) {
+        start = Date.now();
+        const vendorResponse = await getVendorSaleComponents(account, characterId, vendorHash);
+        timings.componentsTime += Date.now() - start;
+        timings.componentsFetched++;
+        dispatch(loadedSingle({ vendorResponse, characterId, vendorHash }));
+      }
     } catch (e) {
       const error = convertToError(e);
       dispatch(loadedError({ characterId, error }));
+    } finally {
+      infoLog(
+        'Vendors',
+        [
+          `sales data loaded: ${timings.salesTime / 1000}s`,
+          `component data for ${timings.componentsFetched} vendors loaded: ${timings.componentsTime / 1000}s`,
+          timings.componentsFetched === timings.componentsNeeded
+            ? 0
+            : `${timings.componentsNeeded - timings.componentsFetched} components not loaded?`,
+        ]
+          .filter(Boolean)
+          .join(),
+      );
     }
   };
+}
+
+function itemNeedsComponents(defs: D2ManifestDefinitions, itemHash: number) {
+  const item = defs.InventoryItem.getOptional(itemHash);
+  return (
+    item &&
+    // probably just need this for weapon perks and armor stats?
+    // TO-DO: what about bounties and quests? where's their pre-existing progress stored? do we care?
+    (item.itemType === DestinyItemType.Armor ||
+      // exotic weapons can be built from defs
+      (item.itemType === DestinyItemType.Weapon && item.inventory!.tierType !== TierType.Exotic))
+  );
+}
+
+function getSubvendorHashes(
+  vendorHashes: number[],
+  defs: D2ManifestDefinitions,
+  accumulator: number[] = Array.from(vendorHashes),
+) {
+  for (const vendorHash of vendorHashes) {
+    const newEntries: number[] = [];
+
+    const itemList = defs.Vendor.getOptional(vendorHash)?.itemList ?? [];
+    for (const i of itemList) {
+      // premature overoptimization: obviously it's not a subvendor if you can buy it
+      if (!i.currencies?.length) {
+        const subvendorHash = defs.InventoryItem.getOptional(i.itemHash)?.preview
+          ?.previewVendorHash;
+        if (
+          subvendorHash &&
+          !newEntries.includes(subvendorHash) &&
+          !accumulator.includes(subvendorHash)
+        ) {
+          newEntries.push(subvendorHash);
+        }
+      }
+    }
+    accumulator.push(...newEntries);
+    if (newEntries.length) {
+      getSubvendorHashes(newEntries, defs, accumulator);
+    }
+  }
+
+  return accumulator;
 }

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -1,3 +1,4 @@
+import { LimitedDestinyVendorsResponse } from 'app/bungie-api/destiny2-api';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { VendorHashes, silverItemHash } from 'app/search/d2-known-values';
@@ -13,7 +14,6 @@ import {
   DestinyVendorDefinition,
   DestinyVendorGroupDefinition,
   DestinyVendorSaleItemComponent,
-  DestinyVendorsResponse,
 } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -36,7 +36,7 @@ const vendorOrder = [VendorHashes.AdaTransmog, VendorHashes.Banshee, VendorHashe
 
 export function toVendorGroups(
   context: ItemCreationContext,
-  vendorsResponse: DestinyVendorsResponse,
+  vendorsResponse: LimitedDestinyVendorsResponse,
   characterId: string,
 ): D2VendorGroup[] {
   if (!vendorsResponse.vendorGroups.data) {
@@ -54,7 +54,7 @@ export function toVendorGroups(
           filterMap(group.vendorHashes, (vendorHash) => {
             const vendor = toVendor(
               // Override the item components from the profile with this vendor's item components
-              { ...context, itemComponents: vendorsResponse.itemComponents[vendorHash] },
+              { ...context, itemComponents: vendorsResponse.itemComponents?.[vendorHash] },
               vendorHash,
               vendorsResponse.vendors.data?.[vendorHash],
               characterId,
@@ -84,7 +84,7 @@ export function toVendor(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
-  vendorsResponse: DestinyVendorsResponse | undefined,
+  vendorsResponse: LimitedDestinyVendorsResponse | undefined,
 ): D2Vendor | undefined {
   const { defs } = context;
   const vendorDef = defs.Vendor.get(vendorHash);
@@ -140,7 +140,7 @@ export function toVendor(
 function gatherVendorCurrencies(
   defs: D2ManifestDefinitions,
   vendor: DestinyVendorDefinition,
-  vendorsResponse: DestinyVendorsResponse | undefined,
+  vendorsResponse: LimitedDestinyVendorsResponse | undefined,
   sales:
     | {
         [key: string]: DestinyVendorSaleItemComponent;

--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -82,7 +82,7 @@ const subVendorsForCharacterSelector = currySelector(
             const vendor = toVendor(
               {
                 ...context,
-                itemComponents: vendorsResponse.itemComponents[vendorHash],
+                itemComponents: vendorsResponse.itemComponents?.[vendorHash],
               },
               item.previewVendorHash,
               vendorsResponse.vendors.data?.[vendorHash],

--- a/src/app/vendors/single-vendor/SingleVendor.tsx
+++ b/src/app/vendors/single-vendor/SingleVendor.tsx
@@ -124,7 +124,7 @@ export default function SingleVendor({
   let refreshTime: Date | undefined;
   if (!isArtifact) {
     d2Vendor = toVendor(
-      { ...itemCreationContext, itemComponents: vendorResponse?.itemComponents[vendorHash] },
+      { ...itemCreationContext, itemComponents: vendorResponse?.itemComponents?.[vendorHash] },
       vendorHash,
       vendor,
       characterId,

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -925,6 +925,7 @@
     },
     "Infuse": "Infuse",
     "InfuseTitle": "Open the infusion fuel finder",
+    "LoadingSockets": "Perk and stat details have not loaded yet for this item.",
     "LockUnlock": {
       "AutoLock": "Lock state is synced to this item's tag",
       "Lock": "Lock {{itemType}}",


### PR DESCRIPTION
addresses https://github.com/DestinyItemManager/DIM/issues/10426 (https://github.com/Bungie-net/api/issues/1887)


early sanity-checking welcome please. is this a good way to combine these?
it results in a pleasant filling-in of info, and polaroids gradually appearing on the vendors page,
but as noted in loadAllVendors comments, there are other possible strategies

this serially fetches, but that ends up taking like 50 seconds for 9 vendors.
should we ratelimit, and dispatch them all, and await allResolved? what rate?