### PR TITLE
reverse flex direction so pathfinder matches the game layout

### DIFF
--- a/src/app/progress/Pathfinder.m.scss
+++ b/src/app/progress/Pathfinder.m.scss
@@ -18,6 +18,7 @@
   box-sizing: border-box;
   gap: 8px;
   flex: 1;
+  flex-direction: column-reverse;
   justify-content: center;
   max-width: 250px;
   min-width: 120px;


### PR DESCRIPTION
this fixes the order of the pathfinders in DIM to match the game. 

game
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/4360f8bf-5e54-4a25-b216-ac0cae85af6b)

before
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/25b8398a-6e4d-4999-8bed-4229b54f930d)

after
![image](https://github.com/DestinyItemManager/DIM/assets/29002828/97266799-91a5-491f-8685-d67fb0de93e0)
