### PR TITLE
Update wishListGuideLink

### DIFF
--- a/src/app/shell/links.ts
+++ b/src/app/shell/links.ts
@@ -5,7 +5,7 @@ export const dimHelpMastodonLink = 'https://mstdn.games/@ThisIsDIM';
 export const discordLink = 'https://discord.gg/UK2GWC7';
 export const userGuideLink = 'https://guide.dim.gg';
 export const wishListGuideLink =
-  'https://github.com/DestinyItemManager/DIM/blob/master/docs/COMMUNITY_CURATIONS.md';
+  'https://github.com/DestinyItemManager/DIM/wiki/Creating-Wish-Lists';
 
 export const dimMastodonAccount = '@ThisIsDIM@mstdn.games';
 export const bungieHelpAccount = '@BungieHelp';


### PR DESCRIPTION
The page moved, so updating to the correct page instead of a redirect.

Was linking to https://github.com/DestinyItemManager/DIM/blob/master/docs/COMMUNITY_CURATIONS.md (deprecated)

Now links to https://github.com/DestinyItemManager/DIM/wiki/Creating-Wish-Lists