### PR TITLE
is:collected filter.

### DIFF
--- a/src/app/destiny1/vendors/D1VendorItems.tsx
+++ b/src/app/destiny1/vendors/D1VendorItems.tsx
@@ -1,4 +1,4 @@
-import { ownedItemsSelector } from 'app/inventory/selectors';
+import { accountWideOwnedItemHashesSelector } from 'app/inventory/selectors';
 import _ from 'lodash';
 import { useSelector } from 'react-redux';
 import BungieImage from '../../dim-ui/BungieImage';
@@ -19,7 +19,7 @@ export default function D1VendorItems({
   };
 }) {
   const allCurrencies: { [hash: number]: VendorCost['currency'] } = {};
-  const ownedItemHashes = useSelector(ownedItemsSelector);
+  const ownedItemHashes = useSelector(accountWideOwnedItemHashesSelector);
 
   for (const saleItem of vendor.allItems) {
     for (const cost of saleItem.costs) {
@@ -52,7 +52,7 @@ export default function D1VendorItems({
                 <D1VendorItem
                   key={item.index}
                   saleItem={item}
-                  owned={ownedItemHashes.accountWideOwned.has(item.item.hash)}
+                  owned={ownedItemHashes.has(item.item.hash)}
                   totalCoins={totalCoins}
                 />
               ))}

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -4,6 +4,7 @@ import {
   DestinyAmmunitionType,
   DestinyBreakerTypeDefinition,
   DestinyClass,
+  DestinyCollectibleState,
   DestinyDamageTypeDefinition,
   DestinyDisplayPropertiesDefinition,
   DestinyInventoryItemDefinition,
@@ -136,6 +137,7 @@ export interface DimItem {
   /** Localized string for where this item comes from... or other stuff like it not being recoverable from collections */
   displaySource?: string;
   collectibleHash?: number;
+  collectibleState?: DestinyCollectibleState;
   // TODO: pull search-only fields out
   /** The DestinyCollectibleDefinition sourceHash for a specific item (D2). Derived entirely from collectibleHash */
   source?: number;

--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -241,6 +241,11 @@ export const ownedItemsSelector = createSelector(allItemsSelector, (allItems) =>
   return { accountWideOwned, storeSpecificOwned };
 });
 
+export const accountWideOwnedItemHashesSelector = createSelector(
+  ownedItemsSelector,
+  (ownedItems) => ownedItems.accountWideOwned,
+);
+
 /**
  * Sets containing all the hashes of owned uncollectible plug items,
  * e.g. emotes and ghost projections. These plug items do not appear
@@ -263,10 +268,12 @@ export const ownedUncollectiblePlugsSelector = createSelector(
       ) => {
         for (const [plugSetHash_, plugSet] of Object.entries(plugs)) {
           const plugSetHash = parseInt(plugSetHash_, 10);
-          filterUnlockedPlugs(plugSetHash, plugSet, insertInto, (plug) => {
-            const def = defs.InventoryItem.get(plug.plugItemHash);
-            return !def || !collectibleFinder(def);
-          });
+          filterUnlockedPlugs(
+            plugSetHash,
+            plugSet,
+            insertInto,
+            (plug) => !collectibleFinder(plug.plugItemHash),
+          );
         }
       };
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -413,7 +413,7 @@ export function makeItem(
     itemDef.iconWatermarkShelved ||
     undefined;
 
-  const collectible = createCollectibleFinder(defs)(itemDef);
+  const collectible = createCollectibleFinder(defs)(item.itemHash);
   // Do we need this now?
   const source = collectible?.sourceHash;
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -2,6 +2,7 @@ import { CustomStatDef } from '@destinyitemmanager/dim-api-types';
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { t } from 'app/i18next-t';
 import { createCollectibleFinder } from 'app/records/collectible-matching';
+import { getCollectibleState } from 'app/records/presentation-nodes';
 import {
   D2ItemTiers,
   SOME_OTHER_DUMMY_BUCKET,
@@ -414,6 +415,7 @@ export function makeItem(
     undefined;
 
   const collectible = createCollectibleFinder(defs)(item.itemHash);
+  const collectibleState = collectible && getCollectibleState(collectible, profileResponse);
   // Do we need this now?
   const source = collectible?.sourceHash;
 
@@ -515,6 +517,7 @@ export function makeItem(
     ammoType: itemDef.equippingBlock ? itemDef.equippingBlock.ammoType : DestinyAmmunitionType.None,
     source,
     collectibleHash: collectible?.hash,
+    collectibleState,
     missingSockets: false,
     displaySource: itemDef.displaySource,
     plug: itemDef.plug && {

--- a/src/app/records/Collectible.tsx
+++ b/src/app/records/Collectible.tsx
@@ -2,12 +2,13 @@ import { VendorItemDisplay } from 'app/vendors/VendorItemComponent';
 import { DestinyCollectibleState } from 'bungie-api-ts/destiny2';
 import { DimCollectible } from './presentation-nodes';
 
-interface Props {
+export default function Collectible({
+  collectible,
+  owned,
+}: {
   collectible: DimCollectible;
   owned: boolean;
-}
-
-export default function Collectible({ collectible, owned }: Props) {
+}) {
   const { state, item } = collectible;
   const acquired = !(state & DestinyCollectibleState.NotAcquired);
 

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -17,8 +17,8 @@ import { useSearchParams } from 'react-router-dom';
 import { DestinyAccount } from '../accounts/destiny-account';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
 import {
+  accountWideOwnedItemHashesSelector,
   bucketsSelector,
-  ownedItemsSelector,
   profileResponseSelector,
 } from '../inventory/selectors';
 import { UNIVERSAL_ORNAMENTS_NODE } from '../search/d2-known-values';
@@ -42,7 +42,7 @@ export default function Records({ account }: Props) {
     ? parseInt(searchParams.get('presentationNodeHash')!, 10)
     : undefined;
   const buckets = useSelector(bucketsSelector);
-  const ownedItemHashes = useSelector(ownedItemsSelector);
+  const ownedItemHashes = useSelector(accountWideOwnedItemHashesSelector);
   const profileResponse = useSelector(profileResponseSelector);
   const searchQuery = useSelector(querySelector);
   const searchFilter = useSelector(searchFilterSelector);
@@ -166,7 +166,7 @@ export default function Records({ account }: Props) {
                   <PresentationNodeRoot
                     presentationNodeHash={nodeDef.hash}
                     profileResponse={profileResponse}
-                    ownedItemHashes={ownedItemHashes.accountWideOwned}
+                    ownedItemHashes={ownedItemHashes}
                     openedPresentationHash={presentationNodeHash}
                     searchQuery={searchQuery}
                     searchFilter={searchFilter}

--- a/src/app/records/collectible-matching.ts
+++ b/src/app/records/collectible-matching.ts
@@ -3,7 +3,6 @@ import { ARMOR_NODE } from 'app/search/d2-known-values';
 import {
   DestinyClass,
   DestinyCollectibleDefinition,
-  DestinyInventoryItemDefinition,
   DestinyPresentationNodeDefinition,
 } from 'bungie-api-ts/destiny2';
 import focusingItemOutputs from 'data/d2/focusing-item-outputs.json';
@@ -70,17 +69,17 @@ export const createCollectibleFinder = memoizeOne((defs: D2ManifestDefinitions) 
   });
 
   return (
-    itemDef: DestinyInventoryItemDefinition,
+    originalItemHash: number,
     knownClassType?: DestinyClass,
   ): DestinyCollectibleDefinition | undefined => {
-    const cacheEntry = cache[itemDef.hash];
+    const cacheEntry = cache[originalItemHash];
     if (cacheEntry !== undefined) {
       return cacheEntry ?? undefined;
     }
 
     const collectible = (() => {
       // If this is a fake focusing item, the item we're actually interested in is the output
-      const itemHash = focusingItemOutputs[itemDef.hash] ?? itemDef.hash;
+      const itemHash = focusingItemOutputs[originalItemHash] ?? originalItemHash;
       const outputItemDef = defs.InventoryItem.get(itemHash);
       if (!outputItemDef) {
         return undefined;
@@ -112,7 +111,7 @@ export const createCollectibleFinder = memoizeOne((defs: D2ManifestDefinitions) 
       }
     })();
 
-    cache[itemDef.hash] = collectible ?? null;
+    cache[originalItemHash] = collectible ?? null;
     return collectible;
   };
 });

--- a/src/app/records/universal-ornaments/universal-ornaments.ts
+++ b/src/app/records/universal-ornaments/universal-ornaments.ts
@@ -187,7 +187,7 @@ export const buildSets = memoizeOne((defs: D2ManifestDefinitions): OrnamentsData
               data[classType].sets[key].name = item.displayProperties.name;
             }
           } else {
-            const node = findCollectibleArmorParentNode(collectibleFinder(item, classType));
+            const node = findCollectibleArmorParentNode(collectibleFinder(item.hash, classType));
             if (node) {
               // Some sets will be mapped to the same presentation node - find things that are categorically different
               // 1. whether the plug is a proper armor piece too, or just a modification

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -14,6 +14,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "chest",
   "class",
   "classitem",
+  "collected",
   "common",
   "consumables",
   "cosmetic",

--- a/src/app/search/items/search-filters/known-values.ts
+++ b/src/app/search/items/search-filters/known-values.ts
@@ -17,6 +17,7 @@ import {
   DamageType,
   DestinyAmmunitionType,
   DestinyClass,
+  DestinyCollectibleState,
   DestinyRecordState,
 } from 'bungie-api-ts/destiny2';
 import { D2EventEnum, D2EventInfo } from 'data/d2/d2-event-info-v2';
@@ -297,6 +298,14 @@ const knownValuesFilters: ItemFilterDefinition[] = [
       const outputValues = Object.values(focusingOutputs);
       return (item) => outputValues.includes(item.hash);
     },
+  },
+  {
+    keywords: 'collected',
+    description: tl('Filter.Focusable'),
+    destinyVersion: 2,
+    filter: () => (item) =>
+      item.collectibleState !== undefined &&
+      !(item.collectibleState & DestinyCollectibleState.NotAcquired),
   },
 ];
 

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -97,7 +97,12 @@ function makeVendorItem(
     originalCategoryIndex: vendorItemDef?.originalCategoryIndex,
     costs: saleItem?.costs || [],
     previewVendorHash: inventoryItem.preview?.previewVendorHash,
-    acquired: getCollectibleState(context.defs, itemHash, profileResponse, characterId),
+    collectibleState: getCollectibleState(
+      context.defs,
+      inventoryItem,
+      profileResponse,
+      characterId,
+    ),
     item: makeFakeItem(context, itemHash, {
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       itemInstanceId: vendorItemIndex.toString(),

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -97,12 +97,7 @@ function makeVendorItem(
     originalCategoryIndex: vendorItemDef?.originalCategoryIndex,
     costs: saleItem?.costs || [],
     previewVendorHash: inventoryItem.preview?.previewVendorHash,
-    collectibleState: getCollectibleState(
-      context.defs,
-      inventoryItem,
-      profileResponse,
-      characterId,
-    ),
+    acquired: getCollectibleState(context.defs, itemHash, profileResponse, characterId),
     item: makeFakeItem(context, itemHash, {
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       itemInstanceId: vendorItemIndex.toString(),

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -5,7 +5,6 @@ import { emptyArray } from 'app/utils/empty';
 import {
   DestinyCollectibleState,
   DestinyDisplayPropertiesDefinition,
-  DestinyInventoryItemDefinition,
   DestinyItemQuantity,
   DestinyProfileResponse,
   DestinyVendorDefinition,
@@ -47,12 +46,12 @@ export interface VendorItem {
  */
 function getCollectibleState(
   defs: D2ManifestDefinitions,
-  inventoryItem: DestinyInventoryItemDefinition,
+  itemHash: number,
   profileResponse: DestinyProfileResponse | undefined,
   characterId: string,
 ) {
   const collectibleFinder = createCollectibleFinder(defs);
-  const collectibleHash = collectibleFinder(inventoryItem)?.hash;
+  const collectibleHash = collectibleFinder(itemHash)?.hash;
   let collectibleState: DestinyCollectibleState | undefined;
   if (collectibleHash) {
     collectibleState =
@@ -97,12 +96,7 @@ function makeVendorItem(
     originalCategoryIndex: vendorItemDef?.originalCategoryIndex,
     costs: saleItem?.costs || [],
     previewVendorHash: inventoryItem.preview?.previewVendorHash,
-    collectibleState: getCollectibleState(
-      context.defs,
-      inventoryItem,
-      profileResponse,
-      characterId,
-    ),
+    collectibleState: getCollectibleState(context.defs, itemHash, profileResponse, characterId),
     item: makeFakeItem(context, itemHash, {
       // For sale items the item ID needs to be the vendor item index, since that's how we look up item components for perks
       itemInstanceId: vendorItemIndex.toString(),


### PR DESCRIPTION
Fixes #10404.

Not sure how useful this is, because the collections data isn't the cleanest. But it does more or less allow you to filter the records page down to what you haven't got. `is:uncollected` may actually be nicer?