### PR TITLE
Add loadout filters for total, weapon, and armor light level

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -206,9 +206,7 @@
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
     "ModsOnly": "Shows loadouts that only contain armor mods.",
     "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text.",
-    "LoadoutLight": "Shows loadouts based on their calculated light level. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
-    "ArmorLight": "Shows loadouts based on the calculated light level of the armor. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
-    "WeaponLight": "Shows loadouts based on the calculated light level of the weapons. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits."
+    "LoadoutLight": "Shows loadouts based on their calculated light level. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits."
   },
   "Filter": {
     "Adept": "\\(Adept\\)",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -205,7 +205,10 @@
     "Season": "Shows loadouts by which season of Destiny 2 they were last modified in.",
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
     "ModsOnly": "Shows loadouts that only contain armor mods.",
-    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text."
+    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text.",
+    "LoadoutLight": "Shows loadouts based on their calculated light level. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
+    "ArmorLight": "Shows loadouts based on the calculated light level of the armor. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
+    "WeaponLight": "Shows loadouts based on the calculated light level of the weapons. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits."
   },
   "Filter": {
     "Adept": "\\(Adept\\)",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Next
+* Add light level filters to the loadout search.
+  * `light:` filter finds loadouts whose light level matches the provided range, for loadouts where all weapon and armor slots have items assigned.
+  * `armorlight:` filter finds loadouts where the armor light level matches the provided range, for loadouts where all armor slots have items assigned.
+  * `weaponlight:` filter finds loadouts whose weapon light level matches the provided range, for loadouts where all weapon slots have items assigned.
 
 ## 8.23.0 <span class="changelog-date">(2024-06-09)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## Next
 * Add light level filters to the loadout search.
   * `light:` filter finds loadouts whose light level matches the provided range, for loadouts where all weapon and armor slots have items assigned.
-  * `armorlight:` filter finds loadouts where the armor light level matches the provided range, for loadouts where all armor slots have items assigned.
-  * `weaponlight:` filter finds loadouts whose weapon light level matches the provided range, for loadouts where all weapon slots have items assigned.
 
 ## 8.23.0 <span class="changelog-date">(2024-06-09)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Next
-* Add light level filters to the loadout search.
-  * `light:` filter finds loadouts whose light level matches the provided range, for loadouts where all weapon and armor slots have items assigned.
+* Add `light:` filter to the loadout search, for searching loadouts that equip all weapon and armor slots.
 
 ## 8.23.0 <span class="changelog-date">(2024-06-09)</span>
 

--- a/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
+++ b/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
@@ -9,8 +9,6 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
 
 exports[`buildSearchConfig generates a reasonable filter map: key-value filters 1`] = `
 [
-  "armorlight",
-  "armorpower",
   "contains",
   "exactcontains",
   "exactname",
@@ -21,7 +19,5 @@ exports[`buildSearchConfig generates a reasonable filter map: key-value filters 
   "power",
   "season",
   "subclass",
-  "weaponlight",
-  "weaponpower",
 ]
 `;

--- a/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
+++ b/src/app/search/loadouts/__snapshots__/loadout-search-filter.test.ts.snap
@@ -9,13 +9,19 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
 
 exports[`buildSearchConfig generates a reasonable filter map: key-value filters 1`] = `
 [
+  "armorlight",
+  "armorpower",
   "contains",
   "exactcontains",
   "exactname",
   "keyword",
+  "light",
   "name",
   "notes",
+  "power",
   "season",
   "subclass",
+  "weaponlight",
+  "weaponpower",
 ]
 `;

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -73,7 +73,12 @@ function allItemsFromLoadout(items: ItemBucket): DimItem[] {
   ].flat();
 }
 
-function ResolveLoadoutToDimItems(
+/**
+ * Simplified version of getItemsFromLoadoutItems that doesn't generate warnItems, and only
+ * converts equipped armor and weapons that can be equipped.
+ */
+
+function getDimItemsFromLoadoutItems(
   loadout: Loadout,
   d2Definitions: D2ManifestDefinitions,
   allItems: DimItem[],
@@ -84,14 +89,15 @@ function ResolveLoadoutToDimItems(
   // 2. items must be able to be equipped by the character
   // This may not be sufficient, but for the moment it seems good enough
   const dimItems = filterMap(loadout.items, (loadoutItem) => {
-    const newItem = findItemForLoadout(d2Definitions, allItems, store.id, loadoutItem);
-    if (
-      loadoutItem.equip &&
-      newItem &&
-      (newItem.bucket.inWeapons || newItem.bucket.inArmor) &&
-      itemCanBeEquippedByStoreId(newItem, store.id, loadout.classType, true)
-    ) {
-      return newItem;
+    if (loadoutItem.equip) {
+      const newItem = findItemForLoadout(d2Definitions, allItems, store.id, loadoutItem);
+      if (
+        newItem &&
+        (newItem.bucket.inWeapons || newItem.bucket.inArmor) &&
+        itemCanBeEquippedByStoreId(newItem, store.id, loadout.classType, true)
+      ) {
+        return newItem;
+      }
     }
   });
   // Resolve this into an object that tells us what we need to know
@@ -276,7 +282,7 @@ const freeformFilters: FilterDefinition<
           return false;
         }
         //
-        const resolvedLoadout = ResolveLoadoutToDimItems(
+        const resolvedLoadout = getDimItemsFromLoadoutItems(
           loadout,
           d2Definitions,
           allItems,

--- a/src/app/search/loadouts/search-filters/freeform.ts
+++ b/src/app/search/loadouts/search-filters/freeform.ts
@@ -3,11 +3,12 @@ import { tl } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { getHashtagsFromNote } from 'app/inventory/note-hashtags';
 import { DimStore } from 'app/inventory/store-types';
-import { findItemForLoadout, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
+import { findItemForLoadout, getLight, getModsFromLoadout } from 'app/loadout-drawer/loadout-utils';
 import { Loadout } from 'app/loadout/loadout-types';
+import { powerLevelByKeyword } from 'app/search/power-levels';
 import { matchText, plainString } from 'app/search/text-utils';
 import { emptyArray } from 'app/utils/empty';
-import { isClassCompatible } from 'app/utils/item-utils';
+import { isClassCompatible, itemCanBeEquippedByStoreId } from 'app/utils/item-utils';
 import { BucketHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { FilterDefinition } from '../../filter-types';
@@ -39,6 +40,106 @@ function subclassFromLoadout(
 
 function isLoadoutCompatibleWithStore(loadout: Loadout, store: DimStore | undefined) {
   return !store || isClassCompatible(loadout.classType, store.classType);
+}
+
+// Helper object to tell us useful things about all the DIM items we get back from a loadout
+// Primarily we are interested in items that contribute to the power level
+class ResolvedEquipment {
+  // properties
+  readonly kinetic: DimItem[];
+  readonly energy: DimItem[];
+  readonly power: DimItem[];
+  readonly helmet: DimItem[];
+  readonly gauntlet: DimItem[];
+  readonly chest: DimItem[];
+  readonly leg: DimItem[];
+  readonly class: DimItem[];
+
+  // Grab total counts
+  weaponCount(): Number {
+    return this.kinetic.length + this.energy.length + this.power.length;
+  }
+  armorCount(): Number {
+    return (
+      this.helmet.length +
+      this.gauntlet.length +
+      this.chest.length +
+      this.leg.length +
+      this.class.length
+    );
+  }
+
+  // Convenience checks
+  hasAllWeapons(): Boolean {
+    return this.kinetic.length > 0 && this.energy.length > 0 && this.power.length > 0;
+  }
+
+  hasAllArmor(): Boolean {
+    return (
+      this.helmet.length > 0 &&
+      this.gauntlet.length > 0 &&
+      this.chest.length > 0 &&
+      this.leg.length > 0 &&
+      this.class.length > 0
+    );
+  }
+
+  // Convenience get specific types
+  allWeapons(): DimItem[] {
+    return [this.kinetic, this.energy, this.power].flat();
+  }
+  allArmor(): DimItem[] {
+    return [this.chest, this.gauntlet, this.chest, this.leg, this.class].flat();
+  }
+  allItems(): DimItem[] {
+    return [
+      this.kinetic,
+      this.energy,
+      this.power,
+      this.chest,
+      this.gauntlet,
+      this.chest,
+      this.leg,
+      this.class,
+    ].flat();
+  }
+
+  constructor(items: DimItem[]) {
+    this.kinetic = items.filter((item) => item.bucket.hash === BucketHashes.KineticWeapons);
+    this.energy = items.filter((item) => item.bucket.hash === BucketHashes.EnergyWeapons);
+    this.power = items.filter((item) => item.bucket.hash === BucketHashes.PowerWeapons);
+    this.helmet = items.filter((item) => item.bucket.hash === BucketHashes.Helmet);
+    this.gauntlet = items.filter((item) => item.bucket.hash === BucketHashes.Gauntlets);
+    this.chest = items.filter((item) => item.bucket.hash === BucketHashes.ChestArmor);
+    this.leg = items.filter((item) => item.bucket.hash === BucketHashes.LegArmor);
+    this.class = items.filter((item) => item.bucket.hash === BucketHashes.ClassArmor);
+  }
+}
+
+function ResolveLoadoutToDimItems(
+  loadout: Loadout,
+  d2Definitions: D2ManifestDefinitions,
+  allItems: DimItem[],
+  store: DimStore,
+): ResolvedEquipment {
+  const dimItems: DimItem[] = [];
+
+  // We have two big requirements here:
+  // 1. items must be weapons or armor
+  // 2. items must be able to be equipped by the character
+  // This may not be sufficient, but for the moment it seems good enough
+  for (const loadoutItem of loadout.items) {
+    const newItem = findItemForLoadout(d2Definitions, allItems, store.id, loadoutItem);
+    if (
+      newItem &&
+      (newItem.bucket.inWeapons || newItem.bucket.inArmor) &&
+      itemCanBeEquippedByStoreId(newItem, store.id, loadout.classType, true)
+    ) {
+      dimItems.push(newItem);
+    }
+  }
+  // Resolve this into an object that tells us what we need to know
+  return new ResolvedEquipment(dimItems);
 }
 
 const freeformFilters: FilterDefinition<
@@ -202,6 +303,113 @@ const freeformFilters: FilterDefinition<
       filterValue = plainString(filterValue, language);
       const test = (s: string) => plainString(s, language).includes(filterValue);
       return (loadout) => test(loadout.name) || Boolean(loadout.notes && test(loadout.notes));
+    },
+  },
+  {
+    keywords: ['light', 'power'],
+    /* t('Filter.PowerKeywords') */
+    description: tl('LoadoutFilter.LoadoutLight'),
+    format: 'range',
+    overload: powerLevelByKeyword,
+    filter: ({ compare, allItems, d2Definitions, selectedLoadoutsStore }) => {
+      if (!d2Definitions || !selectedLoadoutsStore || !allItems) {
+        return () => false;
+      }
+      return (loadout: Loadout) => {
+        if (!isLoadoutCompatibleWithStore(loadout, selectedLoadoutsStore)) {
+          return false;
+        }
+        //
+        const resolvedLoadout = ResolveLoadoutToDimItems(
+          loadout,
+          d2Definitions,
+          allItems,
+          selectedLoadoutsStore,
+        );
+
+        // The UI, at the time of implementing this, only shows the light level using the following rules:
+        // 1. it only shows the light level if all armor + weapon slots have items assigned
+        // 2. it uses all weapons when calculating it (not just equipped)
+        // 3. it doesn't take the artifact level into account
+        // Here we mimic these restrictions.
+
+        // Enforce restriction #1
+        if (!resolvedLoadout.hasAllArmor() || !resolvedLoadout.hasAllWeapons()) {
+          return false;
+        }
+
+        // Calculate light level of *all* items
+        const lightLevel = Math.floor(getLight(selectedLoadoutsStore, resolvedLoadout.allItems()));
+        return Boolean(compare!(lightLevel));
+      };
+    },
+  },
+  {
+    keywords: ['armorlight', 'armorpower'],
+    /* t('Filter.PowerKeywords') */
+    description: tl('LoadoutFilter.ArmorLight'),
+    format: 'range',
+    overload: powerLevelByKeyword,
+    filter: ({ compare, allItems, d2Definitions, selectedLoadoutsStore }) => {
+      if (!d2Definitions || !selectedLoadoutsStore || !allItems) {
+        return () => false;
+      }
+      return (loadout: Loadout) => {
+        if (!isLoadoutCompatibleWithStore(loadout, selectedLoadoutsStore)) {
+          return false;
+        }
+        //
+        const resolvedLoadout = ResolveLoadoutToDimItems(
+          loadout,
+          d2Definitions,
+          allItems,
+          selectedLoadoutsStore,
+        );
+
+        // Only show use the light level of the armor
+        if (!resolvedLoadout.hasAllArmor()) {
+          return false;
+        }
+
+        // Calculate light level of *all* weapon
+        const lightLevel = Math.floor(getLight(selectedLoadoutsStore, resolvedLoadout.allArmor()));
+        return Boolean(compare!(lightLevel));
+      };
+    },
+  },
+  {
+    keywords: ['weaponlight', 'weaponpower'],
+    /* t('Filter.PowerKeywords') */
+    description: tl('LoadoutFilter.WeaponLight'),
+    format: 'range',
+    overload: powerLevelByKeyword,
+    filter: ({ compare, allItems, d2Definitions, selectedLoadoutsStore }) => {
+      if (!d2Definitions || !selectedLoadoutsStore || !allItems) {
+        return () => false;
+      }
+      return (loadout: Loadout) => {
+        if (!isLoadoutCompatibleWithStore(loadout, selectedLoadoutsStore)) {
+          return false;
+        }
+        //
+        const resolvedLoadout = ResolveLoadoutToDimItems(
+          loadout,
+          d2Definitions,
+          allItems,
+          selectedLoadoutsStore,
+        );
+
+        // Only show use the light level of the weapons
+        if (!resolvedLoadout.hasAllWeapons()) {
+          return false;
+        }
+
+        // Calculate light level of *all* weapons
+        const lightLevel = Math.floor(
+          getLight(selectedLoadoutsStore, resolvedLoadout.allWeapons()),
+        );
+        return Boolean(compare!(lightLevel));
+      };
     },
   },
 ];

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -705,7 +705,6 @@
     "UnlockItem": "Unpin Item"
   },
   "LoadoutFilter": {
-    "ArmorLight": "Shows loadouts based on the calculated light level of the armor. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
     "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
     "LoadoutLight": "Shows loadouts based on their calculated light level. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
@@ -714,8 +713,7 @@
     "Notes": "Search for loadouts by their notes field.",
     "PartialMatch": "Shows loadouts where their name or notes has a partial match to the filter text. Search for entire phrases using quotes.",
     "Season": "Shows loadouts by which season of Destiny 2 they were last modified in.",
-    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text.",
-    "WeaponLight": "Shows loadouts based on the calculated light level of the weapons. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits."
+    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text."
   },
   "Loadouts": {
     "Abilities": "Abilities",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -705,14 +705,17 @@
     "UnlockItem": "Unpin Item"
   },
   "LoadoutFilter": {
+    "ArmorLight": "Shows loadouts based on the calculated light level of the armor. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
     "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",
     "FashionOnly": "Shows loadouts that contain only fashion (shaders or ornaments).",
+    "LoadoutLight": "Shows loadouts based on their calculated light level. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits.",
     "ModsOnly": "Shows loadouts that only contain armor mods.",
     "Name": "Shows loadouts whose name matches (exactname:) or partially matches (name:) the filter text. Search for entire phrases using quotes.",
     "Notes": "Search for loadouts by their notes field.",
     "PartialMatch": "Shows loadouts where their name or notes has a partial match to the filter text. Search for entire phrases using quotes.",
     "Season": "Shows loadouts by which season of Destiny 2 they were last modified in.",
-    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text."
+    "Subclass": "Shows loadouts whose subclass name or damage type partially matches the filter text.",
+    "WeaponLight": "Shows loadouts based on the calculated light level of the weapons. Use the pinnaclecap or softcap keyword instead of a number to refer to the current season's power limits."
   },
   "Loadouts": {
     "Abilities": "Abilities",


### PR DESCRIPTION
This might require some iteration before merge (or even being redone entirely) but I figured I'd put the code out there to start the conversation, at least.

Short version is this implements 3 new filters for the loadout search:

- `light:`/`power:` which filters by the calculated light level of the loadout, if all slots are filled
- `weaponlight:`/`weaponpower:` which filters by the calculated light level of the weapons, if all 3 slots are filled
- `armorlight:`/`armorpower:` which filters by the calculated light level of the armor, if all 5 slots are filled

These liberally reuse the range syntax from the `light:` filter from the main inventory, so they largely have all the features you'd expect.

The "If all slots are filled" quirk comes from spending some time staring at the loadout UI - it only shows a light level for a loadout if there are items in all slots, which seems like a reasonable constraint so I carried it forward for all three filters. I could see an argument for weapon/armor light level filtering not needing this restriction, though.

As with the loadout UI (and inventory filters), artifact level is not taken into account when filtering.

My big concern here is that this is well outside my knowledge of the DIM codebase, so I kind of cobbled together the translation from a loadout -> DIM items + all the validation since I couldn't find any sort of pre-implemented utilities for it. I may have missed something very obvious, or honestly I may have simply done something that is counter to long term roadmap.

I'm also not sure I'm happy with having both the `light:` and `power:` variants, but it's no additional maintenance and it seemed worth it for symmetry.

Anyways, apologies for dropping this on you unannounced. I can ping you on discord if we need to chat about it some.