### PR TITLE
RFC: Search keyword expansion

### DIFF
--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -161,7 +161,13 @@ export interface FilterDefinition<
    * A custom function used to generate (additional) suggestions.
    * This should only be necessary for freeform or custom formats.
    *
-   * Suggestions generally have the form of <keyword>:<op>. The
+   * Suggestions generally have the form of <keyword>:<op>. There
+   * are two options here to allow expansion of either side of that
+   * paring.
+   *   - op-expansion will generate suggestions based on the combination
+   *     of the provided keyword with the provided ops
+   *   - keyword-expansion will generation suggestions using the keywords
+   *     defined in the filter itself and the op provided.
    */
   suggestionsGenerator?: (
     args: SuggestionsCtx,

--- a/src/app/search/filter-types.ts
+++ b/src/app/search/filter-types.ts
@@ -160,10 +160,16 @@ export interface FilterDefinition<
   /**
    * A custom function used to generate (additional) suggestions.
    * This should only be necessary for freeform or custom formats.
+   *
+   * Suggestions generally have the form of <keyword>:<op>. The
    */
   suggestionsGenerator?: (
     args: SuggestionsCtx,
-  ) => string[] | { keyword: string; ops?: string[] }[] | undefined;
+  ) =>
+    | string[]
+    | { type: 'op-expansion'; keyword: string; ops?: string[] }[]
+    | { type: 'keyword-expansion'; op: string }[]
+    | undefined;
 
   /**
    * given an item, this generates a filter that should match that item

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -16,7 +16,10 @@ const freeformFilters: FilterDefinition<
     description: tl('LoadoutFilter.Name'),
     format: 'freeform',
     suggestionsGenerator: ({ loadouts }) =>
-      loadouts?.map((loadout) => `exactname:${quoteFilterString(loadout.name.toLowerCase())}`),
+      loadouts?.map((loadout) => ({
+        type: 'keyword-expansion' as const,
+        op: quoteFilterString(loadout.name.toLowerCase()),
+      })),
     filter: ({ filterValue, language, lhs }) => {
       const test = matchText(filterValue, language, /* exact */ lhs === 'exactname');
       return (loadout) => test(loadout.name);

--- a/src/app/search/search-filters/freeform.ts
+++ b/src/app/search/search-filters/freeform.ts
@@ -104,10 +104,10 @@ const nameFilter = {
         .map((i) => i.name.toLowerCase());
       // favor items we actually own
       const allItemNames = getUniqueItemNamesFromManifest(d2Definitions.InventoryItem.getAll());
-      return Array.from(
-        new Set([...myItemNames, ...allItemNames]),
-        (s) => `exactname:${quoteFilterString(s)}`,
-      );
+      return Array.from(new Set([...myItemNames, ...allItemNames]), (s) => ({
+        type: 'keyword-expansion' as const,
+        op: quoteFilterString(s),
+      }));
     }
   },
   filter: ({ filterValue, language, lhs }) => {
@@ -183,7 +183,10 @@ const freeformFilters: FilterDefinition[] = [
           perkNames.add(perkName);
         }
 
-        return Array.from(perkNames, (s) => `exactperk:${quoteFilterString(s)}`);
+        return Array.from(perkNames, (s) => ({
+          type: 'keyword-expansion' as const,
+          op: quoteFilterString(s),
+        }));
       }
     },
     filter: ({ lhs, filterValue, language, d2Definitions }) => {

--- a/src/app/search/search-filters/loadouts.ts
+++ b/src/app/search/search-filters/loadouts.ts
@@ -15,7 +15,7 @@ export function loadoutToSuggestions(loadout: Loadout) {
     quoteFilterString(loadout.name.toLowerCase()), // loadout name
     ...getHashtagsFromNote(loadout.name), // #hashtags in the name
     ...getHashtagsFromNote(loadout.notes), // #hashtags in the notes
-  ].map((suggestion) => `inloadout:${suggestion}`);
+  ].map((suggestion) => ({ type: 'keyword-expansion' as const, op: suggestion }));
 }
 
 const loadoutFilters: FilterDefinition[] = [

--- a/src/app/search/search-filters/stats.ts
+++ b/src/app/search/search-filters/stats.ts
@@ -43,7 +43,7 @@ const statFilters: FilterDefinition[] = [
           suggestions: [...allAtomicStats, ...(customStats?.map((c) => c.shortLabel) ?? [])],
         },
         {},
-      ),
+      ).map((suggestion) => ({ type: 'op-expansion' as const, ...suggestion })),
     validateStat,
     filter: ({ filterValue, compare, customStats }) =>
       statFilterFromString(filterValue, compare!, customStats),
@@ -68,7 +68,7 @@ const statFilters: FilterDefinition[] = [
           ],
         },
         {},
-      ),
+      ).map((suggestion) => ({ type: 'op-expansion' as const, ...suggestion })),
     validateStat,
     filter: ({ filterValue, compare, customStats }) =>
       statFilterFromString(filterValue, compare!, customStats, true),


### PR DESCRIPTION
## Overview

Just after thoughts as this as an approach to automatically generate suggestions for both the keywords in multi keyword search filters.

For example, we have a few instances of `keywords: ['name', 'exactname']` but we only generate suggestions for exact name. This proposes a way that we generate suggestions for both without forcing users to go down the route of definitively using exact name.