### PR TITLE
Milestone item tweaks

### DIFF
--- a/src/app/item-popup/ItemDetails.m.scss
+++ b/src/app/item-popup/ItemDetails.m.scss
@@ -28,6 +28,14 @@
   background: $acquiredGreen;
 }
 
+.fullImage {
+  aspect-ratio: auto 16/9;
+
+  &.milestoneImage {
+    aspect-ratio: auto 7/2;
+  }
+}
+
 .ownedIcon,
 .acquiredIcon {
   width: calc(var(--item-size) / 4) !important;

--- a/src/app/item-popup/ItemDetails.m.scss.d.ts
+++ b/src/app/item-popup/ItemDetails.m.scss.d.ts
@@ -2,10 +2,12 @@
 // Please do not change this file!
 interface CssExports {
   'acquiredIcon': string;
+  'fullImage': string;
   'itemDescription': string;
   'itemDetailsBody': string;
   'itemShader': string;
   'itemSource': string;
+  'milestoneImage': string;
   'mods': string;
   'ownedIcon': string;
 }

--- a/src/app/item-popup/ItemDetails.tsx
+++ b/src/app/item-popup/ItemDetails.tsx
@@ -78,7 +78,15 @@ export default function ItemDetails({
 
       {(item.type === 'Milestone' ||
         item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Ornament)) &&
-        item.secondaryIcon && <BungieImage src={item.secondaryIcon} width="100%" />}
+        item.secondaryIcon && (
+          <BungieImage
+            src={item.secondaryIcon}
+            width="100%"
+            className={clsx(styles.fullImage, {
+              [styles.milestoneImage]: item.type === 'Milestone',
+            })}
+          />
+        )}
 
       <ItemDescription item={item} />
 

--- a/src/app/progress/engrams.ts
+++ b/src/app/progress/engrams.ts
@@ -75,6 +75,12 @@ export function getEngramPowerBonus(
   } else if (parentItemHash === 3243997895) {
     // Captain's Log is a powerful level 2 even though it's listed as a pinnacle.
     itemHash = 3114385606;
+  } else if (parentItemHash === 373284212) {
+    // Enterprising Explorer II is powerful level 2
+    itemHash = 3114385606;
+  } else if (parentItemHash === 373284213) {
+    // Enterprising Explorer III is powerful level 3
+    itemHash = 3114385607;
   }
 
   const engramInfo = engrams[itemHash];

--- a/src/app/progress/milestone-items.ts
+++ b/src/app/progress/milestone-items.ts
@@ -163,7 +163,9 @@ function activityMilestoneToItem(
   defs: D2ManifestDefinitions,
   store: DimStore,
 ): DimItem | null {
-  const objectives = milestone.activities[0].challenges.map((a) => a.objective);
+  const activity = milestone.activities[0];
+  const activityDef = defs.Activity.get(activity.activityHash);
+  const objectives = activity.challenges.map((a) => a.objective);
   if (objectives.every((objective) => objective.complete)) {
     return null;
   }
@@ -179,15 +181,20 @@ function activityMilestoneToItem(
 
   dimItem.pursuit = {
     expiration: milestoneExpiration(milestone),
-    modifierHashes: milestone.activities[0].modifierHashes || [],
+    modifierHashes: activity.modifierHashes || [],
     rewards: [],
   };
   if (milestone.rewards) {
     dimItem.pursuit.rewards = processRewards(milestone.rewards, milestoneDef);
-  } else {
-    const activity = defs.Activity.get(milestone.activities[0].activityHash);
-    if (activity) {
-      dimItem.pursuit.rewards = activity.challenges.flatMap((c) => c.dummyRewards);
+  }
+  if (activityDef) {
+    if (!milestone.rewards) {
+      dimItem.pursuit.rewards = activityDef.challenges.flatMap((c) => c.dummyRewards);
+    }
+    if (milestoneDef.hash === 2029743966 /* Nightfall Weekly Score Challenge */) {
+      dimItem.name = `${dimItem.name}: ${activityDef.displayProperties.description}`;
+    } else if (milestoneDef.hash === 1506285920 /* Crucible Labs Playlist Challenge */) {
+      dimItem.name = `${dimItem.name}: ${activityDef.displayProperties.name}`;
     }
   }
 
@@ -385,7 +392,9 @@ export function recordToPursuitItem(
   };
 
   if (record.recordDef.rewardItems) {
-    dimItem.pursuit.rewards = record.recordDef.rewardItems;
+    dimItem.pursuit.rewards = record.recordDef.rewardItems.filter(
+      (_r, i) => record.recordComponent.rewardVisibilty?.[i] ?? true,
+    );
   }
 
   dimItem.trackable = true;
@@ -409,9 +418,10 @@ function processRewards(
   rewards: DestinyMilestoneRewardCategory[],
   milestoneDef: DestinyMilestoneDefinition,
 ) {
-  return rewards.flatMap((reward) =>
-    Object.values(milestoneDef.rewards[reward.rewardCategoryHash].rewardEntries).flatMap(
-      (entry) => entry.items,
-    ),
-  );
+  return rewards.flatMap((reward) => {
+    const rewardCategoryDef = milestoneDef.rewards[reward.rewardCategoryHash];
+    return reward.entries.flatMap(
+      (entry) => rewardCategoryDef.rewardEntries[entry.rewardEntryHash]?.items ?? [],
+    );
+  });
 }


### PR DESCRIPTION
1. Set aspect ratio for images so they don't re-layout when they load.
2. Include the name of the nightfall in the weekly nightfall milestone.
3. Include the name of the crucible labs playlist in that milestone.
4. Correct some of the reward handling.