### PR TITLE
removes uppercase in side menus

### DIFF
--- a/src/app/dim-ui/PageWithMenu.m.scss
+++ b/src/app/dim-ui/PageWithMenu.m.scss
@@ -97,7 +97,7 @@
 .menuHeader {
   margin-bottom: 4px;
   padding-bottom: 1px;
-  margin-top: 8px;
+  margin-top: 20px;
   letter-spacing: 1px;
   text-transform: uppercase;
   border-bottom: 0.5px solid #666;
@@ -133,7 +133,6 @@
   > span:not(:global(.app-icon)) {
     flex: 1;
     display: block;
-    text-transform: uppercase;
     letter-spacing: 1px;
   }
 }


### PR DESCRIPTION
this removes the uppercase transform from the side menus. there was a suggestion on discord for this and TBH all caps is harder to parse and there are a lot in those side menus. This applies to all pages with side menus, including loadouts, and yes i added empty-space on the vendor sections. 

BEFORE: 
![image](https://github.com/user-attachments/assets/aaa8f7f5-38d9-4b65-b848-34a6e4273213)


After:
![image](https://github.com/user-attachments/assets/0f596626-9110-4c6c-8cb8-ef0a0b850392)
