### PR TITLE
Allow saving loadout search history

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1096,7 +1096,9 @@
     "UsageCount": "# Used",
     "Query": "Search",
     "Link": "View and edit search history",
-    "Title": "Search History"
+    "Title": "Search History",
+    "Item": "Item Searches",
+    "Loadout": "Loadout Searches"
   },
   "Settings": {
     "AutoLockTagged": "Sync item lock state with tag",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.24.5",
-    "@destinyitemmanager/dim-api-types": "^1.30.0",
+    "@destinyitemmanager/dim-api-types": "^1.31.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/react-fontawesome": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^7.24.5
     version: 7.24.5
   '@destinyitemmanager/dim-api-types':
-    specifier: ^1.30.0
-    version: 1.30.0
+    specifier: ^1.31.0
+    version: 1.31.0
   '@fortawesome/fontawesome-free':
     specifier: ^5.15.4
     version: 5.15.4
@@ -2005,8 +2005,8 @@ packages:
       postcss-selector-parser: 6.0.16
     dev: true
 
-  /@destinyitemmanager/dim-api-types@1.30.0:
-    resolution: {integrity: sha512-EMDDUHGHqhYRYpdRh1NZDGy0h3p/EyF5hUWPzIR12PwgOJO0ywY7WDKZ9MPiE/DFjTkrZ+tUgSQsorLrWeouvw==}
+  /@destinyitemmanager/dim-api-types@1.31.0:
+    resolution: {integrity: sha512-ASVG5BZtqFxmmNfpGTODHd291WZ4WgwdPiIsm1Zag0OPEmUE98HVkFBXSBLUQjYRqAb8I28WtHpxw4tbEzSuhA==}
     dev: false
 
   /@discoveryjs/json-ext@0.5.7:

--- a/src/app/dim-api/basic-actions.ts
+++ b/src/app/dim-api/basic-actions.ts
@@ -2,6 +2,7 @@ import {
   GlobalSettings,
   ProfileResponse,
   ProfileUpdateResult,
+  SearchType,
 } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { createAction } from 'typesafe-actions';
@@ -40,16 +41,23 @@ export const trackTriumph = createAction('dim-api/TRACK_TRIUMPH')<{
 }>();
 
 /** Record that a search was used */
-export const searchUsed = createAction('dim-api/SEARCH_USED')<string>();
+export const searchUsed = createAction('dim-api/SEARCH_USED')<{
+  query: string;
+  type: SearchType;
+}>();
 
 /** Save or un-save a search */
 export const saveSearch = createAction('dim-api/SAVE_SEARCH')<{
   query: string;
   saved: boolean;
+  type: SearchType;
 }>();
 
 /** Delete a saved search */
-export const searchDeleted = createAction('dim-api/DELETE_SEARCH')<string>();
+export const searchDeleted = createAction('dim-api/DELETE_SEARCH')<{
+  query: string;
+  type: SearchType;
+}>();
 
 /**
  * This signals that we are about to flush the update queue.

--- a/src/app/dim-api/reducer.test.ts
+++ b/src/app/dim-api/reducer.test.ts
@@ -1,3 +1,4 @@
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { setItemHashTag, setItemTag } from 'app/inventory/actions';
 import { setSettingAction } from 'app/settings/actions';
@@ -643,13 +644,13 @@ describe('saveSearch', () => {
     };
     const updatedState = dimApi(
       state,
-      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: true }),
+      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: true, type: SearchType.Item }),
       currentAccount,
     );
 
     expect(updatedState.searches).toMatchObject({
       [1]: [],
-      [2]: [{ query: 'is:masterwork is:weapon', saved: true }],
+      [2]: [{ query: 'is:masterwork is:weapon', saved: true, type: SearchType.Item }],
     });
   });
 
@@ -659,19 +660,19 @@ describe('saveSearch', () => {
     };
     let updatedState = dimApi(
       state,
-      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: true }),
+      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: true, type: SearchType.Item }),
       currentAccount,
     );
 
     updatedState = dimApi(
       updatedState,
-      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: false }),
+      saveSearch({ query: '(is:masterwork) (is:weapon)', saved: false, type: SearchType.Item }),
       currentAccount,
     );
 
     expect(updatedState.searches).toMatchObject({
       [1]: [],
-      [2]: [{ query: 'is:masterwork is:weapon', saved: false }],
+      [2]: [{ query: 'is:masterwork is:weapon', saved: false, type: SearchType.Item }],
     });
   });
 
@@ -681,7 +682,7 @@ describe('saveSearch', () => {
     };
     const updatedState = dimApi(
       state,
-      saveSearch({ query: 'deepsight:incomplete', saved: true }),
+      saveSearch({ query: 'deepsight:incomplete', saved: true, type: SearchType.Item }),
       currentAccount,
     );
     expect(updatedState.searches).toMatchObject({
@@ -695,12 +696,20 @@ describe('saveSearch', () => {
       ...initialState,
       searches: {
         [1]: [],
-        [2]: [{ usageCount: 1, lastUsage: 919191, saved: true, query: 'deepsight:incomplete' }],
+        [2]: [
+          {
+            usageCount: 1,
+            lastUsage: 919191,
+            saved: true,
+            query: 'deepsight:incomplete',
+            type: SearchType.Item,
+          },
+        ],
       },
     };
     const updatedState = dimApi(
       state,
-      saveSearch({ query: 'deepsight:incomplete', saved: false }),
+      saveSearch({ query: 'deepsight:incomplete', saved: false, type: SearchType.Item }),
       currentAccount,
     );
 

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -1,6 +1,5 @@
 import {
   CustomStatWeights,
-  defaultGlobalSettings,
   DestinyVersion,
   GlobalSettings,
   ItemAnnotation,
@@ -8,7 +7,9 @@ import {
   Loadout,
   ProfileUpdateResult,
   Search,
+  SearchType,
   TagValue,
+  defaultGlobalSettings,
 } from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { t } from 'app/i18next-t';
@@ -31,7 +32,7 @@ import * as inventoryActions from '../inventory/actions';
 import * as loadoutActions from '../loadout-drawer/actions';
 import { Loadout as DimLoadout } from '../loadout-drawer/loadout-types';
 import * as settingsActions from '../settings/actions';
-import { initialSettingsState, Settings } from '../settings/initial-settings';
+import { Settings, initialSettingsState } from '../settings/initial-settings';
 import { DeleteLoadoutUpdateWithRollback, ProfileUpdateWithRollback } from './api-types';
 import * as actions from './basic-actions';
 import { makeProfileKey, makeProfileKeyFromAccount } from './selectors';
@@ -384,17 +385,23 @@ export const dimApi = (
 
     case getType(actions.searchUsed):
       return produce(state, (draft) => {
-        searchUsed(draft, account!, action.payload);
+        searchUsed(draft, account!, action.payload.query, action.payload.type);
       });
 
     case getType(actions.saveSearch):
       return produce(state, (draft) => {
-        saveSearch(account!, draft, action.payload.query, action.payload.saved);
+        saveSearch(
+          account!,
+          draft,
+          action.payload.query,
+          action.payload.saved,
+          action.payload.type,
+        );
       });
 
     case getType(actions.searchDeleted):
       return produce(state, (draft) => {
-        deleteSearch(draft, account!.destinyVersion, action.payload);
+        deleteSearch(draft, account!.destinyVersion, action.payload.query, action.payload.type);
       });
 
     // *** Triumphs ***
@@ -1147,7 +1154,12 @@ function trackTriumph(
   draft.updateQueue.push(updateAction);
 }
 
-function searchUsed(draft: Draft<DimApiState>, account: DestinyAccount, query: string) {
+function searchUsed(
+  draft: Draft<DimApiState>,
+  account: DestinyAccount,
+  query: string,
+  type: SearchType,
+) {
   const destinyVersion = account.destinyVersion;
   // Note: memoized
   const filtersMap = buildItemFiltersMap(destinyVersion);
@@ -1166,6 +1178,7 @@ function searchUsed(draft: Draft<DimApiState>, account: DestinyAccount, query: s
     action: 'search',
     payload: {
       query,
+      type,
     },
     destinyVersion,
   };
@@ -1182,9 +1195,11 @@ function searchUsed(draft: Draft<DimApiState>, account: DestinyAccount, query: s
       usageCount: 1,
       saved: false,
       lastUsage: Date.now(),
+      type,
     });
   }
 
+  // TODO: maybe this should be max per type?
   if (searches.length > MAX_SEARCH_HISTORY) {
     const sortedSearches = searches.toSorted(recentSearchComparator);
 
@@ -1195,7 +1210,7 @@ function searchUsed(draft: Draft<DimApiState>, account: DestinyAccount, query: s
       const lastSearch = sortedSearches.pop()!;
       // Never try to delete the built-in searches or saved searches
       if (!lastSearch.saved && lastSearch.usageCount > 0) {
-        deleteSearch(draft, destinyVersion, lastSearch.query);
+        deleteSearch(draft, destinyVersion, lastSearch.query, lastSearch.type);
       }
     }
   }
@@ -1208,6 +1223,7 @@ function saveSearch(
   draft: Draft<DimApiState>,
   query: string,
   saved: boolean,
+  type: SearchType,
 ) {
   const destinyVersion = account.destinyVersion;
   // Note: memoized
@@ -1228,6 +1244,7 @@ function saveSearch(
     payload: {
       query,
       saved,
+      type,
     },
     destinyVersion,
   };
@@ -1245,11 +1262,13 @@ function saveSearch(
       usageCount: 1,
       saved: true,
       lastUsage: Date.now(),
+      type,
     });
     draft.updateQueue.push({
       action: 'search',
       payload: {
         query,
+        type,
       },
       destinyVersion,
     });
@@ -1258,11 +1277,17 @@ function saveSearch(
   draft.updateQueue.push(updateAction);
 }
 
-function deleteSearch(draft: Draft<DimApiState>, destinyVersion: DestinyVersion, query: string) {
+function deleteSearch(
+  draft: Draft<DimApiState>,
+  destinyVersion: DestinyVersion,
+  query: string,
+  type: SearchType,
+) {
   const updateAction: ProfileUpdateWithRollback = {
     action: 'delete_search',
     payload: {
       query,
+      type,
     },
     destinyVersion,
   };
@@ -1293,7 +1318,7 @@ function cleanupInvalidSearches(draft: Draft<DimApiState>, account: DestinyAccou
       customStats: draft.settings.customStats ?? [],
     } as FilterContext);
     if (!saveInHistory) {
-      deleteSearch(draft, account.destinyVersion, search.query);
+      deleteSearch(draft, account.destinyVersion, search.query, search.type);
     }
   }
 }

--- a/src/app/dim-api/selectors.ts
+++ b/src/app/dim-api/selectors.ts
@@ -1,4 +1,8 @@
-import { DestinyVersion, defaultLoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import {
+  DestinyVersion,
+  SearchType,
+  defaultLoadoutParameters,
+} from '@destinyitemmanager/dim-api-types';
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import { currentAccountSelector, destinyVersionSelector } from 'app/accounts/selectors';
 import { Settings } from 'app/settings/initial-settings';
@@ -57,13 +61,17 @@ export const currentProfileSelector = createSelector(
     currentAccount ? profiles[makeProfileKeyFromAccount(currentAccount)] : undefined,
 );
 
+const recentSearchesSelectorCached = createSelector(
+  (state: RootState) => state.dimApi.searches[destinyVersionSelector(state)],
+  (_state: RootState, searchType: SearchType) => searchType,
+  (searches, searchType) => searches.filter((s) => s.type === searchType),
+);
+
 /**
- * Returns all recent/saved searches.
- *
- * TODO: Sort/trim this list
+ * Returns all recent/saved searches of the given type.
  */
-export const recentSearchesSelector = (state: RootState) =>
-  state.dimApi.searches[destinyVersionSelector(state)];
+export const recentSearchesSelector = (searchType: SearchType) => (state: RootState) =>
+  recentSearchesSelectorCached(state, searchType);
 
 export const trackedTriumphsSelector = createSelector(
   currentProfileSelector,

--- a/src/app/item-actions/ItemActionsDropdown.tsx
+++ b/src/app/item-actions/ItemActionsDropdown.tsx
@@ -1,3 +1,4 @@
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import { destinyVersionSelector } from 'app/accounts/selectors';
 import { compareFilteredItems } from 'app/compare/actions';
 import { saveSearch } from 'app/dim-api/basic-actions';
@@ -102,7 +103,7 @@ export default memo(function ItemActionsDropdown({
   bulkItemTags.push({ type: 'clear', label: t('Tags.ClearTag'), icon: clearIcon });
 
   // Is the current search saved?
-  const recentSearches = useSelector(recentSearchesSelector);
+  const recentSearches = useSelector(recentSearchesSelector(SearchType.Item));
   const validateQuery = useSelector(validateQuerySelector);
   const { valid, saveable } = validateQuery(searchQuery);
   const canonical = searchQuery ? canonicalizeQuery(parseQuery(searchQuery)) : '';
@@ -110,7 +111,7 @@ export default memo(function ItemActionsDropdown({
 
   const toggleSaved = () => {
     // TODO: keep track of the last search, if you search for something more narrow immediately after then replace?
-    dispatch(saveSearch({ query: searchQuery, saved: !saved }));
+    dispatch(saveSearch({ query: searchQuery, saved: !saved, type: SearchType.Item }));
   };
 
   const location = useLocation();

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -1,3 +1,4 @@
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import { languageSelector, settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClassIcon from 'app/dim-ui/ClassIcon';
@@ -166,7 +167,7 @@ export default function LoadoutPopup({
             className={styles.filterInput}
             placeholder={t('Header.FilterHelpLoadouts')}
             onQueryChanged={setLoadoutQuery}
-            loadouts
+            searchType={SearchType.Loadout}
             instant
           />
         </div>

--- a/src/app/search/FilterHelp.tsx
+++ b/src/app/search/FilterHelp.tsx
@@ -1,3 +1,4 @@
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import StaticPage from 'app/dim-ui/StaticPage';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
@@ -27,14 +28,18 @@ function keywordsString(keywords: string | string[]) {
   return keywords;
 }
 
-export default function FilterHelp({ loadouts }: { loadouts?: boolean }) {
+export default function FilterHelp({ searchType = SearchType.Item }: { searchType?: SearchType }) {
   const searchConfig = useSelector<
     RootState,
     | SearchConfig<DimItem, FilterContext, SuggestionsContext>
     | SearchConfig<Loadout, LoadoutFilterContext, LoadoutSuggestionsContext>
-  >(loadouts ? loadoutSearchConfigSelector : searchConfigSelector).filtersMap;
+  >(
+    searchType === SearchType.Loadout ? loadoutSearchConfigSelector : searchConfigSelector,
+  ).filtersMap;
   const suggestionContext = useSelector(
-    loadouts ? loadoutSuggestionsContextSelector : suggestionsContextSelector,
+    searchType === SearchType.Loadout
+      ? loadoutSuggestionsContextSelector
+      : suggestionsContextSelector,
   );
   const [search, setSearch] = useState('');
 

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { Search, SearchType } from '@destinyitemmanager/dim-api-types';
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import ArmorySheet from 'app/armory/ArmorySheet';
 import { saveSearch, searchDeleted, searchUsed } from 'app/dim-api/basic-actions';
 import { languageSelector, recentSearchesSelector } from 'app/dim-api/selectors';
@@ -14,7 +14,6 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
-import { emptyArray } from 'app/utils/empty';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
@@ -236,9 +235,7 @@ function SearchBar(
 ) {
   const dispatch = useThunkDispatch();
   const isPhonePortrait = useIsPhonePortrait();
-  const recentSearches = useSelector(
-    searchType === SearchType.Loadout ? () => emptyArray<Search>() : recentSearchesSelector,
-  );
+  const recentSearches = useSelector(recentSearchesSelector(searchType));
   const autocompleter = useSelector(
     searchType === SearchType.Loadout ? loadoutAutoCompleterSelector : autoCompleterSelector,
   );

--- a/src/app/search/SearchFilter.tsx
+++ b/src/app/search/SearchFilter.tsx
@@ -1,3 +1,4 @@
+import { SearchType } from '@destinyitemmanager/dim-api-types';
 import { t } from 'app/i18next-t';
 import { querySelector, searchQueryVersionSelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
@@ -73,7 +74,7 @@ export default forwardRef(function SearchFilter(
       searchQuery={searchQuery}
       mainSearchBar={true}
       menu={menu}
-      loadouts={onLoadouts}
+      searchType={onLoadouts ? SearchType.Loadout : SearchType.Item}
     >
       {!onLoadouts && extras}
     </SearchBar>

--- a/src/app/search/SearchHistory.m.scss
+++ b/src/app/search/SearchHistory.m.scss
@@ -24,6 +24,11 @@
   }
 }
 
+.tabs {
+  max-width: fit-content;
+  margin-top: 8px;
+}
+
 .iconButton {
   composes: resetButton from '../dim-ui/common.m.scss';
   margin-left: 6px;

--- a/src/app/search/SearchHistory.m.scss.d.ts
+++ b/src/app/search/SearchHistory.m.scss.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'instructions': string;
   'searchHistory': string;
   'sorter': string;
+  'tabs': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/search/SearchHistory.tsx
+++ b/src/app/search/SearchHistory.tsx
@@ -48,16 +48,16 @@ export default function SearchHistory() {
 
   const deleteSearch = (e: React.MouseEvent, item: Search) => {
     e.stopPropagation();
-    dispatch(searchDeleted(item.query));
+    dispatch(searchDeleted({ query: item.query, type: item.type }));
   };
 
   const toggleSaved = (item: Search) => {
-    dispatch(saveSearch({ query: item.query, saved: !item.saved }));
+    dispatch(saveSearch({ query: item.query, saved: !item.saved, type: item.type }));
   };
 
   const onDeleteAll = () => {
     for (const s of recentSearches.filter((s) => !s.saved)) {
-      dispatch(searchDeleted(s.query));
+      dispatch(searchDeleted({ query: s.query, type: s.type }));
     }
   };
 
@@ -79,7 +79,7 @@ export default function SearchHistory() {
     ),
   );
 
-  const radioOptions: Option[] = [
+  const radioOptions: Option<SearchType>[] = [
     { label: t('SearchHistory.Item'), value: SearchType.Item },
     { label: t('SearchHistory.Loadout'), value: SearchType.Loadout },
   ];

--- a/src/app/search/SearchHistory.tsx
+++ b/src/app/search/SearchHistory.tsx
@@ -1,6 +1,7 @@
-import { Search } from '@destinyitemmanager/dim-api-types';
+import { Search, SearchType } from '@destinyitemmanager/dim-api-types';
 import { saveSearch, searchDeleted } from 'app/dim-api/basic-actions';
 import { recentSearchesSelector } from 'app/dim-api/selectors';
+import RadioButtons, { Option } from 'app/dim-ui/RadioButtons';
 import { ColumnSort, SortDirection, useTableColumnSorts } from 'app/dim-ui/table-columns';
 import { t } from 'app/i18next-t';
 import {
@@ -14,7 +15,7 @@ import {
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { Comparator, chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { useShiftHeld } from 'app/utils/hooks';
-import React from 'react';
+import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import styles from './SearchHistory.m.scss';
 
@@ -35,7 +36,8 @@ function comparatorFor(id: string): Comparator<Search> {
 
 export default function SearchHistory() {
   const dispatch = useThunkDispatch();
-  const recentSearches = useSelector(recentSearchesSelector);
+  const [searchType, setSearchType] = useState(SearchType.Item);
+  const recentSearches = useSelector(recentSearchesSelector(searchType));
 
   const [columnSorts, toggleColumnSort] = useTableColumnSorts([
     { columnId: 'starred', sort: SortDirection.DESC },
@@ -77,6 +79,12 @@ export default function SearchHistory() {
     ),
   );
 
+  const radioOptions: Option[] = [
+    { label: t('SearchHistory.Item'), value: SearchType.Item },
+    { label: t('SearchHistory.Loadout'), value: SearchType.Loadout },
+  ];
+
+  // TODO: Tabs
   return (
     <div className={styles.searchHistory}>
       <p className={styles.instructions}>
@@ -84,6 +92,12 @@ export default function SearchHistory() {
         <button type="button" className="dim-button" onClick={onDeleteAll}>
           {t('SearchHistory.DeleteAll')}
         </button>
+        <RadioButtons
+          className={styles.tabs}
+          options={radioOptions}
+          value={searchType}
+          onChange={setSearchType}
+        />
       </p>
       <table>
         <thead>

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -1,4 +1,4 @@
-import { Search } from '@destinyitemmanager/dim-api-types';
+import { Search, SearchType } from '@destinyitemmanager/dim-api-types';
 import {
   autocompleteTermSuggestions,
   filterSortRecentSearches,
@@ -139,36 +139,47 @@ describe('autocompleteTermSuggestions', () => {
 
 describe('filterSortRecentSearches', () => {
   const recentSearches: Search[] = [
-    { query: 'recent saved', usageCount: 1, saved: true, lastUsage: Date.now() },
+    {
+      query: 'recent saved',
+      usageCount: 1,
+      saved: true,
+      lastUsage: Date.now(),
+      type: SearchType.Item,
+    },
     {
       query: 'yearold saved',
       usageCount: 1,
       saved: true,
       lastUsage: Date.now() - 365 * 24 * 60 * 60 * 1000,
+      type: SearchType.Item,
     },
     {
       query: 'yearold unsaved',
       usageCount: 1,
       saved: false,
       lastUsage: Date.now() - 365 * 24 * 60 * 60 * 1000,
+      type: SearchType.Item,
     },
     {
       query: 'yearold highuse',
       usageCount: 100,
       saved: false,
       lastUsage: Date.now() - 365 * 24 * 60 * 60 * 1000,
+      type: SearchType.Item,
     },
     {
       query: 'dayold highuse',
       usageCount: 15,
       saved: false,
       lastUsage: Date.now() - 1 * 24 * 60 * 60 * 1000,
+      type: SearchType.Item,
     },
     {
       query: 'dim api autosuggest',
       usageCount: 0,
       saved: false,
       lastUsage: 0,
+      type: SearchType.Item,
     },
   ];
 
@@ -179,6 +190,7 @@ describe('filterSortRecentSearches', () => {
         lastUsage: Date.now() - day * 24 * 60 * 60 * 1000,
         usageCount,
         saved: false,
+        type: SearchType.Item,
       });
     }
   }
@@ -196,12 +208,14 @@ describe('filterSortRecentSearches', () => {
       usageCount: 1,
       saved: true,
       lastUsage: Date.now(),
+      type: SearchType.Item,
     },
     {
       query: '/* random-roll craftable guns */ is:patternunlocked -is:crafted',
       usageCount: 1,
       saved: true,
       lastUsage: Date.now() - 24 * 60 * 60 * 1000,
+      type: SearchType.Item,
     },
   ];
   const highlightCases: string[] = ['', 'craft', 'craftable', 'crafted'];

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -95,13 +95,6 @@ export const loadoutFilterFactorySelector = createSelector(
 export const validateLoadoutQuerySelector = createSelector(
   loadoutSearchConfigSelector,
   loadoutFilterContextSelector,
-  (searchConfig, filterContext) => (query: string) => {
-    const result = parseAndValidateQuery(query, searchConfig.filtersMap, filterContext);
-    return {
-      ...result,
-      // For now, loadout searches are not saveable
-      saveable: false,
-      saveInHistory: false,
-    };
-  },
+  (searchConfig, filterContext) => (query: string) =>
+    parseAndValidateQuery(query, searchConfig.filtersMap, filterContext),
 );

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1083,7 +1083,9 @@
     "Date": "Last Used",
     "DeleteAll": "Delete all non-starred searches",
     "Description": "These are all your past and saved searches. You can delete them from here.",
+    "Item": "Item Searches",
     "Link": "View and edit search history",
+    "Loadout": "Loadout Searches",
     "Query": "Search",
     "Title": "Search History",
     "UsageCount": "# Used"


### PR DESCRIPTION
This saves loadout searches to DIM Sync, filters them correctly by type when used, and allows toggling between the different types in search history.

Fixes #10407