### PR TITLE
Update engrams again

### DIFF
--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -55,7 +55,7 @@ export default function Milestones({
 
   const milestonesByPower = Map.groupBy(milestoneItems, (m) => {
     for (const reward of m.pursuit?.rewards ?? []) {
-      const powerBonus = getEngramPowerBonus(reward.itemHash, maxGearPower, m.hash);
+      const [powerBonus] = getEngramPowerBonus(reward.itemHash, maxGearPower, m.hash);
       if (powerBonus !== undefined) {
         return powerBonus;
       }

--- a/src/app/progress/Reward.tsx
+++ b/src/app/progress/Reward.tsx
@@ -25,10 +25,9 @@ export function Reward({
   const maxGearPower = useSelector(
     (state: RootState) => powerLevelSelector(state, store?.id)?.maxGearPower,
   );
-  const rewardItem = defs.InventoryItem.get(reward.itemHash);
+  const [powerBonus, rewardItemHash] = getEngramPowerBonus(reward.itemHash, maxGearPower, itemHash);
+  const rewardItem = defs.InventoryItem.get(rewardItemHash);
   const rewardDisplay = rewardItem.displayProperties;
-
-  const powerBonus = getEngramPowerBonus(rewardItem.hash, maxGearPower, itemHash);
 
   const xpValue = getXPValue(reward.itemHash);
 

--- a/src/app/progress/engrams.ts
+++ b/src/app/progress/engrams.ts
@@ -24,6 +24,11 @@ const engrams: HashLookup<{ cap: PowerCap; bonus: number }> = {
     cap: PowerCap.Pinnacle,
     bonus: 5,
   },
+  // Prime Engram from Pathfinder
+  853937142: {
+    cap: PowerCap.Pinnacle,
+    bonus: 5,
+  },
   // Tier 1
   3114385605: {
     cap: PowerCap.Powerful,
@@ -59,29 +64,36 @@ const engrams: HashLookup<{ cap: PowerCap; bonus: number }> = {
 /**
  * How much above the player's current max power will this reward drop?
  */
-export function getEngramPowerBonus(itemHash: number, maxPower?: number, parentItemHash?: number) {
-  // Hawthorne's Clan Rewards gives out a +2 pinnacle even though it's listed as a powerful
+export function getEngramPowerBonus(
+  itemHash: number,
+  maxPower?: number,
+  parentItemHash?: number,
+): [powerLevel: number | undefined, itemHash: number] {
   if (parentItemHash === 3603098564) {
+    // Hawthorne's Clan Rewards gives out a +2 pinnacle even though it's listed as a powerful
     itemHash = 73143230;
+  } else if (parentItemHash === 3243997895) {
+    // Captain's Log is a powerful level 2 even though it's listed as a pinnacle.
+    itemHash = 3114385606;
   }
 
   const engramInfo = engrams[itemHash];
-  if (!engramInfo) {
-    return undefined;
+  if (engramInfo) {
+    maxPower ||= 0;
+    maxPower = Math.floor(maxPower);
+    const powerfulCap = powerLevelByKeyword.powerfulcap;
+    if (engramInfo.cap === PowerCap.Powerful) {
+      // Powerful engrams can't go above the powerful cap
+      return [_.clamp(powerfulCap - maxPower, 0, engramInfo.bonus), itemHash];
+    } else if (engramInfo.cap === PowerCap.Pinnacle) {
+      // Once you're at or above the powerful cap, pinnacles only give +2, up to the hard cap
+      const pinnacleCap = Math.min(
+        powerLevelByKeyword.pinnaclecap,
+        Math.max(maxPower, powerfulCap) + 2,
+      );
+      return [_.clamp(pinnacleCap - maxPower, 0, engramInfo.bonus), itemHash];
+    }
   }
 
-  maxPower ||= 0;
-  maxPower = Math.floor(maxPower);
-  const powerfulCap = powerLevelByKeyword.powerfulcap;
-  if (engramInfo.cap === PowerCap.Powerful) {
-    // Powerful engrams can't go above the powerful cap
-    return _.clamp(powerfulCap - maxPower, 0, engramInfo.bonus);
-  } else if (engramInfo.cap === PowerCap.Pinnacle) {
-    // Once you're at or above the powerful cap, pinnacles only give +2, up to the hard cap
-    const pinnacleCap = Math.min(
-      powerLevelByKeyword.pinnaclecap,
-      Math.max(maxPower, powerfulCap) + 2,
-    );
-    return _.clamp(pinnacleCap - maxPower, 0, engramInfo.bonus);
-  }
+  return [undefined, itemHash];
 }


### PR DESCRIPTION
1. Add Pathfinder engram as a pinnacle
2. Replace Captain's Log pinnacle with a powerful v2. Fixes #10564.
3. Return modified item hash so we display the overridden item name in rewards.