### PR TITLE
Loadout filters: contains item or mod

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -198,6 +198,7 @@
     "Instructions": "Click or drag files"
   },
   "LoadoutFilter": {
+    "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "Name": "Shows loadouts whose name matches (exactname:) or partially matches (name:) the filter text. Search for entire phrases using quotes.",
     "Notes": "Search for loadouts by their notes field.",
     "PartialMatch": "Shows loadouts where their name or notes has a partial match to the filter text. Search for entire phrases using quotes.",

--- a/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
+++ b/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
@@ -9,6 +9,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
 
 exports[`buildSearchConfig generates a reasonable filter map: key-value filters 1`] = `
 [
+  "contains",
   "exactname",
   "keyword",
   "name",

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -33,8 +33,10 @@ const freeformFilters: FilterDefinition<
     keywords: ['name', 'exactname'],
     description: tl('LoadoutFilter.Name'),
     format: 'freeform',
-    suggestionsGenerator: ({ loadouts }) =>
-      loadouts?.map((loadout) => `exactname:${quoteFilterString(loadout.name.toLowerCase())}`),
+    suggestionsGenerator: ({ loadouts, selectedLoadoutsStore }) =>
+      loadouts
+        ?.filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType)
+        .map((loadout) => `exactname:${quoteFilterString(loadout.name.toLowerCase())}`),
     filter: ({ filterValue, language, lhs }) => {
       const test = matchText(filterValue, language, /* exact */ lhs === 'exactname');
       return (loadout) => test(loadout.name);
@@ -89,6 +91,53 @@ const freeformFilters: FilterDefinition<
     },
   },
   {
+    keywords: 'contains',
+    description: tl('LoadoutFilter.Contains'),
+    format: 'freeform',
+    suggestionsGenerator: ({ d2Definitions, loadouts, selectedLoadoutsStore }) => {
+      if (!d2Definitions || !loadouts) {
+        return [];
+      }
+
+      return loadouts.flatMap((loadout) => {
+        if (loadout.classType !== selectedLoadoutsStore?.classType) {
+          return [];
+        }
+
+        const itemSuggestions = loadout.items.map((item) => {
+          const definition = d2Definitions.InventoryItem.get(item.hash);
+          return `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`;
+        });
+        const modSuggestions =
+          loadout.parameters?.mods?.map((modHash) => {
+            const definition = d2Definitions.InventoryItem.get(modHash);
+            return `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`;
+          }) || [];
+
+        return deduplicate([...itemSuggestions, ...modSuggestions]);
+      });
+    },
+    filter: ({ filterValue, language, d2Definitions, selectedLoadoutsStore }) => {
+      const test = matchText(filterValue, language, false);
+      return (loadout) => {
+        if (!d2Definitions || loadout.classType !== selectedLoadoutsStore.classType) {
+          return false;
+        }
+
+        return (
+          loadout.items.some((item) => {
+            const itemDefinition = d2Definitions.InventoryItem.get(item.hash);
+            return itemDefinition && test(itemDefinition.displayProperties.name);
+          }) ||
+          loadout.parameters?.mods?.some((mod) => {
+            const modDefinition = d2Definitions.InventoryItem.get(mod);
+            return modDefinition && test(modDefinition.displayProperties.name);
+          })
+        );
+      };
+    },
+  },
+  {
     keywords: 'notes',
     description: tl('LoadoutFilter.Notes'),
     format: 'freeform',
@@ -102,14 +151,16 @@ const freeformFilters: FilterDefinition<
     keywords: 'keyword',
     description: tl('LoadoutFilter.PartialMatch'),
     format: 'freeform',
-    suggestionsGenerator: ({ loadouts }) =>
+    suggestionsGenerator: ({ loadouts, selectedLoadoutsStore }) =>
       loadouts
         ? Array.from(
             new Set([
-              ...loadouts.flatMap((loadout) => [
-                ...getHashtagsFromNote(loadout.name),
-                ...getHashtagsFromNote(loadout.notes),
-              ]),
+              ...loadouts
+                .filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType)
+                .flatMap((loadout) => [
+                  ...getHashtagsFromNote(loadout.name),
+                  ...getHashtagsFromNote(loadout.notes),
+                ]),
             ]),
           )
         : [],

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -697,6 +697,7 @@
     "UnlockItem": "Unpin Item"
   },
   "LoadoutFilter": {
+    "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
     "ModsOnly": "Shows loadouts that only contain armor mods.",
     "Name": "Shows loadouts whose name matches (exactname:) or partially matches (name:) the filter text. Search for entire phrases using quotes.",


### PR DESCRIPTION
## Overview

This adds a `contains:` filter to loadout search. It allows you to search items and mods by name.

### Example 

https://github.com/DestinyItemManager/DIM/assets/7344652/122b050f-85d2-4641-aaa3-64cd05f2aa59

