### PR TITLE
Update enhanced/enhanceable keywords

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -242,7 +242,7 @@
     "Energy": "Shows items that have energy capacity (Armor 2.0).",
     "Engrams": "Shows engrams.",
     "EnhancedPerk": "Shows weapons that have the specified number of enhanced perks.",
-    "Enhanced": "Shows weapons that have been enhanced.",
+    "Enhanced": "Shows weapons based on their enhancement tier.",
     "Enhanceable": "Shows weapons that can be enhanced.",
     "Equipment": "Items that can be equipped.",
     "Equipped": "Items that are currently equipped on a character.",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * `breaker:` searches now match items that can have that breaker type granted by this season's artifact (whether or not the correct artifact mods are enabled). The effective breaker type from artifact mods also now shows up on item tiles and in the Armory.
 * Add Enhancement tier to weapon level bar.
-* Update 'enhanced' search keyword to allow range of values (0/1/2/3). Old `is:enhanced` behavior is now `enhanced:3`.
-* Update 'enhanceable' search keyword to exclude Tier 3 Enhancement.
+* Update `enhanced` search keyword to allow range of values (0/1/2/3). Old `is:enhanced` behavior is now `enhanced:3`.
+* Update `is:enhanceable` search keyword to exclude Tier 3 Enhancement.
 
 ## 8.35.1 <span class="changelog-date">(2024-09-01)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 * `breaker:` searches now match items that can have that breaker type granted by this season's artifact (whether or not the correct artifact mods are enabled). The effective breaker type from artifact mods also now shows up on item tiles and in the Armory.
 * Add Enhancement tier to weapon level bar.
 * Update `enhanced` search keyword to allow range of values (0/1/2/3). Old `is:enhanced` behavior is now `enhanced:3`.
-* Update `is:enhanceable` search keyword to exclude Tier 3 Enhancement.
+* Update `is:enhanceable` search keyword to exclude Tier 3 Enhanced items.
 
 ## 8.35.1 <span class="changelog-date">(2024-09-01)</span>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Next
 
 * `breaker:` searches now match items that can have that breaker type granted by this season's artifact (whether or not the correct artifact mods are enabled). The effective breaker type from artifact mods also now shows up on item tiles and in the Armory.
+* Add Enhancement tier to weapon level bar.
+* Update 'enhanced' search keyword to allow range of values (0/1/2/3). Old `is:enhanced` behavior is now `enhanced:3`.
+* Update 'enhanceable' search keyword to exclude Tier 3 Enhancement.
 
 ## 8.35.1 <span class="changelog-date">(2024-09-01)</span>
 

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -155,6 +155,7 @@ exports[`buildSearchConfig generates a reasonable filter map: key-value filters 
   "deepsight",
   "description",
   "energycapacity",
+  "enhanced",
   "enhancedperk",
   "exactname",
   "exactperk",

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -312,28 +312,30 @@ const socketFilters: ItemFilterDefinition[] = [
     destinyVersion: 2,
     filter: () => (item) =>
       Boolean(
-        item.sockets?.allSockets.some(
-          (s) =>
-            s.plugged?.plugDef.plug.plugCategoryHash ===
-            PlugCategoryHashes.CraftingPlugsWeaponsModsEnhancers,
-        ),
+        (item.craftedInfo?.enhancementTier || 0) < 3 &&
+          item.sockets?.allSockets.some(
+            (s) =>
+              s.plugged?.plugDef.plug.plugCategoryHash ===
+              PlugCategoryHashes.CraftingPlugsWeaponsModsEnhancers,
+          ),
       ),
   },
   {
-    // this currently tests for full enhancedness, returning false for partially-enhanced items
     keywords: 'enhanced',
     description: tl('Filter.Enhanced'),
     destinyVersion: 2,
-    format: ['simple'], // TO-DO: add 'range' here
-    filter:
-      ({ lhs }) =>
-      (item) => {
-        if (lhs === 'is') {
-          // rules out partially-enhanced items
-          // the game explicitly warns you that partially-enhanced items stop looking masterworked
-          return item.crafted === 'enhanced' && item.masterwork;
-        }
-      },
+    format: ['simple', 'range'],
+    filter: ({ lhs, compare }) => {
+      if (compare) {
+        return (item) => compare(item.craftedInfo?.enhancementTier || 0);
+      }
+      if (lhs === 'is') {
+        return (item) =>
+          item.crafted === 'enhanced' && (item.craftedInfo?.enhancementTier || 0) > 0;
+      }
+      // shouldn't ever get here but need the default case
+      return (_item) => false;
+    },
   },
   {
     keywords: 'retiredperk',


### PR DESCRIPTION
Fixes #10719 
Add range to enhanced and update logic to show any enhanced instead of fully-enhanced
Exclude enhanced:3 from enhanceable

Also update changelog

`is:enhanced` and `enhanced:>0` now show anything t1-3
`is:enhanceable` now shows anything t0-2 that's enhanceable
The other ranges work as expected.