### PR TITLE
Consistent use of d2Definitions in search

### DIFF
--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -47,7 +47,7 @@ export interface SuggestionsContext {
   loadouts?: Loadout[];
   getTag?: (item: DimItem) => TagValue | undefined;
   getNotes?: (item: DimItem) => string | undefined;
-  d2Manifest?: D2ManifestDefinitions;
+  d2Definitions?: D2ManifestDefinitions;
   allNotesHashtags?: string[];
   customStats?: CustomStatDef[];
 }

--- a/src/app/search/loadouts/loadout-filter-types.ts
+++ b/src/app/search/loadouts/loadout-filter-types.ts
@@ -23,5 +23,5 @@ export interface LoadoutFilterContext {
  */
 export interface LoadoutSuggestionsContext {
   loadouts?: Loadout[];
-  d2Manifest?: D2ManifestDefinitions;
+  d2Definitions?: D2ManifestDefinitions;
 }

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -35,11 +35,11 @@ export const loadoutSuggestionsContextSelector = createSelector(
 
 function makeLoadoutSuggestionsContext(
   loadouts: Loadout[],
-  d2Manifest: D2ManifestDefinitions | undefined,
+  d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutSuggestionsContext {
   return {
     loadouts,
-    d2Manifest,
+    d2Definitions,
   };
 }
 

--- a/src/app/search/search-filters/freeform.ts
+++ b/src/app/search/search-filters/freeform.ts
@@ -94,8 +94,8 @@ const nameFilter = {
   keywords: ['name', 'exactname'],
   description: tl('Filter.Name'),
   format: 'freeform',
-  suggestionsGenerator: ({ d2Manifest, allItems }) => {
-    if (d2Manifest && allItems) {
+  suggestionsGenerator: ({ d2Definitions, allItems }) => {
+    if (d2Definitions && allItems) {
       const myItemNames = allItems
         .filter(
           (i) =>
@@ -103,7 +103,7 @@ const nameFilter = {
         )
         .map((i) => i.name.toLowerCase());
       // favor items we actually own
-      const allItemNames = getUniqueItemNamesFromManifest(d2Manifest.InventoryItem.getAll());
+      const allItemNames = getUniqueItemNamesFromManifest(d2Definitions.InventoryItem.getAll());
       return Array.from(
         new Set([...myItemNames, ...allItemNames]),
         (s) => `exactname:${quoteFilterString(s)}`,
@@ -159,8 +159,8 @@ const freeformFilters: FilterDefinition[] = [
     keywords: ['perkname', 'exactperk'],
     description: tl('Filter.PerkName'),
     format: 'freeform',
-    suggestionsGenerator: ({ d2Manifest, allItems }) => {
-      if (d2Manifest && allItems) {
+    suggestionsGenerator: ({ d2Definitions, allItems }) => {
+      if (d2Definitions && allItems) {
         const perkNames = new Set<string>();
         // favor items we actually own by inserting them first
         for (const item of allItems) {
@@ -179,7 +179,7 @@ const freeformFilters: FilterDefinition[] = [
         }
 
         // supplement the list with perks from definitions, so people can search things they don't own
-        for (const perkName of getPerkNamesFromManifest(d2Manifest.InventoryItem.getAll())) {
+        for (const perkName of getPerkNamesFromManifest(d2Definitions.InventoryItem.getAll())) {
           perkNames.add(perkName);
         }
 

--- a/src/app/search/suggestions-generation.ts
+++ b/src/app/search/suggestions-generation.ts
@@ -39,7 +39,7 @@ export const suggestionsContextSelector = createSelector(
 function makeSuggestionsContext(
   allItems: DimItem[],
   loadouts: Loadout[],
-  d2Manifest: D2ManifestDefinitions | undefined,
+  d2Definitions: D2ManifestDefinitions | undefined,
   getTag: (item: DimItem) => TagValue | undefined,
   getNotes: (item: DimItem) => string | undefined,
   allNotesHashtags: string[],
@@ -48,7 +48,7 @@ function makeSuggestionsContext(
   return {
     allItems,
     loadouts,
-    d2Manifest,
+    d2Definitions,
     getTag,
     getNotes,
     allNotesHashtags,


### PR DESCRIPTION
## Overview

We interchangeably used `d2Definitions` and `d2Manifest` in search type declarations. This just syncs them both to `d2Definitions`