### PR TITLE
Use Organizer's table-sort logic in Compare

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -1,5 +1,6 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { SheetHorizontalScrollContainer } from 'app/dim-ui/SheetHorizontalScrollContainer';
+import { ColumnSort, SortDirection, useTableColumnSorts } from 'app/dim-ui/table-columns';
 import { t } from 'app/i18next-t';
 import { locateItem } from 'app/inventory/locate-item';
 import { createItemContextSelector } from 'app/inventory/selectors';
@@ -18,6 +19,7 @@ import { AppIcon, faAngleLeft, faAngleRight, faList } from 'app/shell/icons';
 import { acquisitionRecencyComparator } from 'app/shell/item-comparators';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { emptyArray } from 'app/utils/empty';
+import { useShiftHeld } from 'app/utils/hooks';
 import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -27,7 +29,7 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import Sheet from '../dim-ui/Sheet';
 import { DimItem, DimSocket } from '../inventory/item-types';
-import { chainComparator, compareBy, reverseComparator } from '../utils/comparators';
+import { chainComparator, Comparator, compareBy, reverseComparator } from '../utils/comparators';
 import styles from './Compare.m.scss';
 import CompareItem from './CompareItem';
 import CompareSuggestions from './CompareSuggestions';
@@ -71,10 +73,8 @@ export default function Compare({ session }: { session: CompareSession }) {
 
   /** The stat row to highlight */
   const [highlight, setHighlight] = useState<string | number>();
-  /** The stat row to sort by */
-  const [sortedHash, setSortedHash] = useState<string | number>();
-  const [sortBetterFirst, setSortBetterFirst] = useState<boolean>(true);
   const [socketOverrides, onPlugClicked] = useSocketOverridesForItems();
+  const [columnSorts, toggleColumnSort] = useTableColumnSorts([]);
 
   const comparingArmor = rawCompareItems[0]?.bucket.inArmor;
   const comparingWeapons = rawCompareItems[0]?.bucket.inWeapons;
@@ -153,29 +153,15 @@ export default function Compare({ session }: { session: CompareSession }) {
     [cancel, compareItems.length, dispatch],
   );
 
-  const changeSort = (newSortedHash?: string | number) => {
-    // TODO: put sorting together?
-    setSortedHash(newSortedHash);
-    setSortBetterFirst(sortedHash === newSortedHash ? !sortBetterFirst : true);
-  };
-
   const sortedComparisonItems = useMemo(() => {
     const comparator = sortCompareItemsComparator(
-      sortedHash,
-      sortBetterFirst,
+      columnSorts,
       doCompareBaseStats,
       allStats,
       session.initialItemId,
     );
     return compareItems.toSorted(comparator);
-  }, [
-    sortedHash,
-    sortBetterFirst,
-    doCompareBaseStats,
-    allStats,
-    session.initialItemId,
-    compareItems,
-  ]);
+  }, [columnSorts, doCompareBaseStats, allStats, session.initialItemId, compareItems]);
 
   // If the session was started with a specific item, this is it
   const initialItem = session.initialItemId
@@ -235,35 +221,49 @@ export default function Compare({ session }: { session: CompareSession }) {
     </div>
   );
 
