### PR TITLE
Better display for exotic class item perks, remove stats from class items in itemfeed

### DIFF
--- a/src/app/item-feed/Highlights.tsx
+++ b/src/app/item-feed/Highlights.tsx
@@ -5,8 +5,8 @@ import { DimItem, DimStat } from 'app/inventory/item-types';
 import { ItemTypeName } from 'app/item-popup/ItemPopupHeader';
 import { DimPlugTooltip } from 'app/item-popup/PlugTooltip';
 import {
+  getExtraIntrinsicPerkSockets,
   getWeaponArchetype,
-  socketContainsIntrinsicPlug,
   socketContainsPlugWithCategory,
 } from 'app/utils/socket-utils';
 import clsx from 'clsx';
@@ -64,13 +64,7 @@ export default function Highlights({ item }: { item: DimItem }) {
         {stat.value}
       </div>
     );
-    // exotic class armor intrinsics
-    const extraIntrinsicSockets =
-      item.isExotic && item.bucket.hash === BucketHashes.ClassArmor && item.sockets
-        ? item.sockets.allSockets.filter(
-            (s) => s.isPerk && s.visibleInGame && socketContainsIntrinsicPlug(s),
-          )
-        : [];
+    const extraIntrinsicSockets = getExtraIntrinsicPerkSockets(item);
     return (
       <>
         {item.bucket.hash !== BucketHashes.ClassArmor && (
@@ -85,16 +79,23 @@ export default function Highlights({ item }: { item: DimItem }) {
         )}
         {extraIntrinsicSockets.length > 0 && (
           <div className={styles.perks}>
-            {extraIntrinsicSockets
-              .flatMap((s) => s.plugOptions)
-              .map((p) => (
-                <div key={p.plugDef.hash}>
-                  <PressTip tooltip={() => <DimPlugTooltip item={item} plug={p} />}>
-                    <DefItemIcon itemDef={p.plugDef} borderless={true} />{' '}
-                    {p.plugDef.displayProperties.name}
-                  </PressTip>
-                </div>
-              ))}
+            {extraIntrinsicSockets.map((s) => (
+              <div
+                key={s.socketIndex}
+                className={clsx({
+                  [styles.multiPerk]: s.isPerk && s.plugOptions.length > 1,
+                })}
+              >
+                {s.plugOptions.map((p) => (
+                  <div key={p.plugDef.hash}>
+                    <PressTip tooltip={() => <DimPlugTooltip item={item} plug={p} />}>
+                      <DefItemIcon itemDef={p.plugDef} borderless={true} />{' '}
+                      {p.plugDef.displayProperties.name}
+                    </PressTip>
+                  </div>
+                ))}
+              </div>
+            ))}
           </div>
         )}
       </>

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -136,6 +136,16 @@ export function getIntrinsicArmorPerkSocket(item: DimItem): DimSocket | undefine
   }
 }
 
+export function getExtraIntrinsicPerkSockets(item: DimItem): DimSocket[] {
+  // returns sockets that contains intrinsic perks even if those sockets are not the "Intrinsic" socket
+  return item.isExotic && item.bucket.hash === BucketHashes.ClassArmor && item.sockets
+    ? item.sockets.allSockets
+        .filter((s) => s.isPerk && s.visibleInGame && socketContainsIntrinsicPlug(s))
+        // exotic class item intrinsics need to set isReusable false to avoid showing as selectable
+        .map((s) => ({ ...s, isReusable: false }))
+    : [];
+}
+
 export function socketContainsPlugWithCategory(
   socket: DimSocket,
   category: PlugCategoryHashes,


### PR DESCRIPTION
Makes exotic class items use the intrinsicRow display instead of normal socket UI. It also treats exotic class items' intrinsic perks as non-reusable so that they don't get highlighted as selectable perks in the UI.

This also removes the stat display from class items in the item feed.

<details>
<summary>Desktop:</summary>
<img width="370" alt="Screenshot 2024-06-16 at 4 15 24 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/cf3b915d-c57d-4479-b688-df8a79d3daf9">
<img width="370" alt="Screenshot 2024-06-16 at 4 21 44 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/358ccfc9-ff9b-4268-8124-b17c8518fd28">
<img width="478" alt="Screenshot 2024-06-16 at 4 15 13 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/94341330-5160-4602-91ca-958fe4030737">
<img width="257" alt="Screenshot 2024-06-18 at 2 00 14 PM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/4eb7fb99-6ca4-49b9-b20a-0bb03ce0fcaa">
</details>

<details>
<summary>Mobile:</summary>
<img width="393" alt="Screenshot 2024-06-19 at 2 11 54 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/edacdcfc-da43-49d5-b58b-96e3d9a71836">
<img width="399" alt="Screenshot 2024-06-19 at 2 12 06 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/33c0b1cc-01fe-47d1-be5d-8ca0ce456798">
<img width="394" alt="Screenshot 2024-06-19 at 2 11 30 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/405d7e22-c945-4e11-9d0b-b834fd84f26b">
<img width="333" alt="Screenshot 2024-06-19 at 2 12 42 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/431d8c4b-0c21-425a-ba70-3993c77b60b2">
</details>