### PR TITLE
Banish legendary shards

### DIFF
--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -90,7 +90,6 @@ export const isNewSelector = (item: DimItem) => (state: RootState) =>
 
 const visibleCurrencies = [
   3159615086, // Glimmer
-  1022552290, // Legendary Shards
   2817410917, // Bright Dust
   3147280338, // Silver
   2534352370, // Legendary Marks (D1)

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -135,7 +135,6 @@ const materialsInRarityOrder = [
   4257549985, // InventoryItem "Ascendant Shard"
   4257549984, // InventoryItem "Enhancement Prism"
   3853748946, // InventoryItem "Enhancement Core"
-  1022552290, // InventoryItem "Legendary Shards"
   3159615086, // InventoryItem "Glimmer"
 ];
 

--- a/src/app/store-stats/AccountCurrencies.tsx
+++ b/src/app/store-stats/AccountCurrencies.tsx
@@ -25,8 +25,8 @@ export default memo(function AccountCurrency() {
           </div>
         </React.Fragment>
       ))}
-      {/* add 0-3 blank slots to keep each currencyGroup rounded to a multiple of 4 (for css grid) */}
-      {_.times((4 - (currencies.length % 4)) % 4, (i) => (
+      {/* add 0-2 blank slots to keep each currencyGroup rounded to a multiple of 3 (for css grid) */}
+      {_.times((3 - (currencies.length % 3)) % 3, (i) => (
         <React.Fragment key={i}>
           <div />
           <div />

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -1,7 +1,7 @@
 .vaultStats {
   max-width: 230px;
   display: grid;
-  grid-template-columns: repeat(4, 16px minmax(min-content, 1fr));
+  grid-template-columns: repeat(3, 16px minmax(min-content, 1fr));
   grid-auto-rows: 16px;
   gap: 4px 2px;
   align-items: center;


### PR DESCRIPTION
Nukes legendary shards from the account currencies display and elsewhere. Unless someone knows of another useful account currency I swapped things to 3 columns:

<img width="236" alt="Screenshot 2024-06-05 at 11 45 57 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/c9b10c0c-fe21-4352-8a1b-846cf397a232">