+  const isShiftHeld = useShiftHeld();
   return (
     <Sheet onClose={cancel} header={header} allowClickThrough>
       <div className={styles.bucket} onPointerLeave={() => setHighlight(undefined)}>
         <div className={styles.statList}>
           <div className={styles.spacer} />
-          {allStats.map((stat) => (
-            <div
-              key={stat.id}
-              className={clsx(styles.statLabel, {
-                [styles.sortDesc]: stat.id === sortedHash && sortBetterFirst,
-                [styles.sortAsc]: stat.id === sortedHash && !sortBetterFirst,
-              })}
-              onPointerEnter={() => setHighlight(stat.id)}
-              onClick={() => changeSort(stat.id)}
-            >
-              {stat.displayProperties.hasIcon && (
-                <span title={stat.displayProperties.name}>
-                  <BungieImage src={stat.displayProperties.icon} />
-                </span>
-              )}
-              {stat.id in statLabels
-                ? t(statLabels[stat.id as StatHashes]!)
-                : stat.displayProperties.name}{' '}
-              {stat.id === sortedHash && (
-                <AppIcon icon={sortBetterFirst ? faAngleRight : faAngleLeft} />
-              )}
-              {stat.id === highlight && <div className={styles.highlightBar} />}
-            </div>
-          ))}
+          {allStats.map((stat) => {
+            const columnSort = columnSorts.find((c) => c.columnId === stat.id.toString());
+            return (
+              <div
+                key={stat.id}
+                className={clsx(
+                  styles.statLabel,
+                  columnSort
+                    ? columnSort.sort === SortDirection.ASC
+                      ? styles.sortDesc
+                      : styles.sortAsc
+                    : undefined,
+                )}
+                onPointerEnter={() => setHighlight(stat.id)}
+                onClick={toggleColumnSort(
+                  stat.id.toString(),
+                  isShiftHeld,
+                  stat.lowerBetter ? SortDirection.DESC : SortDirection.ASC,
+                )}
+              >
+                {stat.displayProperties.hasIcon && (
+                  <span title={stat.displayProperties.name}>
+                    <BungieImage src={stat.displayProperties.icon} />
+                  </span>
+                )}
+                {stat.id in statLabels
+                  ? t(statLabels[stat.id as StatHashes]!)
+                  : stat.displayProperties.name}{' '}
+                {columnSort && (
+                  <AppIcon
+                    icon={columnSort.sort === SortDirection.ASC ? faAngleRight : faAngleLeft}
+                  />
+                )}
+                {stat.id === highlight && <div className={styles.highlightBar} />}
+              </div>
+            );
+          })}
         </div>
         {items}
       </div>
@@ -308,39 +308,37 @@ function CompareItems({
 }
 
 function sortCompareItemsComparator(
-  sortedHash: string | number | undefined,
-  sortBetterFirst: boolean,
+  columnSorts: ColumnSort[],
   compareBaseStats: boolean,
   allStats: StatInfo[],
   initialItemId?: string,
 ) {
-  if (!sortedHash) {
+  if (!columnSorts.length) {
     return chainComparator(
       compareBy((item) => item.id !== initialItemId),
       acquisitionRecencyComparator,
     );
   }
 
-  const sortStat = allStats.find((s) => s.id === sortedHash);
-
-  if (!sortStat) {
-    return (_a: DimItem, _b: DimItem) => 0;
-  }
-
-  const shouldReverse = sortStat.lowerBetter ? sortBetterFirst : !sortBetterFirst;
-
   return reverseComparator(
     chainComparator<DimItem>(
-      compareBy((item) => {
-        const stat = sortStat.getStat(item);
-        if (!stat) {
-          return -1;
+      ...columnSorts.map((sorter) => {
+        const sortStat = allStats.find((s) => s.id.toString() === sorter.columnId);
+        if (!sortStat) {
+          return compareBy(() => 0);
         }
-        const statValue = compareBaseStats ? (stat.base ?? stat.value) : stat.value;
-        if (stat.statHash === StatHashes.RecoilDirection) {
-          return recoilValue(stat.value);
-        }
-        return shouldReverse ? -statValue : statValue;
+        const compare: Comparator<DimItem> = compareBy((item) => {
+          const stat = sortStat.getStat(item);
+          if (!stat) {
+            return -1;
+          }
+          const statValue = compareBaseStats ? (stat.base ?? stat.value) : stat.value;
+          if (stat.statHash === StatHashes.RecoilDirection) {
+            return recoilValue(stat.value);
+          }
+          return statValue;
+        });
+        return sorter.sort === SortDirection.ASC ? compare : reverseComparator(compare);
       }),
       compareBy((i) => i.index),
       compareBy((i) => i.name),

--- a/src/app/dim-ui/table-columns.test.ts
+++ b/src/app/dim-ui/table-columns.test.ts
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { SortDirection, useTableColumnSorts } from './table-columns';
+
+describe('useTableColumnSorts', () => {
+  it('use cases', () => {
+    const { result } = renderHook(() => useTableColumnSorts([]));
+
+    // Toggle on one column
+    act(() => {
+      const [_columnSorts, toggleColumnSort] = result.current;
+      toggleColumnSort('one', false, SortDirection.ASC)();
+    });
+
+    let [columnSorts] = result.current;
+    expect(columnSorts).toEqual([{ columnId: 'one', sort: SortDirection.ASC }]);
+
+    // Now toggle that same column
+    act(() => {
+      const [_columnSorts, toggleColumnSort] = result.current;
+      toggleColumnSort('one', false, SortDirection.ASC)();
+    });
+
+    // Now we should see the sort inverted
+    [columnSorts] = result.current;
+    expect(columnSorts).toEqual([{ columnId: 'one', sort: SortDirection.DESC }]);
+
+    // Now toggle another column
+    act(() => {
+      const [_columnSorts, toggleColumnSort] = result.current;
+      toggleColumnSort('two', false, SortDirection.ASC)();
+    });
+
+    // Now we should see only the second column
+    [columnSorts] = result.current;
+    expect(columnSorts).toEqual([{ columnId: 'two', sort: SortDirection.ASC }]);
+
+    // Toggle the first column, but with additive=true
+    act(() => {
+      const [_columnSorts, toggleColumnSort] = result.current;
+      toggleColumnSort('one', true, SortDirection.ASC)();
+    });
+
+    // Now we should see both columns
+    [columnSorts] = result.current;
+    expect(columnSorts).toEqual([
+      { columnId: 'two', sort: SortDirection.ASC },
+      { columnId: 'one', sort: SortDirection.ASC },
+    ]);
+
+    // Toggle a third column with additive=false, but this one has a different default sort
+    act(() => {
+      const [_columnSorts, toggleColumnSort] = result.current;
+      toggleColumnSort('three', false, SortDirection.DESC)();
+    });
+
+    // Now we should see only the third column, but with its default sort
+    [columnSorts] = result.current;
+    expect(columnSorts).toEqual([{ columnId: 'three', sort: SortDirection.DESC }]);
+  });
+});

--- a/src/app/dim-ui/table-columns.ts
+++ b/src/app/dim-ui/table-columns.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState } from 'react';
 
 export interface ColumnSort {
-  columnId: string;
-  sort: SortDirection;
+  readonly columnId: string;
+  readonly sort: SortDirection;
 }
 
 export const enum SortDirection {
@@ -13,35 +13,30 @@ export const enum SortDirection {
 export function useTableColumnSorts(defaultSorts: ColumnSort[]) {
   const [columnSorts, setColumnSorts] = useState<ColumnSort[]>(defaultSorts);
 
-  // Toggle sorting of columns. If shift is held, adds this column to the sort.
+  // Toggle sorting of columns. If shift is held (the additive param), adds this column to the sort.
   const toggleColumnSort = useCallback(
-    (columnId: string, inverted: boolean, defaultDirection?: SortDirection) => () => {
+    (columnId: string, additive: boolean, defaultDirection?: SortDirection) => () =>
       setColumnSorts((sorts) => {
-        const newColumnSorts = inverted
-          ? Array.from(sorts)
-          : sorts.filter((s) => s.columnId === columnId);
-        let found = false;
-        let index = 0;
-        for (const columnSort of newColumnSorts) {
-          if (columnSort.columnId === columnId) {
-            newColumnSorts[index] = {
-              ...columnSort,
-              sort: columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC,
-            };
-            found = true;
-            break;
-          }
-          index++;
-        }
-        if (!found) {
+        const newColumnSorts = additive
+          ? Array.from(sorts) // start with a copy of the existing sorts
+          : sorts.filter((s) => s.columnId === columnId); // otherwise just this column
+        const index = newColumnSorts.findIndex((s) => s.columnId === columnId);
+        if (index >= 0) {
+          // This column is already in the sort, flip the direction
+          const columnSort = newColumnSorts[index];
+          newColumnSorts[index] = {
+            ...columnSort,
+            sort: columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC,
+          };
+        } else {
+          // Add the column to the sort
           newColumnSorts.push({
             columnId: columnId,
             sort: defaultDirection || SortDirection.ASC,
           });
         }
         return newColumnSorts;
-      });
-    },
+      }),
     [],
   );
 

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -603,7 +603,7 @@ function sortRows(
     }),
   );
 
-  return Array.from(unsortedRows).sort(comparator);
+  return unsortedRows.toSorted(comparator);
 }
 
 function TableRow({


### PR DESCRIPTION
This replaces Compare's stat-sorting logic with the table sorter from Organizer. It should behave identically, with the one difference that it is now possible to shift-click a stat to sort by multiple stats at once.