### PR TITLE
Handle reverting a bad loadout

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1330,6 +1330,9 @@
     "MenuTitle": "Sync & Backups",
     "ProfileErrorTitle": "DIM Sync Download Error",
     "ProfileErrorBody": "We had a problem communicating with DIM Sync. Your latest settings, tags, loadouts, and searches may not be shown. Your data is still on our servers, and any updates you make locally will be saved when we can reconnect. We'll keep retrying while DIM is open.",
+    "UpdateInvalid": "Failed to save data to DIM Sync",
+    "UpdateInvalidBody": "Data sent to DIM Sync was invalid and will not be saved.",
+    "UpdateInvalidBodyLoadout": "The loadout \"{{name}}\" is invalid and will not be saved. If you imported it from another site, please let them know that they are exporting invalid loadouts.",
     "UpdateErrorTitle": "DIM Sync Save Error",
     "UpdateErrorBody": "We had a problem saving your data to DIM Sync. We'll keep retrying while DIM is open.",
     "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device. This includes the downloaded Destiny item databases from Bungie.net."

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -1377,10 +1377,14 @@ function applyUpdateLocally(draft: Draft<DimApiState>, update: ProfileUpdateWith
       break;
     }
     case 'loadout': {
-      const { platformMembershipId, destinyVersion } = update;
+      const { platformMembershipId, destinyVersion, payload: loadout } = update;
       const profileKey = makeProfileKey(platformMembershipId!, destinyVersion!);
-      const loadout = update.payload;
-      ensureProfile(draft, profileKey).loadouts[loadout.id] = update.payload;
+      if (loadout) {
+        ensureProfile(draft, profileKey).loadouts[loadout.id] = update.payload;
+      } else if (update.before?.id) {
+        // This handles the case where we're reversing a create-loadout action.
+        delete ensureProfile(draft, profileKey).loadouts[update.before.id];
+      }
       break;
     }
     case 'track_triumph': {

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -881,8 +881,9 @@ function applyFinishedUpdatesToQueue(state: DimApiState, results: ProfileUpdateR
       reportException('dim sync', new Error('invalid dim api update'), {
         action: update.action,
         status: result.status,
-        update: message,
         message: result.message,
+        update,
+        resultMessage: result.message,
       });
       state = produce(state, (draft) => reverseUpdateLocally(draft, update));
     } else {

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -869,11 +869,13 @@ function applyFinishedUpdatesToQueue(state: DimApiState, results: ProfileUpdateR
       showNotification({
         type: 'error',
         title: t('Storage.UpdateInvalid'),
-        body:
-          (update.action === 'loadout' && update.payload
-            ? t('Storage.UpdateInvalidBodyLoadout', { name: update.payload.name })
-            : t('Storage.UpdateInvalidBody')) +
-          `\n\n${result.status}(${message}): ${result.message}`,
+        body: Number(
+          `${
+            update.action === 'loadout' && update.payload
+              ? t('Storage.UpdateInvalidBodyLoadout', { name: update.payload.name })
+              : t('Storage.UpdateInvalidBody')
+          }\n\n${result.status}(${message}): ${result.message}`,
+        ),
       });
       errorLog('dim sync', update.action, result.status, message, result.message, update);
       reportException('dim sync', new Error('invalid dim api update'), {

--- a/src/app/loadout/loadout-share/loadout-import.ts
+++ b/src/app/loadout/loadout-share/loadout-import.ts
@@ -96,6 +96,7 @@ function preprocessReceivedLoadout(loadout: Loadout): Loadout {
   loadout.items = loadout.items.map((item) => ({
     ...item,
     id: item.id === '0' ? generateMissingLoadoutItemId() : item.id,
+    hash: Number(item.hash),
   }));
 
   return loadout;

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1317,6 +1317,9 @@
     "ProfileErrorTitle": "DIM Sync Download Error",
     "UpdateErrorBody": "We had a problem saving your data to DIM Sync. We'll keep retrying while DIM is open.",
     "UpdateErrorTitle": "DIM Sync Save Error",
+    "UpdateInvalid": "Failed to save data to DIM Sync",
+    "UpdateInvalidBody": "Data sent to DIM Sync was invalid and will not be saved.",
+    "UpdateInvalidBodyLoadout": "The loadout \"{{name}}\" is invalid and will not be saved. If you imported it from another site, please let them know that they are exporting invalid loadouts.",
     "UpdateQueueLength": "{{count}} new change will be saved when we can reconnect.",
     "UpdateQueueLength_plural": "{{count}} new changes will be saved when we can reconnect.",
     "Usage": "DIM is using {{usage, humanBytes}} out of {{quota, humanBytes}} available to it on this device. This includes the downloaded Destiny item databases from Bungie.net."


### PR DESCRIPTION
Fixes DIM-1T95. I think some third party site (d2armorpicker?) is sending strings in the item hash field, and that's blowing up DIM API. When I implemented reverting bad updates, I didn't properly account for the loadout being undefined when reverting - that's fixed, and I also now show a notification when an update is rejected. I also did a little more preprocessing on imported loadouts in the hope that they can be fixed up.