### PR TITLE
For character-to-character (multistep) transfers, ensure each step has space before executing that step

### DIFF
--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1037,7 +1037,7 @@ export function executeMoveItem(
         // make sure the vault has space before trying to vault the item
         await dispatch(
           ensureValidTransfer(
-            equip,
+            false,
             getVault(getStores())!,
             item,
             amount,

--- a/src/app/inventory/item-move-service.ts
+++ b/src/app/inventory/item-move-service.ts
@@ -1003,13 +1003,15 @@ export function executeMoveItem(
       }
     }
 
-    await dispatch(
-      ensureValidTransfer(equip, target, item, amount, excludes, reservations, session),
-    );
-
-    // Replace the target store - ensureValidTransfer may have reloaded it
-    target = getStore(getStores(), target.id)!;
-    source = getStore(getStores(), item.owner)!;
+    // for any case that's not char-to-char, we can free up space ahead of time
+    if (source.isVault || target.isVault || source.id === target.id || item.bucket.accountWide) {
+      await dispatch(
+        ensureValidTransfer(equip, target, item, amount, excludes, reservations, session),
+      );
+      // Replace the target store - ensureValidTransfer may have reloaded it
+      target = getStore(getStores(), target.id)!;
+      source = getStore(getStores(), item.owner)!;
+    }
 
     // Get from postmaster first
     if (item.location.inPostmaster) {
@@ -1031,7 +1033,29 @@ export function executeMoveItem(
         if (item.equipped) {
           item = await dispatch(dequipItem(item, session));
         }
+        // for char to char, two moves are required: char to vault then vault to char
+        // make sure the vault has space before trying to vault the item
+        await dispatch(
+          ensureValidTransfer(
+            equip,
+            getVault(getStores())!,
+            item,
+            amount,
+            excludes,
+            reservations,
+            session,
+          ),
+        );
+        target = getStore(getStores(), target.id)!;
+        source = getStore(getStores(), item.owner)!;
         item = await dispatch(moveToVault(item, amount, session));
+
+        // now make sure the target char has space before trying to unvault the item
+        await dispatch(
+          ensureValidTransfer(equip, target, item, amount, excludes, reservations, session),
+        );
+        target = getStore(getStores(), target.id)!;
+        source = getStore(getStores(), item.owner)!;
         item = await dispatch(moveToStore(item, target, equip, amount, session));
       }
       if (equip && !item.equipped) {


### PR DESCRIPTION
For step 1 (char to vault), ensure vault has space.
Then, for step 2 (vault to char), ensure the destination char has space.
For users with decently-free vault space this shouldn't affect behavior at all.
For users with overflowing vaults this will still allow items to be transferred cleanly as long as there's at least one open inventory slot. It will move an item to a character to free up a vault slot, move the desired item to the vault, then fill the newly empty slot on the source character with an arbitrary item, then move another item from the dest char to vault to free up a slot, then finally move the desired item to the dest char.

Caveat: if the open inventory slot is on the initial source char in the same slot as the item being transferred, this doesn't work out and balks immediately at `ensureValidTransfer(item, VAULT)`. This is also how current DIM behaves, so it's not a regression.

Tested a variety of move scenarios with a 699/700-vault account with 10 items in each character inventory slot.

Let me know of any edge cases you can think of.