### PR TITLE
Filter suggestions in loadouts based on the currently selected store.

### DIFF
--- a/src/app/search/loadouts/loadout-filter-types.ts
+++ b/src/app/search/loadouts/loadout-filter-types.ts
@@ -12,6 +12,10 @@ import { LoadoutsByItem } from 'app/loadout-drawer/selectors';
  */
 export interface LoadoutFilterContext {
   currentStore: DimStore;
+  /**
+   * The selected store on the loadouts page
+   */
+  selectedLoadoutsStore: DimStore;
   loadoutsByItem: LoadoutsByItem;
   language: DimLanguage;
   d2Definitions: D2ManifestDefinitions | undefined;
@@ -23,5 +27,9 @@ export interface LoadoutFilterContext {
  */
 export interface LoadoutSuggestionsContext {
   loadouts?: Loadout[];
+  /**
+   * The selected store on the loadouts page
+   */
+  selectedLoadoutsStore?: DimStore;
   d2Definitions?: D2ManifestDefinitions;
 }

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -8,7 +8,11 @@ import { d2ManifestSelector } from 'app/manifest/selectors';
 import { createSelector } from 'reselect';
 import { currentStoreSelector } from '../../inventory/selectors';
 import { DimStore } from '../../inventory/store-types';
-import { LoadoutsByItem, loadoutsByItemSelector } from '../../loadout-drawer/selectors';
+import {
+  LoadoutsByItem,
+  loadoutsByItemSelector,
+  selectedLoadoutStoreSelector,
+} from '../../loadout-drawer/selectors';
 import { buildSearchConfig } from '../search-config';
 import { makeSearchFilterFactory } from '../search-filter';
 import { parseAndValidateQuery } from '../search-utils';
@@ -30,16 +34,19 @@ export const allLoadoutFilters = [...simpleFilters, ...freeformFilters, ...overl
  */
 export const loadoutSuggestionsContextSelector = createSelector(
   loadoutsSelector,
+  selectedLoadoutStoreSelector,
   d2ManifestSelector,
   makeLoadoutSuggestionsContext,
 );
 
 function makeLoadoutSuggestionsContext(
   loadouts: Loadout[],
+  selectedLoadoutsStore: DimStore,
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutSuggestionsContext {
   return {
     loadouts,
+    selectedLoadoutsStore,
     d2Definitions,
   };
 }
@@ -54,12 +61,14 @@ export const loadoutSearchConfigSelector = createSelector(
 
 function makeLoadoutFilterContext(
   currentStore: DimStore | undefined,
+  selectedLoadoutsStore: DimStore,
   loadoutsByItem: LoadoutsByItem,
   language: DimLanguage,
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutFilterContext {
   return {
     currentStore: currentStore!,
+    selectedLoadoutsStore,
     loadoutsByItem,
     language,
     d2Definitions,
@@ -73,6 +82,7 @@ function makeLoadoutFilterContext(
  */
 const loadoutFilterContextSelector = createSelector(
   currentStoreSelector,
+  selectedLoadoutStoreSelector,
   loadoutsByItemSelector,
   languageSelector,
   d2ManifestSelector,

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -44,7 +44,7 @@ const freeformFilters: FilterDefinition<
     keywords: ['subclass'],
     description: tl('LoadoutFilter.Subclass'),
     format: 'freeform',
-    suggestionsGenerator: ({ loadouts, d2Definitions }) => {
+    suggestionsGenerator: ({ loadouts, d2Definitions, selectedLoadoutsStore }) => {
       if (!loadouts || !d2Definitions) {
         return [];
       }
@@ -54,7 +54,10 @@ const freeformFilters: FilterDefinition<
       return deduplicate(
         loadouts.flatMap((loadout) => {
           const subclass = subclassDefFromLoadout(loadout, d2Definitions);
-          if (!subclass) {
+          if (
+            !subclass ||
+            (selectedLoadoutsStore && loadout.classType !== selectedLoadoutsStore?.classType)
+          ) {
             return;
           }
           const damageType = getDamageTypeForSubclassDef(subclass)!;
@@ -67,12 +70,12 @@ const freeformFilters: FilterDefinition<
         }),
       );
     },
-    filter: ({ filterValue, language, d2Definitions }) => {
+    filter: ({ filterValue, language, d2Definitions, selectedLoadoutsStore }) => {
       const test = matchText(filterValue, language, false);
       const damageDefs = d2Definitions && getDamageDefsByDamageType(d2Definitions);
       return (loadout: Loadout) => {
         const subclass = d2Definitions && subclassDefFromLoadout(loadout, d2Definitions);
-        if (!subclass) {
+        if (!subclass || subclass.classType !== selectedLoadoutsStore.classType) {
           return false;
         }
         if (test(subclass.displayProperties.name)) {


### PR DESCRIPTION
## Overview

This utilises that lifting of the loadout store id to redux.

Note that in the example below we have the titan suggestions immediately. Before this, you would get warlock suggestions just because it was the first in the list.

<img width="1283" alt="Screenshot 2024-05-25 at 11 16 12 PM" src="https://github.com/DestinyItemManager/DIM/assets/7344652/bab2ea17-3100-4ab6-9ddc-24e08b8ad6d7">
