### PR TITLE
Add exotic class intrinsics to CompareButtons, update dontInvert handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Exotic class item perks will now show up in Compare suggestions
+
 ## 8.33.1 <span class="changelog-date">(2024-08-20)</span>
 
 * Fixed the symbol picker displaying in the wrong part of the screen.

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -43,18 +43,20 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
       filterMap(
         getExtraIntrinsicPerkSockets(exampleItem),
         (s) => s.plugged?.plugDef.displayProperties,
-      )?.map((intrinsic) => ({
-        buttonLabel: [
-          <BungieImage
-            key="1"
-            className={clsx(styles.intrinsicIcon, 'dontInvert')}
-            src={intrinsic.icon}
-          />,
-          intrinsic.name,
-          <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
-        ],
-        query: `is:armor2.0 perk:${quoteFilterString(intrinsic.name)}`,
-      }))) ||
+      )
+        ?.map((intrinsic) => ({
+          buttonLabel: [
+            <BungieImage
+              key="1"
+              className={clsx(styles.intrinsicIcon, 'dontInvert')}
+              src={intrinsic.icon}
+            />,
+            intrinsic.name,
+            <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
+          ],
+          query: `is:armor2.0 perk:${quoteFilterString(intrinsic.name)}`,
+        }))
+        .reverse()) ||
     [];
 
   let comparisonSets: CompareButton[] = _.compact([

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -8,6 +8,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { quoteFilterString } from 'app/search/query-parser';
 import { getInterestingSocketMetadatas, getItemDamageShortName } from 'app/utils/item-utils';
 import { getIntrinsicArmorPerkSocket, getWeaponArchetype } from 'app/utils/socket-utils';
+import clsx from 'clsx';
 import rarityIcons from 'data/d2/engram-rarity-icons.json';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
@@ -51,7 +52,7 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
     exampleItem.destinyVersion === 2 &&
       exampleItem.tier === 'Legendary' && {
         buttonLabel: [
-          <BungieImage key="rarity" src={rarityIcons.Legendary} />,
+          <BungieImage key="rarity" src={rarityIcons.Legendary} className="dontInvert" />,
           <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
         ],
         query: 'is:armor2.0 is:legendary',
@@ -80,7 +81,11 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
       exampleItemIntrinsic && {
         buttonLabel: [
           <PressTip minimal tooltip={exampleItemIntrinsic.name} key="1">
-            <BungieImage key="2" className={styles.intrinsicIcon} src={exampleItemIntrinsic.icon} />
+            <BungieImage
+              key="2"
+              className={clsx(styles.intrinsicIcon, 'dontInvert')}
+              src={exampleItemIntrinsic.icon}
+            />
           </PressTip>,
           <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
         ],
@@ -134,7 +139,7 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
     exampleItem.destinyVersion === 2 &&
       exampleItem.tier === 'Legendary' && {
         buttonLabel: [
-          <BungieImage key="rarity" src={rarityIcons.Legendary} />,
+          <BungieImage key="rarity" src={rarityIcons.Legendary} className="dontInvert" />,
           <WeaponTypeIcon key="type" item={exampleItem} className={styles.svgIcon} />,
         ],
         query: 'is:legendary',

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -6,8 +6,13 @@ import { SpecialtyModSlotIcon } from 'app/dim-ui/SpecialtyModSlotIcon';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import { quoteFilterString } from 'app/search/query-parser';
+import { filterMap } from 'app/utils/collections';
 import { getInterestingSocketMetadatas, getItemDamageShortName } from 'app/utils/item-utils';
-import { getIntrinsicArmorPerkSocket, getWeaponArchetype } from 'app/utils/socket-utils';
+import {
+  getExtraIntrinsicPerkSockets,
+  getIntrinsicArmorPerkSocket,
+  getWeaponArchetype,
+} from 'app/utils/socket-utils';
 import clsx from 'clsx';
 import rarityIcons from 'data/d2/engram-rarity-icons.json';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
@@ -31,6 +36,26 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
   const exampleItemIntrinsic =
     !exampleItem.isExotic &&
     getIntrinsicArmorPerkSocket(exampleItem)?.plugged?.plugDef.displayProperties;
+
+  // exotic class item perks
+  const extraIntrinsicButtons =
+    (exampleItem.destinyVersion === 2 &&
+      filterMap(
+        getExtraIntrinsicPerkSockets(exampleItem),
+        (s) => s.plugged?.plugDef.displayProperties,
+      )?.map((intrinsic) => ({
+        buttonLabel: [
+          <BungieImage
+            key="1"
+            className={clsx(styles.intrinsicIcon, 'dontInvert')}
+            src={intrinsic.icon}
+          />,
+          intrinsic.name,
+          <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,
+        ],
+        query: `is:armor2.0 perk:${quoteFilterString(intrinsic.name)}`,
+      }))) ||
+    [];
 
   let comparisonSets: CompareButton[] = _.compact([
     // same slot on the same class
@@ -91,6 +116,9 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
         ],
         query: `is:armor2.0 perk:${quoteFilterString(exampleItemIntrinsic.name)}`,
       },
+
+    // exotic class items
+    ...extraIntrinsicButtons,
 
     // basically stuff with the same name & categories
     {

--- a/src/app/dim-ui/dim-button.scss
+++ b/src/app/dim-ui/dim-button.scss
@@ -52,7 +52,7 @@
     :hover &,
     :active &,
     .selected & {
-      filter: invert(0) !important;
+      filter: invert(0) drop-shadow(0 0 1px black) !important;
     }
   }
 


### PR DESCRIPTION
Add exotic class item intrinsics to CompareButtons
Add dontInvert to non-monochromatic CompareButtons icons, update dontInvert.selected style with drop shadow

Previous appearance:
<img width="117" alt="Screenshot 2024-08-21 at 5 04 09 AM" src="https://github.com/user-attachments/assets/f58e9bcb-511c-492c-81ae-d32b92cf987d">

Updated appearance:

<img width="529" alt="Screenshot 2024-08-21 at 5 28 12 AM" src="https://github.com/user-attachments/assets/d29b6c89-fe8e-48dc-b668-d6e9ea0bdc4d">
<img width="489" alt="Screenshot 2024-08-21 at 5 28 20 AM" src="https://github.com/user-attachments/assets/30b4b416-67cd-4eeb-b045-fa794bf5afc0">
<img width="259" alt="Screenshot 2024-08-21 at 5 28 34 AM" src="https://github.com/user-attachments/assets/8bb823ed-088a-441d-94dc-4bbb2b14633f">
<img width="105" alt="Screenshot 2024-08-21 at 5 28 38 AM" src="https://github.com/user-attachments/assets/171651aa-5001-4b43-99a2-ad722a80a291">
