### PR TITLE
Show Intrinsic for randomized-intrinsic weapons in Item Feed (Ergo Sum, crafted intrinsics)

### DIFF
--- a/src/app/item-feed/Highlights.tsx
+++ b/src/app/item-feed/Highlights.tsx
@@ -7,6 +7,7 @@ import { DimPlugTooltip } from 'app/item-popup/PlugTooltip';
 import {
   getExtraIntrinsicPerkSockets,
   getWeaponArchetype,
+  socketContainsIntrinsicPlug,
   socketContainsPlugWithCategory,
 } from 'app/utils/socket-utils';
 import clsx from 'clsx';
@@ -21,7 +22,10 @@ export default function Highlights({ item }: { item: DimItem }) {
   if (item.bucket.sort === 'Weapons' && item.sockets) {
     // Don't ask me why Traits are called "Frames" but it does work.
     const perkSockets = item.sockets.allSockets.filter(
-      (s) => s.isPerk && socketContainsPlugWithCategory(s, PlugCategoryHashes.Frames),
+      (s) =>
+        s.isPerk &&
+        (socketContainsPlugWithCategory(s, PlugCategoryHashes.Frames) ||
+          (s.hasRandomizedPlugItems && socketContainsIntrinsicPlug(s))),
     );
     const archetype = !item.isExotic && getWeaponArchetype(item)?.displayProperties.name;
 


### PR DESCRIPTION
This is mainly for Ergo Sum, but also has the side effect of showing the intrinsic level for crafted exotics. I don't think the latter is something we necessarily need to hide in the item feed.

I could not find any other examples of guns that mistakenly got perks displayed in the feed as a result of this.

<img width="250" alt="Screenshot 2024-06-25 at 5 43 10 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/2a0c7423-58f4-4ad7-8748-5abed35c82a6">
<img width="254" alt="Screenshot 2024-06-25 at 5 43 32 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/1687642c-d9ca-4413-a112-c3c77f470f84">
