### PR TITLE
Clean out previous seasonal items from MaterialCounts

### DIFF
--- a/src/app/material-counts/MaterialCounts.tsx
+++ b/src/app/material-counts/MaterialCounts.tsx
@@ -16,7 +16,7 @@ import styles from './MaterialCounts.m.scss';
 
 const showMats = spiderMats;
 const goodMats = [2979281381, 4257549984, 3853748946, 4257549985, 3702027555, 353704689];
-const seasonal = [1224079819, 2329379380, 2329379381, 2392300858, 1289622079, 1471199156];
+const seasonal = [1289622079, 1471199156];
 
 export function MaterialCounts({
   wide,
@@ -60,8 +60,12 @@ export function MaterialCounts({
         })}
       </React.Fragment>
     )),
-    <CurrencyGroup key="engrams" currencies={vendorCurrencyEngrams} />,
-    <CurrencyGroup key="transmog" currencies={transmogCurrencies} />,
+    vendorCurrencyEngrams.length > 0 && (
+      <CurrencyGroup key="engrams" currencies={vendorCurrencyEngrams} />
+    ),
+    transmogCurrencies.length > 0 && (
+      <CurrencyGroup key="transmog" currencies={transmogCurrencies} />
+    ),
   ];
 
   return (


### PR DESCRIPTION
I don't know if there's something you can do with last year's keys, or if there are new seasonal materials we should track here, but I figured it's best to remove them:

<img width="469" alt="Screenshot 2024-06-06 at 12 21 16 AM" src="https://github.com/DestinyItemManager/DIM/assets/313208/91f4664e-1142-4a7a-8ec6-93066ea3c1ab">
