### PR TITLE
[Draft] Loadout filters: exactcontains and class type filtering lift.

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -82,7 +82,9 @@ function Loadouts({ account }: { account: DestinyAccount }) {
   const dispatch = useDispatch();
 
   const stores = useSelector(storesSelector);
-  const selectedStore = useSelector(selectedLoadoutStoreSelector);
+  // Technically this can be undefined if the stores haven't been loaded into existence yet
+  // TODO (ryan) fix this so we dont need to have the non-null assertion
+  const selectedStore = useSelector(selectedLoadoutStoreSelector)!;
 
   const setSelectedStoreId = useCallback(
     (storeId: string) => {

--- a/src/app/loadout/selectors.ts
+++ b/src/app/loadout/selectors.ts
@@ -133,7 +133,8 @@ export const selectedLoadoutStoreSelector = createSelector(
   sortedStoresSelector,
   currentStoreSelector,
   (rootState: RootState) => rootState.loadouts.selectedLoadoutStoreId,
-  (stores, currentStore, selectedLoadoutStoreId): DimStore => {
+  (stores, currentStore, selectedLoadoutStoreId): DimStore | undefined => {
+    // stores[0] can be undefined it seems
     const defaultStore = currentStore || stores[0];
     if (selectedLoadoutStoreId === undefined) {
       return defaultStore;

--- a/src/app/search/loadouts/loadout-filter-types.ts
+++ b/src/app/search/loadouts/loadout-filter-types.ts
@@ -16,7 +16,7 @@ export interface LoadoutFilterContext {
   /**
    * The selected store on the loadouts page
    */
-  selectedLoadoutsStore: DimStore;
+  selectedLoadoutsStore?: DimStore;
   loadoutsByItem: LoadoutsByItem;
   language: DimLanguage;
   d2Definitions: D2ManifestDefinitions | undefined;

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -41,11 +41,11 @@ export const loadoutSuggestionsContextSelector = createSelector(
 
 function makeLoadoutSuggestionsContext(
   loadouts: Loadout[],
-  selectedLoadoutsStore: DimStore,
+  selectedLoadoutsStore: DimStore | undefined,
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutSuggestionsContext {
   return {
-    loadouts,
+    loadouts: loadouts.filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType),
     selectedLoadoutsStore,
     d2Definitions,
   };

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -45,7 +45,9 @@ function makeLoadoutSuggestionsContext(
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutSuggestionsContext {
   return {
-    loadouts: loadouts.filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType),
+    loadouts: selectedLoadoutsStore
+      ? loadouts.filter((loadout) => loadout.classType === selectedLoadoutsStore.classType)
+      : loadouts,
     selectedLoadoutsStore,
     d2Definitions,
   };
@@ -59,7 +61,7 @@ export const loadoutSearchConfigSelector = createSelector(
 );
 
 function makeLoadoutFilterContext(
-  selectedLoadoutsStore: DimStore,
+  selectedLoadoutsStore: DimStore | undefined,
   loadoutsByItem: LoadoutsByItem,
   language: DimLanguage,
   d2Definitions: D2ManifestDefinitions | undefined,


### PR DESCRIPTION
## Overview

This lifts the filtering of loadouts by class type up to the context scope and adds the exactcontains keyword to the contains filter.