### PR TITLE
Ownership style fixes

### DIFF
--- a/src/app/item-popup/ItemDetails.m.scss
+++ b/src/app/item-popup/ItemDetails.m.scss
@@ -42,7 +42,6 @@
     font-size: calc(var(--item-size) / 5) !important;
     vertical-align: middle;
     padding: 0;
-    margin-right: 0;
     border-radius: 0%;
     filter: invert(1);
     background: none !important;

--- a/src/app/item-popup/ItemDetails.m.scss
+++ b/src/app/item-popup/ItemDetails.m.scss
@@ -39,11 +39,10 @@
 
   .mods & {
     width: calc(var(--item-size) / 3) !important;
-    height: calc(var(--item-size) / 3) !important;
     font-size: calc(var(--item-size) / 5) !important;
     vertical-align: middle;
     padding: 0;
-    margin-right: 2px;
+    margin-right: 0;
     border-radius: 0%;
     filter: invert(1);
     background: none !important;

--- a/src/app/item-popup/ItemDetails.m.scss
+++ b/src/app/item-popup/ItemDetails.m.scss
@@ -42,7 +42,7 @@
     font-size: calc(var(--item-size) / 5) !important;
     vertical-align: middle;
     padding: 0;
-    border-radius: 0%;
+    border-radius: 0;
     filter: invert(1);
     background: none !important;
   }

--- a/src/app/item-popup/ItemDetails.m.scss
+++ b/src/app/item-popup/ItemDetails.m.scss
@@ -38,11 +38,13 @@
   box-sizing: border-box;
 
   .mods & {
-    width: calc(var(--item-size) / 2.5) !important;
-    height: calc(var(--item-size) / 2.5) !important;
+    width: calc(var(--item-size) / 3) !important;
+    height: calc(var(--item-size) / 3) !important;
     font-size: calc(var(--item-size) / 5) !important;
-    vertical-align: -0.5em;
+    vertical-align: middle;
     padding: 0;
+    margin-right: 2px;
+    border-radius: 0%;
     filter: invert(1);
     background: none !important;
   }


### PR DESCRIPTION
fixes styles for the ownership icons of modifications mentioned in #9702. apparently there can also be a helmet icon? but I've yet to see that anywhere. At any rate this removes the rounding that the typical check icons for ownership have and stops forcing the aspect to be square for the gun icon. 

before: 
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/ebc32793-70e2-4f98-b15a-64d83a06ca29)
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/bd88e7c6-086c-49b6-8582-692ba4f9c8c4)

after:
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/a0a11eb0-3e31-4e3f-ae49-4eaba31c0100)
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/cf738075-250d-4bbd-83b9-a31e1a68506d)




