### PR TITLE
Fix Europa theme godroll indicator color and add godroll/archived to item preview on settings page

### DIFF
--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -90,13 +90,16 @@ export default function SettingsPage() {
       !i.deepsightInfo,
   );
   const exampleArmor = allItems.find((i) => i.bucket.sort === 'Armor' && !i.isExotic);
+  const exampleArchivedArmor = allItems.find(
+    (i) => i !== exampleArmor && i.bucket.sort === 'Armor' && !i.isExotic,
+  );
   const godRoll = {
-    wishListPerks: new Set(),
+    wishListPerks: new Set<number>(),
     notes: undefined,
     isUndesirable: false,
   };
   const badRoll = {
-    wishListPerks: new Set(),
+    wishListPerks: new Set<number>(),
     notes: undefined,
     isUndesirable: true,
   };
@@ -332,7 +335,15 @@ export default function SettingsPage() {
                 <InventoryItem
                   item={exampleArmor}
                   isNew={settings.showNewItems}
+                  autoLockTagged={settings.autoLockTagged}
+                />
+              )}
+              {exampleArchivedArmor && (
+                <InventoryItem
+                  item={exampleArchivedArmor}
+                  isNew={settings.showNewItems}
                   tag="archive"
+                  searchHidden={true}
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -69,25 +69,9 @@ export default function SettingsPage() {
   const exampleWeapon = allItems.find(
     (i) => i.bucket.sort === 'Weapons' && !i.isExotic && !i.masterwork && !i.deepsightInfo,
   );
-  const exampleWeaponBad = allItems.find(
-    (i) =>
-      i !== exampleWeapon &&
-      i.bucket.sort === 'Weapons' &&
-      !i.isExotic &&
-      !i.masterwork &&
-      !i.deepsightInfo,
-  );
   // Include a masterworked item because they look different in some themes
   const exampleWeaponMasterworked = allItems.find(
     (i) => i.bucket.sort === 'Weapons' && !i.isExotic && i.masterwork && !i.deepsightInfo,
-  );
-  const exampleWeaponMasterworkedBad = allItems.find(
-    (i) =>
-      i !== exampleWeaponMasterworked &&
-      i.bucket.sort === 'Weapons' &&
-      !i.isExotic &&
-      i.masterwork &&
-      !i.deepsightInfo,
   );
   const exampleArmor = allItems.find((i) => i.bucket.sort === 'Armor' && !i.isExotic);
   const exampleArchivedArmor = allItems.find(
@@ -97,11 +81,6 @@ export default function SettingsPage() {
     wishListPerks: new Set<number>(),
     notes: undefined,
     isUndesirable: false,
-  };
-  const badRoll = {
-    wishListPerks: new Set<number>(),
-    notes: undefined,
-    isUndesirable: true,
   };
 
   const onCheckChange = (checked: boolean, name: keyof Settings) => {
@@ -304,30 +283,12 @@ export default function SettingsPage() {
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}
-              {exampleWeaponBad && (
-                <InventoryItem
-                  item={exampleWeaponBad}
-                  isNew={settings.showNewItems}
-                  tag="infuse"
-                  wishlistRoll={badRoll}
-                  autoLockTagged={settings.autoLockTagged}
-                />
-              )}
               {exampleWeaponMasterworked && (
                 <InventoryItem
                   item={exampleWeaponMasterworked}
                   isNew={settings.showNewItems}
                   tag="favorite"
                   wishlistRoll={godRoll}
-                  autoLockTagged={settings.autoLockTagged}
-                />
-              )}
-              {exampleWeaponMasterworkedBad && (
-                <InventoryItem
-                  item={exampleWeaponMasterworkedBad}
-                  isNew={settings.showNewItems}
-                  tag="junk"
-                  wishlistRoll={badRoll}
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -69,11 +69,37 @@ export default function SettingsPage() {
   const exampleWeapon = allItems.find(
     (i) => i.bucket.sort === 'Weapons' && !i.isExotic && !i.masterwork && !i.deepsightInfo,
   );
+  const exampleWeaponBad = allItems.find(
+    (i) =>
+      i !== exampleWeapon &&
+      i.bucket.sort === 'Weapons' &&
+      !i.isExotic &&
+      !i.masterwork &&
+      !i.deepsightInfo,
+  );
   // Include a masterworked item because they look different in some themes
   const exampleWeaponMasterworked = allItems.find(
     (i) => i.bucket.sort === 'Weapons' && !i.isExotic && i.masterwork && !i.deepsightInfo,
   );
+  const exampleWeaponMasterworkedBad = allItems.find(
+    (i) =>
+      i !== exampleWeaponMasterworked &&
+      i.bucket.sort === 'Weapons' &&
+      !i.isExotic &&
+      i.masterwork &&
+      !i.deepsightInfo,
+  );
   const exampleArmor = allItems.find((i) => i.bucket.sort === 'Armor' && !i.isExotic);
+  const godRoll = {
+    wishListPerks: new Set(),
+    notes: undefined,
+    isUndesirable: false,
+  };
+  const badRoll = {
+    wishListPerks: new Set(),
+    notes: undefined,
+    isUndesirable: true,
+  };
 
   const onCheckChange = (checked: boolean, name: keyof Settings) => {
     if (name.length === 0) {
@@ -270,7 +296,17 @@ export default function SettingsPage() {
                 <InventoryItem
                   item={exampleWeapon}
                   isNew={settings.showNewItems}
-                  tag="favorite"
+                  tag="keep"
+                  wishlistRoll={godRoll}
+                  autoLockTagged={settings.autoLockTagged}
+                />
+              )}
+              {exampleWeaponBad && (
+                <InventoryItem
+                  item={exampleWeaponBad}
+                  isNew={settings.showNewItems}
+                  tag="infuse"
+                  wishlistRoll={badRoll}
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}
@@ -278,7 +314,17 @@ export default function SettingsPage() {
                 <InventoryItem
                   item={exampleWeaponMasterworked}
                   isNew={settings.showNewItems}
-                  tag="keep"
+                  tag="favorite"
+                  wishlistRoll={godRoll}
+                  autoLockTagged={settings.autoLockTagged}
+                />
+              )}
+              {exampleWeaponMasterworkedBad && (
+                <InventoryItem
+                  item={exampleWeaponMasterworkedBad}
+                  isNew={settings.showNewItems}
+                  tag="junk"
+                  wishlistRoll={badRoll}
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}
@@ -286,7 +332,7 @@ export default function SettingsPage() {
                 <InventoryItem
                   item={exampleArmor}
                   isNew={settings.showNewItems}
-                  tag="keep"
+                  tag="archive"
                   autoLockTagged={settings.autoLockTagged}
                 />
               )}

--- a/src/app/themes/_theme-europa.scss
+++ b/src/app/themes/_theme-europa.scss
@@ -71,7 +71,7 @@
   --theme-item-polaroid-masterwork-txt: #000;
   --theme-item-polaroid-capped: #f2a5ce;
   --theme-item-polaroid-capped-txt: #be0a99;
-  --theme-item-polaroid-godroll: white;
+  --theme-item-polaroid-godroll: #0b486b;
   --theme-item-polaroid-trashroll: #d14334;
 
   // Item popup


### PR DESCRIPTION
Fixes #10640 

Only including two mobile screenshots, for Default and Europa themes, as it's a bit redundant to have all of them.

<details>
<summary>Screenshots:</summary>
<img width="507" alt="Screenshot 2024-08-04 at 3 33 12 PM" src="https://github.com/user-attachments/assets/1ff1781e-8461-4bdb-80ee-25d5b8285e42">
<img width="362" alt="Screenshot 2024-08-04 at 3 36 04 PM" src="https://github.com/user-attachments/assets/c30a115e-23b2-4893-8589-50f20fe7709b">
<img width="511" alt="Screenshot 2024-08-04 at 3 33 24 PM" src="https://github.com/user-attachments/assets/c8d55a83-d4e2-4055-846e-997a24938bb9">
<img width="354" alt="Screenshot 2024-08-04 at 3 34 09 PM" src="https://github.com/user-attachments/assets/1fc39d79-d9c4-43ba-9b41-f26e65f4668d">
<img width="499" alt="Screenshot 2024-08-04 at 3 33 16 PM" src="https://github.com/user-attachments/assets/34aff595-84b6-4d62-ba76-27954266d4ff">
<img width="495" alt="Screenshot 2024-08-04 at 3 33 20 PM" src="https://github.com/user-attachments/assets/46edec42-3a2e-4f48-a675-87a7ace038d8">
<img width="504" alt="Screenshot 2024-08-04 at 3 33 29 PM" src="https://github.com/user-attachments/assets/db79b23e-ce9e-428b-8d54-ff48d68bd990">
<img width="499" alt="Screenshot 2024-08-04 at 3 33 33 PM" src="https://github.com/user-attachments/assets/a1e19f57-f2f2-4b87-9b15-3bb0a1530fb3">
<img width="495" alt="Screenshot 2024-08-04 at 3 33 39 PM" src="https://github.com/user-attachments/assets/9a5bf100-432f-45e9-91ea-01ddea89fc61">
<img width="490" alt="Screenshot 2024-08-04 at 3 33 44 PM" src="https://github.com/user-attachments/assets/e7a3ac23-66f1-4b44-bd04-ca2f33f3ada8">

</details>