### PR TITLE
Restore hover-visibility of track triumph button

### DIFF
--- a/src/app/records/Record.m.scss
+++ b/src/app/records/Record.m.scss
@@ -161,6 +161,8 @@
   opacity: 0.5;
 }
 
+// The "track triumph" icon that appears when you hover over a record. You can
+// click it to track the triumph.
 .dimTrackedIcon {
   position: absolute;
   display: none;
@@ -191,11 +193,11 @@
     opacity: 1;
     top: -10px;
   }
-  .triumphRecord {
-    @include interactive($hover: true) {
-      display: block;
-      opacity: 0.7;
-    }
+
+  // When the record is hovered, show the icon
+  .triumphRecord:hover & {
+    display: block;
+    opacity: 0.7;
   }
 }
 


### PR DESCRIPTION
#10698 broke the track triumph button by reordering the hover rules. This is my bad - both for insufficiently documenting the CSS, and for not checking the Records.m.css case that @liamdebeasi had called out (I only looked at the dim-button case).

Fixes #10711. 