### PR TITLE
Correctly calculate conditional stats' effects on plugs themselves

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -382,7 +382,7 @@ export interface PluggableInventoryItemDefinition extends DestinyInventoryItemDe
 }
 
 /** Describes the conditions under which a plug stat is active */
-export type PlugStatActivityRule =
+export type PlugStatActivationRule =
   | /** always active */ undefined
   | {
       /** never active */
@@ -412,11 +412,11 @@ export type PlugStatActivityRule =
  *
  * The idea is that DestinyItemInvestmentStatDefinition[] is assignable to DimPlugInvestmentStat[].
  * That way we can reuse the plug def's investmentStats array if it has no conditional stats or doesn't
- * require fixup in general, and map to our own format with a PlugStatActivityRule if need be
+ * require fixup in general, and map to our own format with a PlugStatActivationRule if need be
  */
 export interface DimPlugInvestmentStat
   extends Omit<DestinyItemInvestmentStatDefinition, 'isConditionallyActive'> {
-  activityRule?: PlugStatActivityRule;
+  activationRule?: PlugStatActivationRule;
 }
 
 /**

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -345,7 +345,7 @@ function applyPlugsToStats(
         }
 
         // check special conditionals
-        if (!isPlugStatActive(pluggedInvestmentStat.activityRule, createdItem)) {
+        if (!isPlugStatActive(pluggedInvestmentStat.activationRule, createdItem)) {
           continue;
         }
 
@@ -386,7 +386,7 @@ function applyPlugsToStats(
  */
 function getPlugStatValue(createdItem: DimItem, stat: DimPlugInvestmentStat) {
   if (
-    stat.activityRule?.rule === 'enhancedIntrinsic' &&
+    stat.activationRule?.rule === 'enhancedIntrinsic' &&
     adeptWeaponHashes.includes(createdItem.hash)
   ) {
     return stat.value + ((createdItem.craftedInfo?.level ?? 0) >= 20 ? 2 : 1);
@@ -421,6 +421,9 @@ function attachPlugStats(
     const activePlugStats: DimPlug['stats'] = {};
 
     for (const plugInvestmentStat of mapAndFilterInvestmentStats(activePlug.plugDef)) {
+      if (!isPlugStatActive(plugInvestmentStat.activationRule, createdItem)) {
+        continue;
+      }
       const plugStatInvestmentValue = getPlugStatValue(createdItem, plugInvestmentStat);
       const itemStat = statsByHash[plugInvestmentStat.statTypeHash];
       const statDisplay = statDisplaysByStatHash[plugInvestmentStat.statTypeHash];
@@ -462,6 +465,9 @@ function attachPlugStats(
     const plugStats: DimPlug['stats'] = {};
 
     for (const plugInvestmentStat of mapAndFilterInvestmentStats(plug.plugDef)) {
+      if (!isPlugStatActive(plugInvestmentStat.activationRule, createdItem)) {
+        continue;
+      }
       const plugStatInvestmentValue = getPlugStatValue(createdItem, plugInvestmentStat);
       const itemStat = statsByHash[plugInvestmentStat.statTypeHash];
       const statDisplay = statDisplaysByStatHash[plugInvestmentStat.statTypeHash];

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -145,7 +145,7 @@ export default function SocketDetailsSelectedPlug({
       return undefined;
     }
 
-    if (!isPlugStatActive(stat.activityRule, item)) {
+    if (!isPlugStatActive(stat.activationRule, item)) {
       return undefined;
     }
 

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -115,7 +115,7 @@ export function getTotalModStatChanges(
       for (const stat of mapAndFilterInvestmentStats(mod)) {
         if (
           stat.statTypeHash in totals &&
-          isPlugStatActive(stat.activityRule, undefined, characterClass)
+          isPlugStatActive(stat.activationRule, undefined, characterClass)
         ) {
           const value = stat.value * modCount;
           totals[stat.statTypeHash as ArmorStatHashes].value += value;

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -295,7 +295,7 @@ export function getPlugDefStats(
     .filter(
       (stat) =>
         (isAllowedItemStat(stat.statTypeHash) || isAllowedPlugStat(stat.statTypeHash)) &&
-        (classType === undefined || isPlugStatActive(stat.activityRule, undefined, classType)),
+        (classType === undefined || isPlugStatActive(stat.activationRule, undefined, classType)),
     )
     .map((stat) => ({
       statHash: stat.statTypeHash,


### PR DESCRIPTION
Fixes a regression introduced by #9974.

We correctly calculated item stats but failed to filter them when estimating the effect that plugs contributed to the stats, leading to confusing/incorrect tooltips or wrongly colored stat bars.

Also renames "Activity" -> "Activation", nev had suggested that but I never picked up that PR again