### PR TITLE
Revert wishlistable change, add is:wishlistable search

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -347,6 +347,7 @@
     "WishlistDupe": "Shows duplicate items where at least one of the duplicates is on your wish list.",
     "WishlistNotes": "Shows wish listed items whose notes match the search.",
     "WishlistUnknown": "Shows items with no roll recommendations in the loaded wish lists.",
+    "WishlistEnabled": "Shows items that are eligible to have wish list rolls.",
     "Year": "Shows items from which year of Destiny they appeared in."
   },
   "General": {

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -251,7 +251,9 @@ export default function Armory({
           <ItemGrid items={storeItems} noLink />
         </>
       )}
-      <AllWishlistRolls item={item} realAvailablePlugHashes={realAvailablePlugHashes} />
+      {item.wishListEnabled && (
+        <AllWishlistRolls item={item} realAvailablePlugHashes={realAvailablePlugHashes} />
+      )}
     </div>
   );
 }

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -577,7 +577,9 @@ export function makeItem(
   }
 
   createdItem.wishListEnabled = Boolean(
-    createdItem.sockets?.allSockets.some((s) => s.hasRandomizedPlugItems),
+    createdItem.sockets &&
+      (createdItem.bucket.inWeapons ||
+        (createdItem.bucket.hash === BucketHashes.ClassArmor && createdItem.isExotic)),
   );
 
   // Extract weapon crafting info from the crafted socket but

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -82,7 +82,7 @@ export function TriageTabToggle({ tabActive, item }: { tabActive: boolean; item:
 export function ItemTriage({ item, id }: { item: DimItem; id: string }) {
   return (
     <div id={id} role="tabpanel" aria-labelledby={`${id}-tab`} className={styles.itemTriagePane}>
-      {item.bucket.inWeapons && <WishlistTriageSection item={item} />}
+      {item.wishListEnabled && <WishlistTriageSection item={item} />}
       <LoadoutsTriageSection item={item} />
       <SimilarItemsTriageSection item={item} />
       {item.bucket.inArmor && item.bucket.hash !== BucketHashes.ClassArmor && (

--- a/src/app/search/items/search-filters/wishlist.ts
+++ b/src/app/search/items/search-filters/wishlist.ts
@@ -66,6 +66,12 @@ const wishlistFilters: ItemFilterDefinition[] = [
       (item) =>
         !wishListsByHash.has(item.hash),
   },
+  {
+    keywords: 'wishlistable',
+    destinyVersion: 2,
+    description: tl('Filter.WishlistEnabled'),
+    filter: () => (item) => item.wishListEnabled,
+  },
 ];
 
 export default wishlistFilters;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -333,6 +333,7 @@
     "WeaponType": "Shows weapons based on their weapon type.",
     "Wishlist": "Shows items that match your wish list.",
     "WishlistDupe": "Shows duplicate items where at least one of the duplicates is on your wish list.",
+    "WishlistEnabled": "Shows items that are eligible to have wish list rolls.",
     "WishlistNotes": "Shows wish listed items whose notes match the search.",
     "WishlistUnknown": "Shows items with no roll recommendations in the loaded wish lists.",
     "Year": "Shows items from which year of Destiny they appeared in."


### PR DESCRIPTION
1. Reverts #10583, now all weapons are wishlistable regardless of whether they have random rolls or perk options.
2. Manually adds exotic class items as wishlistable.
3. Hide wish list rolls if an item isn't wishlistable (just in case).
4. Add an `is:wishlistable` search so I can better visualize what it's matching.