### PR TITLE
Item Feed: Add compare button

### DIFF
--- a/src/app/item-feed/ItemFeed.m.scss
+++ b/src/app/item-feed/ItemFeed.m.scss
@@ -12,11 +12,12 @@
   composes: flexRow from '../dim-ui/common.m.scss';
   align-items: flex-start;
   margin: 8px 0;
+  gap: 8px;
   padding-left: 1px; // to account for the item hover outline
 }
 
 .info {
-  margin-left: 8px;
+  flex: 1;
 }
 
 .title {

--- a/src/app/item-feed/TagButtons.m.scss
+++ b/src/app/item-feed/TagButtons.m.scss
@@ -2,5 +2,14 @@
 
 .tagButton {
   composes: dim-button from global;
-  margin-right: 4px;
+  flex: 1;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.tagButtons {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  margin-top: 4px;
+  gap: 4px;
+  width: 100%;
 }

--- a/src/app/item-feed/TagButtons.m.scss.d.ts
+++ b/src/app/item-feed/TagButtons.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'tagButton': string;
+  'tagButtons': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/item-feed/TagButtons.tsx
+++ b/src/app/item-feed/TagButtons.tsx
@@ -1,7 +1,9 @@
+import { addCompareItem } from 'app/compare/actions';
 import { clearNewItem, setTag } from 'app/inventory/actions';
 import { TagValue, tagConfig } from 'app/inventory/dim-item-info';
 import { DimItem } from 'app/inventory/item-types';
-import { AppIcon } from 'app/shell/icons';
+import { hideItemPopup } from 'app/item-popup/item-popup';
+import { AppIcon, compareIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import _ from 'lodash';
 import styles from './TagButtons.m.scss';
@@ -21,8 +23,16 @@ export default function TagButtons({ item, tag }: { item: DimItem; tag: TagValue
     dispatch(clearNewItem(item.id));
   };
 
+  const openCompare = () => {
+    hideItemPopup();
+    dispatch(addCompareItem(item));
+  };
+
   return (
-    <div>
+    <div className={styles.tagButtons}>
+      <button key="compare" className={styles.tagButton} type="button" onClick={openCompare}>
+        <AppIcon icon={compareIcon} />
+      </button>
       {tagOptions.map((tagOption) => (
         <button
           key={tagOption.type}


### PR DESCRIPTION
1. Add a compare button to the tag icons in the item feed. I almost always end up opening compare for items in the feed, and this just shortcuts that.
2. Flex the buttons so they are larger on mobile.

<img width="299" alt="Screenshot 2024-06-19 at 3 07 14 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/7526eeb4-5fad-4431-b5a1-866a239c15d9">
<img width="195" alt="Screenshot 2024-06-19 at 3 07 30 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/0b9c368e-3feb-41a6-868c-dddc6d0bb6de">
