### PR TITLE
Add max stack size to item popup

### DIFF
--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -76,6 +76,11 @@ export default function ItemPopupHeader({
         <div className={styles.details}>
           {showElementIcon && <ElementIcon element={item.element} className={styles.elementIcon} />}
           <div className={styles.power}>{item.primaryStat?.value}</div>
+          {item.maxStackSize > 1 && (
+            <div className={styles.itemType}>
+              {item.amount} / {item.maxStackSize}
+            </div>
+          )}
           {Boolean(item.powerCap) && <div className={styles.powerCap}>| {item.powerCap} </div>}
           {item.pursuit?.questLine && (
             <div className={styles.itemType}>

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -9,7 +9,7 @@ import type { ItemTierName } from 'app/search/d2-known-values';
 import { LookupTable } from 'app/utils/util-types';
 import { DestinyAmmunitionType, DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import heavy from 'destiny-icons/general/ammo-heavy.svg';
 import primary from 'destiny-icons/general/ammo-primary.svg';
 import special from 'destiny-icons/general/ammo-special.svg';
@@ -76,11 +76,12 @@ export default function ItemPopupHeader({
         <div className={styles.details}>
           {showElementIcon && <ElementIcon element={item.element} className={styles.elementIcon} />}
           <div className={styles.power}>{item.primaryStat?.value}</div>
-          {item.maxStackSize > 1 && (
-            <div className={styles.itemType}>
-              {item.amount} / {item.maxStackSize}
-            </div>
-          )}
+          {item.maxStackSize > 1 &&
+            !item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Ornament) && (
+              <div className={styles.itemType}>
+                {item.amount.toLocaleString()} / {item.maxStackSize.toLocaleString()}
+              </div>
+            )}
           {Boolean(item.powerCap) && <div className={styles.powerCap}>| {item.powerCap} </div>}
           {item.pursuit?.questLine && (
             <div className={styles.itemType}>


### PR DESCRIPTION
Fixes #10536. Really simple, just show current / max for stackables, that way we don't need any text like "MAX STACK SIZE". It occupies space that was otherwise unused.

<img width="437" alt="Screenshot 2024-06-13 at 10 34 08 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/0f997fb0-670e-413e-ba11-f4189375d9cb">
