### PR TITLE
Fix alignment for multiperk vs not-multiperk divs

### DIFF
--- a/src/app/item-feed/Highlights.m.scss
+++ b/src/app/item-feed/Highlights.m.scss
@@ -16,7 +16,13 @@
     margin-left: -3px;
     padding-left: 4px;
   }
+
+  .multiPerk {
+    border-left: 2px solid #888;
+    padding-left: 2px;
+  }
 }
+
 .perk {
   display: flex;
   flex-direction: row;
@@ -28,10 +34,6 @@
     width: 24px;
     margin-left: -1px;
   }
-}
-.multiPerk {
-  border-left: 2px solid #888;
-  padding-left: 2px;
 }
 
 .stats {


### PR DESCRIPTION
Regression from #10616 
Bugged:
<img width="249" alt="Screenshot 2024-06-29 at 1 45 52 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/4366ddca-0a47-4202-b897-340d05518535">

Fixed:
<img width="248" alt="Screenshot 2024-06-29 at 1 45 31 AM" src="https://github.com/DestinyItemManager/DIM/assets/2764675/702871fc-e5da-4756-a78a-c37f69debe03">
