### PR TITLE
Use drop power for engrams

### DIFF
--- a/src/app/inventory/store/selectors.ts
+++ b/src/app/inventory/store/selectors.ts
@@ -122,3 +122,6 @@ export const allPowerLevelsSelector = createSelector(
 
 export const powerLevelSelector = (state: RootState, storeId: string | undefined) =>
   storeId !== undefined ? allPowerLevelsSelector(state)[storeId] : undefined;
+
+export const dropPowerLevelSelector = (storeId: string | undefined) => (state: RootState) =>
+  powerLevelSelector(state, storeId)?.dropPower;

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -2,9 +2,8 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { InventoryBuckets } from 'app/inventory/inventory-buckets';
 import { DimStore } from 'app/inventory/store-types';
-import { powerLevelSelector } from 'app/inventory/store/selectors';
+import { dropPowerLevelSelector } from 'app/inventory/store/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { RootState } from 'app/store/types';
 import { uniqBy } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
@@ -38,9 +37,7 @@ export default function Milestones({
   const defs = useD2Definitions()!;
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
   const characterProgressions = getCharacterProgressions(profileInfo, store.id);
-  const maxGearPower = useSelector(
-    (state: RootState) => powerLevelSelector(state, store.id)?.maxGearPower,
-  );
+  const dropPower = useSelector(dropPowerLevelSelector(store.id));
   const season = profileInfo.profile?.data?.currentSeasonHash
     ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
     : undefined;
@@ -55,7 +52,7 @@ export default function Milestones({
 
   const milestonesByPower = Map.groupBy(milestoneItems, (m) => {
     for (const reward of m.pursuit?.rewards ?? []) {
-      const [powerBonus] = getEngramPowerBonus(reward.itemHash, maxGearPower, m.hash);
+      const [powerBonus] = getEngramPowerBonus(reward.itemHash, dropPower, m.hash);
       if (powerBonus !== undefined) {
         return powerBonus;
       }

--- a/src/app/progress/Reward.tsx
+++ b/src/app/progress/Reward.tsx
@@ -1,8 +1,7 @@
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { DimStore } from 'app/inventory/store-types';
-import { powerLevelSelector } from 'app/inventory/store/selectors';
+import { dropPowerLevelSelector } from 'app/inventory/store/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { RootState } from 'app/store/types';
 import { DestinyItemQuantity } from 'bungie-api-ts/destiny2';
 import { useSelector } from 'react-redux';
 import BungieImage from '../dim-ui/BungieImage';
@@ -22,10 +21,8 @@ export function Reward({
   itemHash?: number;
 }) {
   const defs = useD2Definitions()!;
-  const maxGearPower = useSelector(
-    (state: RootState) => powerLevelSelector(state, store?.id)?.maxGearPower,
-  );
-  const [powerBonus, rewardItemHash] = getEngramPowerBonus(reward.itemHash, maxGearPower, itemHash);
+  const dropPower = useSelector(dropPowerLevelSelector(store?.id));
+  const [powerBonus, rewardItemHash] = getEngramPowerBonus(reward.itemHash, dropPower, itemHash);
   const rewardItem = defs.InventoryItem.get(rewardItemHash);
   const rewardDisplay = rewardItem.displayProperties;
 


### PR DESCRIPTION
Correct me if I'm wrong, but I think we should be using the "drop power" to determine what bonus powerful/pinnacle engrams provide, rather than the character max power.