### PR TITLE
Allow anything with random perks to be wishlisted

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -589,7 +589,9 @@ export function makeItem(
     reportException('Sockets', e, { itemHash: item.itemHash });
   }
 
-  createdItem.wishListEnabled = Boolean(createdItem.bucket.inWeapons && createdItem.sockets);
+  createdItem.wishListEnabled = Boolean(
+    createdItem.sockets?.allSockets.some((s) => s.hasRandomizedPlugItems),
+  );
 
   // Masterwork
   try {


### PR DESCRIPTION
Maybe fixes #10570. I don't have the exotic class item so I can't test, but this redefines `wishListEnabled` to be any item that has a random-rolled perk. You can test this by opening the armory for the item and seeing if it has a wishlist line.