### PR TITLE
disabled mod exclude subclasses

### DIFF
--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -44,6 +44,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "green",
   "grenadelauncher",
   "handcannon",
+  "hasdisabledmod",
   "haslight",
   "hasmod",
   "hasnotes",

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -170,6 +170,7 @@ const socketFilters: ItemFilterDefinition[] = [
     destinyVersion: 2,
 
     filter: () => (item) =>
+      !item.itemCategoryHashes.includes(ItemCategoryHashes.Subclasses) &&
       item.sockets?.allSockets.some((socket) =>
         Boolean(socket.plugged && socket.visibleInGame && !socket.plugged.enabled),
       ),


### PR DESCRIPTION
Currently matching all subclasses, not sure why.

![image](https://github.com/DestinyItemManager/DIM/assets/4798491/11ed8dbb-f2a5-435a-9299-f16ef8f98e6e)
