### PR TITLE
Move eslint-disable comment so it doesn't get lost in organize imports

### DIFF
--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -28,8 +28,7 @@ import _ from 'lodash';
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DimItem } from '../inventory/item-types';
-// eslint-disable-next-line css-modules/no-unused-class
-import popupStyles from '../item-popup/ItemDescription.m.scss';
+import popupStyles from '../item-popup/ItemDescription.m.scss'; // eslint-disable-line css-modules/no-unused-class
 import styles from './ItemTriage.m.scss';
 import { Factor } from './triage-factors';
 import {

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -58,8 +58,8 @@ import { createPortal } from 'react-dom';
 
 import { DimLanguage } from 'app/i18n';
 import { localizedSorter } from 'app/utils/intl';
-// eslint-disable-next-line css-modules/no-unused-class
-import styles from './ItemTable.m.scss';
+
+import styles from './ItemTable.m.scss'; // eslint-disable-line css-modules/no-unused-class
 import { ItemCategoryTreeNode, armorTopLevelCatHashes } from './ItemTypeSelector';
 import { ColumnDefinition, ColumnSort, Row, SortDirection } from './table-types';
 


### PR DESCRIPTION
Organize imports can cause the eslint-disable-next-line comment to be disassociated with its next line. By putting the comment on the same line, it will no longer get lost.