### PR TITLE
Fixed character sorting on the Loadouts page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed character sorting on the Loadouts page.
+
 ## 8.31.0 <span class="changelog-date">(2024-08-04)</span>
 
 * Improved item move logic to do a better job of making room for transfers between characters.

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -9,7 +9,7 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { VirtualListRef, WindowVirtualList } from 'app/dim-ui/VirtualList';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { t, tl } from 'app/i18next-t';
-import { artifactUnlocksSelector, storesSelector } from 'app/inventory/selectors';
+import { artifactUnlocksSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import {
   MakeLoadoutAnalysisAvailable,
@@ -81,7 +81,7 @@ export default function LoadoutsContainer({ account }: { account: DestinyAccount
 function Loadouts({ account }: { account: DestinyAccount }) {
   const dispatch = useDispatch();
 
-  const stores = useSelector(storesSelector);
+  const stores = useSelector(sortedStoresSelector);
   const selectedStore = useSelector(selectedLoadoutStoreSelector);
 
   const setSelectedStoreId = useCallback(


### PR DESCRIPTION
### Issue
Characters on the Loadouts page are not being sorted according to the preference picked in Settings. 

### Fix
Updated `Loadout` to use `sortedStoresSelector` instead of `storesSelector`.