### PR TITLE
Get subclass element from definitions

### DIFF
--- a/src/app/destiny2/d2-definitions.ts
+++ b/src/app/destiny2/d2-definitions.ts
@@ -115,6 +115,7 @@ export interface D2ManifestDefinitions extends ManifestDefinitions {
   Race: DefinitionTable<DestinyRaceDefinition>;
   Faction: DefinitionTable<DestinyFactionDefinition>;
   ItemTierType: DefinitionTable<DestinyItemTierTypeDefinition>;
+  // ActivityMode is used only from destiny-symbols.ts
   ActivityMode: DefinitionTable<DestinyActivityModeDefinition>;
   InventoryItem: DefinitionTable<DestinyInventoryItemDefinition>;
   Objective: DefinitionTable<DestinyObjectiveDefinition>;

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -232,6 +232,10 @@ export interface ItemCreationContext {
   itemComponents?: DestinyItemComponentSetOfint64;
 }
 
+const damageDefsByDamageType = memoizeOne((defs: D2ManifestDefinitions) =>
+  _.keyBy(Object.values(defs.DamageType.getAll()), (d) => d.enumValue),
+);
+
 /**
  * Process a single raw item into a DIM item.
  */
@@ -366,6 +370,10 @@ export function makeItem(
       defs.DamageType.get(itemInstanceData.damageTypeHash)) ||
     (itemDef.defaultDamageTypeHash !== undefined &&
       defs.DamageType.get(itemDef.defaultDamageTypeHash)) ||
+    // Subclasses have their elemental damage type in the talent grid
+    (normalBucket.hash === BucketHashes.Subclass &&
+      itemDef.talentGrid?.hudDamageType !== undefined &&
+      damageDefsByDamageType(defs)[itemDef.talentGrid.hudDamageType]) ||
     null;
 
   const powerCapHash =

--- a/src/app/inventory/subclass.ts
+++ b/src/app/inventory/subclass.ts
@@ -1,9 +1,9 @@
 import { damageNamesByEnum } from 'app/search/search-filter-values';
 import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
 import { LookupTable } from 'app/utils/util-types';
-import { DamageType } from 'bungie-api-ts/destiny2';
+import { DamageType, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
-import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import subclassArc from 'images/subclass-arc.png';
 import subclassSolar from 'images/subclass-solar.png';
 import subclassStasis from 'images/subclass-stasis.png';
@@ -30,7 +30,7 @@ export function getSubclassIconInfo(item: DimItem): SubclassIconInfo | undefined
     const superPlug = superSocket?.plugged?.plugDef;
     const superIcon = superPlug?.displayProperties?.icon;
     if (superIcon) {
-      const damageType = getDamageTypeForSubclassPlug(superPlug);
+      const damageType = item.element?.enumValue;
       if (damageType && baseImagesByDamageType[damageType]) {
         const base = baseImagesByDamageType[damageType]!;
         return {
@@ -61,4 +61,11 @@ export function getDamageTypeForSubclassPlug(item: PluggableInventoryItemDefinit
     }
   }
   return null;
+}
+
+/** Get the DamageType enum value for a subclass item definition. */
+export function getDamageTypeForSubclassDef(subclass: DestinyInventoryItemDefinition) {
+  return subclass.inventory?.bucketTypeHash === BucketHashes.Subclass
+    ? subclass.talentGrid?.hudDamageType
+    : undefined;
 }

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -3,12 +3,10 @@ import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, storesSelector } from 'app/inventory/selectors';
-import { getDamageTypeForSubclassPlug } from 'app/inventory/subclass';
 import { ResolvedLoadoutItem } from 'app/loadout-drawer/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, powerActionIcon } from 'app/shell/icons';
 import { itemCanBeInLoadout } from 'app/utils/item-utils';
-import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { BucketHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
@@ -47,17 +45,7 @@ export default function LoadoutEditSubclass({
     item.owner === storeId &&
     itemCanBeInLoadout(item);
 
-  const subclassItems = _.sortBy(allItems.filter(subclassItemFilter), (i) => {
-    if (i.sockets) {
-      // Sort by super damage hash
-      const superPlug = getFirstSocketByCategoryHash(i.sockets, SocketCategoryHashes.Super)?.plugged
-        ?.plugDef;
-      if (superPlug) {
-        return getDamageTypeForSubclassPlug(superPlug);
-      }
-    }
-    return undefined;
-  });
+  const subclassItems = _.sortBy(allItems.filter(subclassItemFilter), (i) => i.element?.enumValue);
 
   const getModRenderKey = createGetModRenderKey();
   const plugs = useMemo(() => getSubclassPlugs(defs, subclass), [subclass, defs]);

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -17,6 +17,7 @@ import {
   DestinyItemTranslationBlockDefinition,
   DestinyManifestComponentName,
 } from 'bungie-api-ts/destiny2';
+import { BucketHashes } from 'data/d2/generated-enums';
 import { deepEqual } from 'fast-equals';
 import { Draft } from 'immer';
 import _ from 'lodash';
@@ -54,7 +55,10 @@ const tableTrimmers: LookupTable<DestinyManifestComponentName, (table: any) => a
       if (def.preview?.derivedItemCategories?.length) {
         def.preview.derivedItemCategories = emptyArray();
       }
-      def.talentGrid = emptyObject<Draft<DestinyItemTalentGridBlockDefinition>>();
+      if (def.inventory?.bucketTypeHash !== BucketHashes.Subclass) {
+        // The only useful bit about talent grids is for subclass damage types
+        def.talentGrid = emptyObject<Draft<DestinyItemTalentGridBlockDefinition>>();
+      }
 
       if (def.sockets) {
         def.sockets.intrinsicSockets = emptyArray();
@@ -149,7 +153,7 @@ function loadManifest(tableAllowList: string[]): ThunkResult<AllDestinyManifestC
 
       // Use the path as the version, rather than the "version" field, because
       // Bungie can update the manifest file without changing that version.
-      version = path;
+      version = `v2-${path}`; // the prefix is used to bust the cache if we change the table trimmers
     } catch (e) {
       // If we can't get info about the current manifest, try to just use whatever's already saved.
       version = localStorage.getItem(localStorageKey);


### PR DESCRIPTION
It turns out that you can find the subclass element from the definitions, but it's in the `talentGrid`, which we'd stripped out of the defs. I put it back, only for subclasses, but it requires forcing a re-download of the manifest.

This makes a few things work, like subclasses matching `is:void` searches, but should also be helpful in adding element-based subclass search for loadouts.