### PR TITLE
Remove v from version

### DIFF
--- a/build/deploy-prod.sh
+++ b/build/deploy-prod.sh
@@ -4,9 +4,9 @@ git config --global user.email "destinyitemmanager@gmail.com"
 git config --global user.name "DIM Release Bot"
 
 if [ "$PATCH" = 'true' ]; then
-  VERSION=$(npm version patch --no-git-tag-version)
+  VERSION=$(npm version patch --no-git-tag-version | sed 's/v//')
 else
-  VERSION=$(npm version minor --no-git-tag-version)
+  VERSION=$(npm version minor --no-git-tag-version | sed 's/v//')
 fi
 
 awk '/## Next/{flag=1;next}/##/{flag=0}flag' docs/CHANGELOG.md >release-notes.txt

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 * The search suggestions dropdown now shows more results, based on the size of your screen.
 * Added an overload to the `inloadout:` search which allows searching items based on how many loadouts they are in, for example `inloadout:>2`.
 
-## v8.20.0 <span class="changelog-date">(2024-05-19)</span>
+## 8.20.0 <span class="changelog-date">(2024-05-19)</span>
 
 ## 8.19.2 <span class="changelog-date">(2024-05-15)</span>
 


### PR DESCRIPTION
My previous change #10411 accidentally introduced an extra "v" in the version number (before, it was not included in the `VERSION` variable). This restores that by stripping the v from the version string.