### PR TITLE
color for prismatic symbol

### DIFF
--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -21,6 +21,7 @@ $solar: #f0631e;
 $void: #8e749e;
 $stasis: #4d88ff;
 $strand: #35e366;
+$prismatic: #e3619b;
 
 // Item rarities
 $common: #dcdcdc;

--- a/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.m.scss
+++ b/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.m.scss
@@ -19,3 +19,7 @@
 .strand {
   color: $strand;
 }
+
+.prismatic {
+  color: $prismatic;
+}

--- a/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.m.scss.d.ts
+++ b/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.m.scss.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'arc': string;
+  'prismatic': string;
   'stasis': string;
   'strand': string;
   'thermal': string;

--- a/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.tsx
+++ b/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.tsx
@@ -2,7 +2,7 @@ import { FontGlyphs } from 'data/font/d2-font-glyphs';
 import { DimCustomSymbols } from 'data/font/dim-custom-symbols';
 import styles from './ColorDestinySymbols.m.scss';
 
-const iconPlaceholder = /([\uE000-\uF8FF])/g;
+const iconPlaceholder = /([\uE000-\uF8FF\u{F0000}-\u{F1000}])/gu;
 
 const styleTable = {
   [String.fromCodePoint(FontGlyphs.thermal)]: styles.thermal,

--- a/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.tsx
+++ b/src/app/dim-ui/destiny-symbols/ColorDestinySymbols.tsx
@@ -1,4 +1,5 @@
 import { FontGlyphs } from 'data/font/d2-font-glyphs';
+import { DimCustomSymbols } from 'data/font/dim-custom-symbols';
 import styles from './ColorDestinySymbols.m.scss';
 
 const iconPlaceholder = /([\uE000-\uF8FF])/g;
@@ -9,6 +10,7 @@ const styleTable = {
   [String.fromCodePoint(FontGlyphs.void)]: styles.void,
   [String.fromCodePoint(FontGlyphs.stasis)]: styles.stasis,
   [String.fromCodePoint(FontGlyphs.strand_kill)]: styles.strand,
+  [String.fromCodePoint(DimCustomSymbols.prismatic)]: styles.prismatic,
 };
 
 export default function ColorDestinySymbols({


### PR DESCRIPTION
this adds the color for the prismatic icon like the other "element" icons but only partially. It works in filter pills and the preview in the icon picker but no where else. I think something needs to change in RichDestinyText to get the other places working but I can't figure it out. if anyone else wants to take a look I'd appreciate it. 

![image](https://github.com/DestinyItemManager/DIM/assets/29002828/52b81490-f572-461b-9469-8985bbc80def)
