### PR TITLE
Re-add Xûr vendor armor to LO

### DIFF
--- a/src/app/loadout-builder/loadout-builder-vendors.ts
+++ b/src/app/loadout-builder/loadout-builder-vendors.ts
@@ -20,6 +20,7 @@ const allowedVendorHashes = [
   VendorHashes.DevrimKay,
   VendorHashes.Failsafe,
   VendorHashes.RivensWishesExotics,
+  VendorHashes.XurLegendaryItems,
 ];
 
 export const loVendorItemsSelector = currySelector(

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -247,6 +247,7 @@ export const enum VendorHashes {
   DevrimKay = 396892126,
   Failsafe = 1576276905,
   RivensWishesExotics = 2388521577,
+  XurLegendaryItems = 3751514131, // Vendor "Strange Gear Offers"
 }
 
 /** used to snag the icon for display */


### PR DESCRIPTION
Final Shape reorganized some things so we were using the exotics but not the legendary armor.