### PR TITLE
Don't save invalid vendor item IDs in loadouts

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -869,13 +869,11 @@ function applyFinishedUpdatesToQueue(state: DimApiState, results: ProfileUpdateR
       showNotification({
         type: 'error',
         title: t('Storage.UpdateInvalid'),
-        body: Number(
-          `${
-            update.action === 'loadout' && update.payload
-              ? t('Storage.UpdateInvalidBodyLoadout', { name: update.payload.name })
-              : t('Storage.UpdateInvalidBody')
-          }\n\n${result.status}(${message}): ${result.message}`,
-        ),
+        body: `${
+          update.action === 'loadout' && update.payload
+            ? t('Storage.UpdateInvalidBodyLoadout', { name: update.payload.name })
+            : t('Storage.UpdateInvalidBody')
+        }\n\n${result.status}(${message}): ${result.message}`,
       });
       errorLog('dim sync', update.action, result.status, message, result.message, update);
       reportException('dim sync', new Error('invalid dim api update'), {

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -152,7 +152,7 @@ const lbConfigInit = ({
   const storeMatchingClass = pickBackingStore(stores, storeId, classTypeFromPreloadedLoadout);
   const initialLoadoutParameters = preloadedLoadout?.parameters;
 
-  const isEditingExistingLoadout = Boolean(preloadedLoadout);
+  const isEditingExistingLoadout = Boolean(preloadedLoadout && preloadedLoadout.id !== 'equipped');
 
   // If we requested a specific class type but the user doesn't have it, we
   // need to pick some different store, but ensure that class-specific stuff

--- a/src/app/loadout/loadout-type-converters.ts
+++ b/src/app/loadout/loadout-type-converters.ts
@@ -49,7 +49,12 @@ function convertDimLoadoutItemToLoadoutItem(item: DimLoadoutItem): LoadoutItem {
   const result: LoadoutItem = {
     hash: item.hash,
   };
-  if (item.id && item.id !== '0') {
+  if (
+    item.id &&
+    item.id !== '0' &&
+    // Vendor items have an invalid item ID
+    !item.id.includes('-')
+  ) {
     result.id = item.id;
   }
   if (item.amount > 1) {


### PR DESCRIPTION
1. Something weird happened (copilot) that wrapped my error message in `Number`
2. We shouldn't consider the Equipped loadout to be an existing loadout for the purpose of LO
3. Vendor item IDs shouldn't be included in loadouts.