### PR TITLE
Highlight currently active filter in Compare

### DIFF
--- a/src/app/compare/CompareSuggestions.tsx
+++ b/src/app/compare/CompareSuggestions.tsx
@@ -1,9 +1,11 @@
 import { DimItem } from 'app/inventory/item-types';
 import { filterFactorySelector } from 'app/search/items/item-search-filter';
+import { canonicalizeQuery, parseQuery } from 'app/search/query-parser';
+import clsx from 'clsx';
 import { memo } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultComparisons, findSimilarArmors, findSimilarWeapons } from './compare-buttons';
-import { compareCategoryItemsSelector } from './selectors';
+import { compareCategoryItemsSelector, compareQuerySelector } from './selectors';
 
 /**
  * Display a row of buttons that suggest alternate queries based on an example item.
@@ -15,6 +17,7 @@ export default memo(function CompareSuggestions({
   exampleItem: DimItem;
   onQueryChanged: (query: string) => void;
 }) {
+  const currentQuery = useSelector(compareQuerySelector);
   const categoryItems = useSelector(compareCategoryItemsSelector);
   const filterFactory = useSelector(filterFactorySelector);
 
@@ -64,13 +67,18 @@ export default memo(function CompareSuggestions({
     return true;
   });
 
+  const parsedQuery = currentQuery && canonicalizeQuery(parseQuery(currentQuery));
+
   return (
     <>
       {filteredCompareButtons.map(({ query, items, buttonLabel }) => (
         <button
           key={query}
           type="button"
-          className="dim-button"
+          className={clsx('dim-button', {
+            selected:
+              parsedQuery !== undefined && canonicalizeQuery(parseQuery(query)) === parsedQuery,
+          })}
           title={query}
           onClick={() => onQueryChanged(query)}
         >

--- a/src/app/compare/selectors.ts
+++ b/src/app/compare/selectors.ts
@@ -15,6 +15,8 @@ import { createSelector } from 'reselect';
  */
 export const compareSessionSelector = (state: RootState) => state.compare.session;
 
+export const compareQuerySelector = (state: RootState) => compareSessionSelector(state)?.query;
+
 export const compareOpenSelector = (state: RootState) => Boolean(compareSessionSelector(state));
 
 /**


### PR DESCRIPTION
This is something I've wanted for a bit, and it was pretty simple. Basically, if the current search in Compare matches one of the buttons, the button is highlighted. Now it's easy to see which filter you have active.

<img width="852" alt="Screenshot 2024-06-20 at 10 39 03 PM" src="https://github.com/DestinyItemManager/DIM/assets/313208/120e4fde-e4fd-485f-af5a-2f1264ea5f61">
