### PR TITLE
Fix tooltip text, while still hiding it for enhanceable weapons' tooltips

### DIFF
--- a/src/app/dim-ui/DestinyTooltipText.tsx
+++ b/src/app/dim-ui/DestinyTooltipText.tsx
@@ -2,6 +2,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { AppIcon, faClock, shapedIcon } from 'app/shell/icons';
 import { DestinyItemTooltipNotification } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import styles from './DestinyTooltipText.m.scss';
 import RichDestinyText from './destiny-symbols/RichDestinyText';
 
@@ -11,8 +12,9 @@ export function DestinyTooltipText({ item }: { item: DimItem }) {
   }
   return (
     <>
-      {!isDeepsightTooltip &&
-        item.tooltipNotifications.map((tip) => (
+      {item.tooltipNotifications
+        .filter((tip) => !isEnhancementTooltip(item, tip))
+        .map((tip) => (
           <div
             key={tip.displayString}
             className={clsx('quest-expiration item-details', {
@@ -36,6 +38,11 @@ function isPatternTooltip(tip: DestinyItemTooltipNotification) {
   return tip.displayStyle === 'ui_display_style_deepsight';
 }
 
-function isDeepsightTooltip(tip: DestinyItemTooltipNotification) {
-  return tip.displayStyle === 'ui_display_style_info';
+function isEnhancementTooltip(item: DimItem, tip: DestinyItemTooltipNotification) {
+  return (
+    tip.displayStyle === 'ui_display_style_crafting' ||
+    // assume weapons with this tooltip style are non-enhanced weapons offering enhancement
+    (tip.displayStyle === 'ui_display_style_info' &&
+      item.itemCategoryHashes?.includes(ItemCategoryHashes.Weapon))
+  );
 }


### PR DESCRIPTION
Fixes #10594 

Wondering if `!isDeepsightTooltip` ever functioned here or always blocked this from displaying.

I unfortunately don't think I have any items that fulfill the expiration or deepsight cases to check on those.

<img width="411" alt="Screenshot 2024-08-01 at 8 33 42 PM" src="https://github.com/user-attachments/assets/a51145f9-a8d8-4c49-a001-e73424c4ad2d">
