### PR TITLE
Add enhancementTier to craftedInfo and display it in weapon level bar

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -967,6 +967,7 @@
     "Consolidate": "Consolidate",
     "CommunityData": "Community Insight",
     "DistributeEvenly": "Distribute Evenly",
+    "EnhancementTier": "Tier {{tier}}",
     "Equip": "Equip on:",
     "EquipWithName": "Equip on {{character}}",
     "FavoriteUnFavorite": {

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -267,6 +267,8 @@ export interface DimCrafted {
   progress: number;
   /** when this weapon was crafted, UTC epoch seconds timestamp */
   craftedDate: number;
+  /** the enhancement tier for this weapon, if enhanced. 0 otherwise. */
+  enhancementTier: number;
 }
 
 export interface DimCatalyst {

--- a/src/app/inventory/store/crafted.ts
+++ b/src/app/inventory/store/crafted.ts
@@ -1,6 +1,7 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { warnLog } from 'app/utils/log';
 import { getFirstSocketByCategoryHash } from 'app/utils/socket-utils';
+import { HashLookup } from 'app/utils/util-types';
 import { DestinyObjectiveProgress, DestinyObjectiveUiStyle } from 'bungie-api-ts/destiny2';
 import { DimCrafted, DimItem, DimSocket } from '../item-types';
 
@@ -9,6 +10,14 @@ export const craftedSocketCategoryHash = 3583996951;
 
 /** the socket category containing the Mementos */
 export const mementoSocketCategoryHash = 3201856887;
+
+/** the socket containing the enhancement tier plugs */
+export const enhancementSocketHash = 4251072212;
+export const plugHashToEnhancementTier: HashLookup<number> = {
+  2728416798: 1,
+  2728416797: 2,
+  2728416796: 3,
+};
 
 export function buildCraftedInfo(
   item: DimItem,
@@ -23,8 +32,12 @@ export function buildCraftedInfo(
   if (!objectives) {
     return undefined;
   }
-
-  return getCraftingInfo(defs, objectives);
+  const craftingInfo = getCraftingInfo(defs, objectives);
+  if (!craftingInfo) {
+    return undefined;
+  }
+  craftingInfo.enhancementTier = getEnhancementTier(item);
+  return craftingInfo;
 }
 
 /** find the item socket that could contain the "this weapon was crafted" plug with its objectives */
@@ -32,6 +45,16 @@ export function getCraftedSocket(item: DimItem): DimSocket | undefined {
   if (item.bucket.inWeapons && item.sockets) {
     return getFirstSocketByCategoryHash(item.sockets, craftedSocketCategoryHash);
   }
+}
+
+export function getEnhancementTier(item: DimItem): number {
+  if (item.bucket.inWeapons && item.sockets) {
+    const plugHash = item.sockets.allSockets.find(
+      (s) => s.socketDefinition.socketTypeHash === enhancementSocketHash,
+    )?.plugged?.plugDef.hash;
+    return (plugHash && plugHashToEnhancementTier[plugHash]) || 0;
+  }
+  return 0;
 }
 
 function getCraftingInfo(
@@ -64,5 +87,5 @@ function getCraftingInfo(
     return undefined;
   }
 
-  return { level, progress, craftedDate };
+  return { level, progress, craftedDate, enhancementTier: 0 };
 }

--- a/src/app/item-popup/WeaponCraftedInfo.tsx
+++ b/src/app/item-popup/WeaponCraftedInfo.tsx
@@ -29,6 +29,8 @@ export function WeaponCraftedInfo({ item, className }: { item: DimItem; classNam
       <div className="objective-progress">
         <div className="objective-progress-bar" style={progressBarStyle} />
         <div className="objective-description">
+          {item.craftedInfo?.enhancementTier > 0 &&
+            `${t('MovePopup.EnhancementTier', { tier: item.craftedInfo?.enhancementTier })} - `}
           {t('MovePopup.WeaponLevel', { level: item.craftedInfo.level })}
         </div>
         <div className="objective-text">{percentWithSingleDecimal(progress)}</div>


### PR DESCRIPTION
Fixes #10715 

<img width="324" alt="Screenshot 2024-09-02 at 6 05 16 AM" src="https://github.com/user-attachments/assets/f97baf4f-e229-4b8f-b676-ffa227f1e001">

For reference, here's how Bungie displays this: 
![image](https://github.com/user-attachments/assets/a53e9e90-2c9f-4923-b3ef-d2d49c91ae61)
