### PR TITLE
Fix bug in the displayed calculated loadout power

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
-* Add `light:` filter to the loadout search, for searching loadouts that equip all weapon and armor slots.
+* Fix issue where light level displayed in the Loadouts views was calculated using all weapons and armor in the loadout, instead of just the weapons and armor to be equipped.
+* Add `light:` filter to the Loadouts search. Only works with loadouts that equip an item for all weapon and armor slots.
+
 
 ## 8.23.0 <span class="changelog-date">(2024-06-09)</span>
 

--- a/src/app/loadout/LoadoutView.tsx
+++ b/src/app/loadout/LoadoutView.tsx
@@ -16,7 +16,7 @@ import { Loadout, LoadoutItem, ResolvedLoadoutItem } from 'app/loadout/loadout-t
 import AppIcon from 'app/shell/icons/AppIcon';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useStreamDeckSelection } from 'app/stream-deck/stream-deck';
-import { count, filterMap } from 'app/utils/collections';
+import { filterMap } from 'app/utils/collections';
 import { emptyObject } from 'app/utils/empty';
 import { itemCanBeEquippedBy } from 'app/utils/item-utils';
 import { addDividers } from 'app/utils/react';
@@ -217,14 +217,14 @@ export default function LoadoutView({
 export function loadoutPower(store: DimStore, categories: _.Dictionary<ResolvedLoadoutItem[]>) {
   const isEquipped = (li: ResolvedLoadoutItem) =>
     Boolean(!li.missing && li.item.power && li.loadoutItem.equip);
-  const showPower =
-    count(categories.Weapons ?? [], isEquipped) === 3 &&
-    count(categories.Armor ?? [], isEquipped) === 5;
+  const equippedWeapons = categories.Weapons.filter(isEquipped);
+  const equippedArmor = categories.Armor.filter(isEquipped);
+  const showPower = equippedWeapons.length === 3 && equippedArmor.length === 5;
   const power = showPower
     ? Math.floor(
         getLight(
           store,
-          [...categories.Weapons, ...categories.Armor].map((li) => li.item),
+          [...equippedWeapons, ...equippedArmor].map((li) => li.item),
         ),
       )
     : 0;


### PR DESCRIPTION
The calculated loadout power displayed in the UI was using all weapons + armor in a loadout to calculate the power level, which could lead to incorrect results when applied in-game. This change filters the items used in the power level calculation down to just equipped weapons and armor, so that it (hopefully) matches the in-game value after it has been applied.

This should resolve #10527.