### PR TITLE
Rate limit on arrival rate

### DIFF
--- a/src/app/bungie-api/rate-limit-config.ts
+++ b/src/app/bungie-api/rate-limit-config.ts
@@ -65,4 +65,10 @@ export default function setupRateLimiter() {
       1000,
     ),
   );
+  addLimiter(
+    new RateLimiterQueue(
+      /www\.bungie\.net\/Platform\/Destiny2\/\d+\/Profile\/\d+\/Character\/\d+\/Vendors\/\d+\//,
+      100,
+    ),
+  );
 }

--- a/src/app/bungie-api/rate-limiter.ts
+++ b/src/app/bungie-api/rate-limiter.ts
@@ -71,11 +71,11 @@ export class RateLimiterQueue {
       if (this.canProcess()) {
         const config = this.queue.shift()!;
         this.count++;
+        this.lastRequestTime = window.performance.now();
         config
           .fetcher(config.request, config.options)
           .finally(() => {
             this.count--;
-            this.lastRequestTime = window.performance.now();
             this.processQueue();
           })
           .then(config.resolver, config.rejecter);

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -111,28 +111,38 @@ export function loadAllVendors(
       );
 
       const vendorResponses: [vendorHash: number, DestinyVendorResponse][] = [];
+      const promises: Promise<void>[] = [];
       for (const vendorHash of vendorsNeedingComponents) {
-        try {
-          start = Date.now();
-          const vendorResponse = await getVendorSaleComponents(account, characterId, vendorHash);
-          timings.componentsTime += Date.now() - start;
-          timings.componentsFetched++;
-          if (isVendorsPage) {
-            dispatch(
-              loadedVendorComponents({
-                vendorResponses: [[vendorHash, vendorResponse]],
+        promises.push(
+          (async () => {
+            try {
+              start = Date.now();
+              const vendorResponse = await getVendorSaleComponents(
+                account,
                 characterId,
-              }),
-            );
-          } else {
-            vendorResponses.push([vendorHash, vendorResponse]);
-          }
-        } catch {
-          // TO-DO: what to do here if a single vendor component call fails?
-          // not necessarily knock the overall vendors state into error mode.
-          // maybe retry failed single-vendors later? add them to a new list in vendors state?
-        }
+                vendorHash,
+              );
+              timings.componentsTime += Date.now() - start;
+              timings.componentsFetched++;
+              if (isVendorsPage) {
+                dispatch(
+                  loadedVendorComponents({
+                    vendorResponses: [[vendorHash, vendorResponse]],
+                    characterId,
+                  }),
+                );
+              } else {
+                vendorResponses.push([vendorHash, vendorResponse]);
+              }
+            } catch {
+              // TO-DO: what to do here if a single vendor component call fails?
+              // not necessarily knock the overall vendors state into error mode.
+              // maybe retry failed single-vendors later? add them to a new list in vendors state?
+            }
+          })(),
+        );
       }
+      await Promise.all(promises);
       if (!isVendorsPage) {
         dispatch(loadedVendorComponents({ vendorResponses, characterId }));
       }


### PR DESCRIPTION
@nev-r mentioned that we ought to try rate limiting on request arrival rate, rather than request completion rate. This does that, and anecdotally it's *much* snappier. I still get a lot of random pauses, and I can't tell if that's us being throttled or just the API being generally slow still.

I also parallelized (and rate-limited) the vendors fetch while I was at it.