### PR TITLE
Loadout filters: contains item or mod take 2

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -198,6 +198,7 @@
     "Instructions": "Click or drag files"
   },
   "LoadoutFilter": {
+    "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "Name": "Shows loadouts whose name matches (exactname:) or partially matches (name:) the filter text. Search for entire phrases using quotes.",
     "Notes": "Search for loadouts by their notes field.",
     "PartialMatch": "Shows loadouts where their name or notes has a partial match to the filter text. Search for entire phrases using quotes.",

--- a/src/app/inventory/subclass.ts
+++ b/src/app/inventory/subclass.ts
@@ -1,9 +1,9 @@
 import { damageNamesByEnum } from 'app/search/search-filter-values';
 import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
 import { LookupTable } from 'app/utils/util-types';
-import { DamageType, DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
+import { DamageType } from 'bungie-api-ts/destiny2';
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
-import { BucketHashes, ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
+import { ItemCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import subclassArc from 'images/subclass-arc.png';
 import subclassSolar from 'images/subclass-solar.png';
 import subclassStasis from 'images/subclass-stasis.png';
@@ -61,11 +61,4 @@ export function getDamageTypeForSubclassPlug(item: PluggableInventoryItemDefinit
     }
   }
   return null;
-}
-
-/** Get the DamageType enum value for a subclass item definition. */
-export function getDamageTypeForSubclassDef(subclass: DestinyInventoryItemDefinition) {
-  return subclass.inventory?.bucketTypeHash === BucketHashes.Subclass
-    ? subclass.talentGrid?.hudDamageType
-    : undefined;
 }

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -786,11 +786,11 @@ function isFashionPlug(defs: D2ManifestDefinitions, modHash: number) {
 export function getModsFromLoadout(
   defs: D2ManifestDefinitions | undefined,
   loadout: Loadout,
-  unlockedPlugs?: Set<number>,
+  unlockedPlugs = new Set<number>(),
 ) {
   const internalModHashes = loadout.parameters?.mods ?? [];
 
-  return resolveLoadoutModHashes(defs, internalModHashes, unlockedPlugs || new Set());
+  return resolveLoadoutModHashes(defs, internalModHashes, unlockedPlugs);
 }
 
 const oldToNewMod: HashLookup<number> = {

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -786,11 +786,11 @@ function isFashionPlug(defs: D2ManifestDefinitions, modHash: number) {
 export function getModsFromLoadout(
   defs: D2ManifestDefinitions | undefined,
   loadout: Loadout,
-  unlockedPlugs: Set<number>,
+  unlockedPlugs?: Set<number>,
 ) {
   const internalModHashes = loadout.parameters?.mods ?? [];
 
-  return resolveLoadoutModHashes(defs, internalModHashes, unlockedPlugs);
+  return resolveLoadoutModHashes(defs, internalModHashes, unlockedPlugs || new Set());
 }
 
 const oldToNewMod: HashLookup<number> = {

--- a/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
+++ b/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
@@ -10,6 +10,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
 exports[`buildSearchConfig generates a reasonable filter map: key-value filters 1`] = `
 [
   "contains",
+  "exactcontains",
   "exactname",
   "keyword",
   "name",

--- a/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
+++ b/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
@@ -9,6 +9,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
 
 exports[`buildSearchConfig generates a reasonable filter map: key-value filters 1`] = `
 [
+  "contains",
   "exactname",
   "keyword",
   "name",

--- a/src/app/search/loadouts/loadout-filter-types.ts
+++ b/src/app/search/loadouts/loadout-filter-types.ts
@@ -1,5 +1,6 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimLanguage } from 'app/i18n';
+import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { Loadout } from 'app/loadout/loadout-types';
 import { LoadoutsByItem } from 'app/loadout/selectors';
@@ -19,6 +20,7 @@ export interface LoadoutFilterContext {
   selectedLoadoutsStore: DimStore;
   loadoutsByItem: LoadoutsByItem;
   language: DimLanguage;
+  allItems: DimItem[];
   d2Definitions: D2ManifestDefinitions | undefined;
 }
 
@@ -32,6 +34,7 @@ export interface LoadoutSuggestionsContext {
    * The selected store on the loadouts page
    */
   selectedLoadoutsStore?: DimStore;
+  allItems?: DimItem[];
   d2Definitions?: D2ManifestDefinitions;
 }
 

--- a/src/app/search/loadouts/loadout-search-filter.ts
+++ b/src/app/search/loadouts/loadout-search-filter.ts
@@ -3,6 +3,8 @@ import { destinyVersionSelector } from 'app/accounts/selectors';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { languageSelector } from 'app/dim-api/selectors';
 import { DimLanguage } from 'app/i18n';
+import { DimItem } from 'app/inventory/item-types';
+import { allItemsSelector } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
 import { Loadout } from 'app/loadout/loadout-types';
 import { loadoutsSelector } from 'app/loadout/loadouts-selector';
@@ -35,6 +37,7 @@ export const allLoadoutFilters = [...simpleFilters, ...freeformFilters, ...overl
 export const loadoutSuggestionsContextSelector = createSelector(
   loadoutsSelector,
   selectedLoadoutStoreSelector,
+  allItemsSelector,
   d2ManifestSelector,
   makeLoadoutSuggestionsContext,
 );
@@ -42,11 +45,13 @@ export const loadoutSuggestionsContextSelector = createSelector(
 function makeLoadoutSuggestionsContext(
   loadouts: Loadout[],
   selectedLoadoutsStore: DimStore,
+  allItems: DimItem[],
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutSuggestionsContext {
   return {
     loadouts,
     selectedLoadoutsStore,
+    allItems,
     d2Definitions,
   };
 }
@@ -62,12 +67,14 @@ function makeLoadoutFilterContext(
   selectedLoadoutsStore: DimStore,
   loadoutsByItem: LoadoutsByItem,
   language: DimLanguage,
+  allItems: DimItem[],
   d2Definitions: D2ManifestDefinitions | undefined,
 ): LoadoutFilterContext {
   return {
     selectedLoadoutsStore,
     loadoutsByItem,
     language,
+    allItems,
     d2Definitions,
   };
 }
@@ -81,6 +88,7 @@ const loadoutFilterContextSelector = createSelector(
   selectedLoadoutStoreSelector,
   loadoutsByItemSelector,
   languageSelector,
+  allItemsSelector,
   d2ManifestSelector,
   makeLoadoutFilterContext,
 );

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -100,7 +100,7 @@ const freeformFilters: FilterDefinition<
     },
   },
   {
-    keywords: 'contains',
+    keywords: ['contains', 'exactcontains'],
     description: tl('LoadoutFilter.Contains'),
     format: 'freeform',
     suggestionsGenerator: ({ d2Definitions, allItems, loadouts, selectedLoadoutsStore }) => {
@@ -123,19 +123,21 @@ const freeformFilters: FilterDefinition<
             selectedLoadoutsStore?.id,
             item,
           );
-          return resolvedItem && `contains:${quoteFilterString(resolvedItem.name.toLowerCase())}`;
+          return (
+            resolvedItem && `exactcontains:${quoteFilterString(resolvedItem.name.toLowerCase())}`
+          );
         });
         const modSuggestions =
           getModsFromLoadout(d2Definitions, loadout).map(
             (mod) =>
-              `contains:${quoteFilterString(mod.resolvedMod.displayProperties.name.toLowerCase())}`,
+              `exactcontains:${quoteFilterString(mod.resolvedMod.displayProperties.name.toLowerCase())}`,
           ) || [];
 
         return deduplicate([...itemSuggestions, ...modSuggestions]);
       });
     },
-    filter: ({ filterValue, language, allItems, d2Definitions, selectedLoadoutsStore }) => {
-      const test = matchText(filterValue, language, false);
+    filter: ({ filterValue, language, allItems, d2Definitions, selectedLoadoutsStore, lhs }) => {
+      const test = matchText(filterValue, language, lhs === 'exactcontains');
       return (loadout) => {
         if (!d2Definitions || !isLoadoutCompatibleWithStore(loadout, selectedLoadoutsStore)) {
           return false;

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -33,8 +33,10 @@ const freeformFilters: FilterDefinition<
     keywords: ['name', 'exactname'],
     description: tl('LoadoutFilter.Name'),
     format: 'freeform',
-    suggestionsGenerator: ({ loadouts }) =>
-      loadouts?.map((loadout) => `exactname:${quoteFilterString(loadout.name.toLowerCase())}`),
+    suggestionsGenerator: ({ loadouts, selectedLoadoutsStore }) =>
+      loadouts
+        ?.filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType)
+        .map((loadout) => `exactname:${quoteFilterString(loadout.name.toLowerCase())}`),
     filter: ({ filterValue, language, lhs }) => {
       const test = matchText(filterValue, language, /* exact */ lhs === 'exactname');
       return (loadout) => test(loadout.name);
@@ -89,6 +91,53 @@ const freeformFilters: FilterDefinition<
     },
   },
   {
+    keywords: 'contains',
+    description: tl('LoadoutFilter.Contains'),
+    format: 'freeform',
+    suggestionsGenerator: ({ d2Definitions, loadouts, selectedLoadoutsStore }) => {
+      if (!d2Definitions || !loadouts) {
+        return [];
+      }
+
+      return loadouts.flatMap((loadout) => {
+        if (loadout.classType !== selectedLoadoutsStore?.classType) {
+          return [];
+        }
+
+        const itemSuggestions = loadout.items.map((item) => {
+          const definition = d2Definitions.InventoryItem.get(item.hash);
+          return `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`;
+        });
+        const modSuggestions =
+          loadout.parameters?.mods?.map((modHash) => {
+            const definition = d2Definitions.InventoryItem.get(modHash);
+            return `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`;
+          }) || [];
+
+        return deduplicate([...itemSuggestions, ...modSuggestions]);
+      });
+    },
+    filter: ({ filterValue, language, d2Definitions, selectedLoadoutsStore }) => {
+      const test = matchText(filterValue, language, false);
+      return (loadout) => {
+        if (!d2Definitions || loadout.classType !== selectedLoadoutsStore.classType) {
+          return false;
+        }
+
+        return (
+          loadout.items.some((item) => {
+            const itemDefinition = d2Definitions.InventoryItem.get(item.hash);
+            return itemDefinition && test(itemDefinition.displayProperties.name);
+          }) ||
+          loadout.parameters?.mods?.some((mod) => {
+            const modDefinition = d2Definitions.InventoryItem.get(mod);
+            return modDefinition && test(modDefinition.displayProperties.name);
+          })
+        );
+      };
+    },
+  },
+  {
     keywords: 'notes',
     description: tl('LoadoutFilter.Notes'),
     format: 'freeform',
@@ -102,14 +151,16 @@ const freeformFilters: FilterDefinition<
     keywords: 'keyword',
     description: tl('LoadoutFilter.PartialMatch'),
     format: 'freeform',
-    suggestionsGenerator: ({ loadouts }) =>
+    suggestionsGenerator: ({ loadouts, selectedLoadoutsStore }) =>
       loadouts
         ? Array.from(
             new Set([
-              ...loadouts.flatMap((loadout) => [
-                ...getHashtagsFromNote(loadout.name),
-                ...getHashtagsFromNote(loadout.notes),
-              ]),
+              ...loadouts
+                .filter((loadout) => loadout.classType === selectedLoadoutsStore?.classType)
+                .flatMap((loadout) => [
+                  ...getHashtagsFromNote(loadout.name),
+                  ...getHashtagsFromNote(loadout.notes),
+                ]),
             ]),
           )
         : [],

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -7,6 +7,7 @@ import { findItemForLoadout, getModsFromLoadout } from 'app/loadout-drawer/loado
 import { Loadout } from 'app/loadout/loadout-types';
 import { matchText, plainString } from 'app/search/text-utils';
 import { getDamageDefsByDamageType } from 'app/utils/definitions';
+import { emptyArray } from 'app/utils/empty';
 import { isClassCompatible } from 'app/utils/item-utils';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -25,7 +26,12 @@ function subclassFromLoadout(
   store: DimStore | undefined,
 ) {
   for (const item of loadout.items) {
-    const resolvedItem = findItemForLoadout(d2Definitions, allItems ?? emptyList(), store?.id, item);
+    const resolvedItem = findItemForLoadout(
+      d2Definitions,
+      allItems ?? emptyArray(),
+      store?.id,
+      item,
+    );
     if (resolvedItem?.bucket.hash === BucketHashes.Subclass) {
       return resolvedItem;
     }

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -111,7 +111,14 @@ const freeformFilters: FilterDefinition<
         const modSuggestions =
           loadout.parameters?.mods?.map((modHash) => {
             const definition = d2Definitions.InventoryItem.get(modHash);
-            return `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`;
+            // For some reason this definition is undefined when switching characters in the
+            // loadouts page. This suggestion function will be run, as redux is updated, and
+            // the modHash will be defined but d2Definitions.InventoryItem.get(modHash)
+            // returns undefined
+            return (
+              definition &&
+              `contains:${quoteFilterString(definition.displayProperties.name.toLowerCase())}`
+            );
           }) || [];
 
         return deduplicate([...itemSuggestions, ...modSuggestions]);

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -25,7 +25,7 @@ function subclassFromLoadout(
   store: DimStore | undefined,
 ) {
   for (const item of loadout.items) {
-    const resolvedItem = findItemForLoadout(d2Definitions, allItems || [], store?.id, item);
+    const resolvedItem = findItemForLoadout(d2Definitions, allItems ?? emptyList(), store?.id, item);
     if (resolvedItem?.bucket.hash === BucketHashes.Subclass) {
       return resolvedItem;
     }
@@ -79,7 +79,7 @@ const freeformFilters: FilterDefinition<
           if (!subclass) {
             return;
           }
-          const damageType = subclass.element?.enumValue;
+          const damageType = subclass.element?.displayProperties.name;
           // DamageType.None is 0
           const damageName =
             damageType !== undefined ? damageDefs[damageType].displayProperties.name : undefined;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -697,6 +697,7 @@
     "UnlockItem": "Unpin Item"
   },
   "LoadoutFilter": {
+    "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
     "ModsOnly": "Shows loadouts that only contain armor mods.",
     "Name": "Shows loadouts whose name matches (exactname:) or partially matches (name:) the filter text. Search for entire phrases using quotes.",


### PR DESCRIPTION
Reverts DestinyItemManager/DIM#10473

This reintroduces https://github.com/DestinyItemManager/DIM/pull/10470 with a fix for definitions returning undefined.

After some discussion with @robojumper on discord I now better understand the "migration" we do of armour mods which was causing this. I believe my issue was having deprecated armour mods in my loadout. 

Given this, I have added some safer handling of mod and subclass definition resolution as per the chat we had in discord. Specifically, we have functions in `loadout-utils` that upgrade and manage hashes for us. Because this is search and is supposed to be lightweight I have kept this implementation to definition based name resolution, which man not be entirely correct but I think it is close enough for the use case we have here.

