### PR TITLE
little less unnecessary logging

### DIFF
--- a/src/app/item-popup/item-popup.ts
+++ b/src/app/item-popup/item-popup.ts
@@ -36,7 +36,7 @@ export function showItemPopup(
   } else {
     // Log the item so it's easy to inspect item structure by clicking on an item
     if ($DIM_FLAVOR !== 'release') {
-      infoLog('clicked item', `https://data.destinysets.com/i/InventoryItem%3A${item.hash}`, item);
+      infoLog('clicked item', item);
     }
     showItemPopup$.next({ item, element, extraInfo });
   }

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -3,7 +3,6 @@ import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-ty
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { getModTypeTagByPlugCategoryHash } from 'app/utils/item-utils';
-import { infoLog } from 'app/utils/log';
 import { releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -118,7 +117,6 @@ export function runProcess({
   return {
     cleanup,
     resultPromise: new Promise((resolve) => {
-      const workerStart = performance.now();
       worker
         .process(
           processItems,
@@ -132,13 +130,8 @@ export function runProcess({
           stopOnFirstSet,
         )
         .then((result) => {
-          infoLog(
-            'loadout optimizer',
-            `useProcess: worker time ${performance.now() - workerStart}ms`,
-          );
           const hydratedSets = result.sets.map((set) => hydrateArmorSet(set, itemsById));
           const processTime = performance.now() - processStart;
-          infoLog('loadout optimizer', `useProcess ${processTime}ms`);
           resolve({ ...result, sets: hydratedSets, processTime });
         })
         // Cleanup the worker, we don't need it anymore.


### PR DESCRIPTION
item popup: armory sheet now has a destinysets link and it was unnecessarily offsetting the dimitem in browser console.

optimizer processor: removed two nearly-dupe timestamps, that are also covered by the main console log of the optimizer result. are we done with these? can they go?