### PR TITLE
fix/simplify deepsight red border display rules

### DIFF
--- a/src/app/inventory/store/deepsight.ts
+++ b/src/app/inventory/store/deepsight.ts
@@ -1,20 +1,11 @@
 import { THE_FORBIDDEN_BUCKET } from 'app/search/d2-known-values';
 import { socketContainsPlugWithCategory } from 'app/utils/socket-utils';
-import { DestinyRecordState } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { DimItem, DimSocket } from '../item-types';
 
 export function buildDeepsightInfo(item: DimItem): boolean {
   const resonanceSocket = getResonanceSocket(item);
-  if (!resonanceSocket?.plugged?.plugObjectives) {
-    return false;
-  }
-
-  // Only show deepsight if the pattern hasn't been completed
-  return (
-    !item.patternUnlockRecord ||
-    Boolean(item.patternUnlockRecord.state & DestinyRecordState.ObjectiveNotCompleted)
-  );
+  return Boolean(resonanceSocket?.visibleInGame);
 }
 
 function getResonanceSocket(item: DimItem): DimSocket | undefined {


### PR DESCRIPTION
the `plugObjectives` part of the condition has been short circuited true for who knows how long (the array always exists)

plus the outbreak prime pattern started causing trouble by being differently scoped from all other pattern records (we must not correctly be collapsing character pattern records into profile-scoped ones)

this lets bungie do the work for us, because they hide the extraction socket when the pattern's already complete, and we can detect that