### PR TITLE
Use first sorted item in Compare view as 'firstCompareItem' rather than first unsorted item

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Compare view's suggestion buttons will now use the leftmost item's perks instead of an arbitrary item if the initial compare item is removed
+
 ## 8.33.1 <span class="changelog-date">(2024-08-20)</span>
 
 * Fixed the symbol picker displaying in the wrong part of the screen.

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -159,15 +159,7 @@ export default function Compare({ session }: { session: CompareSession }) {
     setSortBetterFirst(sortedHash === newSortedHash ? !sortBetterFirst : true);
   };
 
-  // If the session was started with a specific item, this is it
-  const initialItem = session.initialItemId
-    ? compareItems.find((i) => i.id === session.initialItemId)
-    : undefined;
-  const firstCompareItem = compareItems[0];
-  // The example item is the one we'll use for generating suggestion buttons
-  const exampleItem = initialItem || firstCompareItem;
-
-  const items = useMemo(() => {
+  const sortedComparisonItems = useMemo(() => {
     const comparator = sortCompareItemsComparator(
       sortedHash,
       sortBetterFirst,
@@ -175,8 +167,26 @@ export default function Compare({ session }: { session: CompareSession }) {
       allStats,
       session.initialItemId,
     );
-    const sortedComparisonItems = compareItems.toSorted(comparator);
-    return (
+    return compareItems.toSorted(comparator);
+  }, [
+    sortedHash,
+    sortBetterFirst,
+    doCompareBaseStats,
+    allStats,
+    session.initialItemId,
+    compareItems,
+  ]);
+
+  // If the session was started with a specific item, this is it
+  const initialItem = session.initialItemId
+    ? compareItems.find((i) => i.id === session.initialItemId)
+    : undefined;
+  const firstCompareItem = sortedComparisonItems[0];
+  // The example item is the one we'll use for generating suggestion buttons
+  const exampleItem = initialItem || firstCompareItem;
+
+  const items = useMemo(
+    () => (
       <CompareItems
         items={sortedComparisonItems}
         allStats={allStats}
@@ -186,17 +196,16 @@ export default function Compare({ session }: { session: CompareSession }) {
         doCompareBaseStats={doCompareBaseStats}
         initialItemId={session.initialItemId}
       />
-    );
-  }, [
-    allStats,
-    compareItems,
-    doCompareBaseStats,
-    onPlugClicked,
-    remove,
-    session.initialItemId,
-    sortBetterFirst,
-    sortedHash,
-  ]);
+    ),
+    [
+      sortedComparisonItems,
+      allStats,
+      doCompareBaseStats,
+      onPlugClicked,
+      remove,
+      session.initialItemId,
+    ],
+  );
 
   const header = (
     <div className={styles.options}>


### PR DESCRIPTION
Also confirmed that if the sorting is changed it updates properly (when initialItem is no longer in the list).

Initial state:
<img width="875" alt="Screenshot 2024-08-21 at 5 49 55 AM" src="https://github.com/user-attachments/assets/9ee995e4-7618-43e7-b67a-ba59586f5b61">

Previous behavior after removing first item:
<img width="946" alt="Screenshot 2024-08-21 at 5 50 14 AM" src="https://github.com/user-attachments/assets/af243ff7-ae0e-4991-9f84-e9ab74affe52">

Updated behavior after removing first item:
<img width="881" alt="Screenshot 2024-08-21 at 5 49 43 AM" src="https://github.com/user-attachments/assets/7543dd8a-dd0f-43ab-9647-82ffe4904ff4">
