### PR TITLE
Armory: No longer show wish list entry helper on non-wishlistable items

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -59,7 +59,7 @@ export default function Armory({
 
   const itemDef = defs.InventoryItem.get(itemHash);
 
-  const itemWithoutSockets = makeFakeItem(itemCreationContext, itemHash);
+  const itemWithoutSockets = makeFakeItem(itemCreationContext, itemHash, { allowWishList: true });
 
   if (!itemWithoutSockets) {
     return (
@@ -229,7 +229,7 @@ export default function Armory({
         </>
       )}
 
-      {!isPhonePortrait && <WishListEntry item={item} />}
+      {!isPhonePortrait && item.wishListEnabled && <WishListEntry item={item} />}
 
       {storeItems.length > 0 && (
         <>

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -142,11 +142,18 @@ export const getClassTypeNameLocalized = _.memoize(
 export function makeFakeItem(
   context: ItemCreationContext,
   itemHash: number,
-  itemInstanceId = '0',
-  quantity = 1,
-  allowWishList = false,
-  /** if available, this should be passed in from a vendor saleItem (DestinyVendorSaleItemComponent) */
-  itemValueVisibility?: DestinyVendorSaleItemComponent['itemValueVisibility'],
+  {
+    itemInstanceId = '0',
+    quantity = 1,
+    allowWishList = false,
+    itemValueVisibility,
+  }: {
+    itemInstanceId?: string;
+    quantity?: number;
+    allowWishList?: boolean;
+    /** if available, this should be passed in from a vendor saleItem (DestinyVendorSaleItemComponent) */
+    itemValueVisibility?: DestinyVendorSaleItemComponent['itemValueVisibility'];
+  } = emptyObject(),
 ): DimItem | undefined {
   const item = makeItem(
     context,

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -103,16 +103,14 @@ function makeVendorItem(
       profileResponse,
       characterId,
     ),
-    item: makeFakeItem(
-      context,
-      itemHash,
+    item: makeFakeItem(context, itemHash, {
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
-      vendorItemIndex.toString(),
-      vendorItemDef ? vendorItemDef.quantity : 1,
+      itemInstanceId: vendorItemIndex.toString(),
+      quantity: vendorItemDef ? vendorItemDef.quantity : 1,
       // vendor items are wish list enabled!
-      true,
-      saleItem?.itemValueVisibility,
-    ),
+      allowWishList: true,
+      itemValueVisibility: saleItem?.itemValueVisibility,
+    }),
   };
 
   if (vendorItem.item) {


### PR DESCRIPTION
This is an embarrassing miss - I had enabled showing the wish list line on every armory page, when it should only be shown for items which can be in wish lists.