### PR TITLE
Make DimItem#itemCategoryHashes type be ItemCategoryHash

### DIFF
--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -4,7 +4,7 @@ import { showNotification } from 'app/notifications/notifications';
 import { getSelectionTree } from 'app/organizer/ItemTypeSelector';
 import { quoteFilterString } from 'app/search/query-parser';
 import { getInterestingSocketMetadatas, isD1Item } from 'app/utils/item-utils';
-import { PlugCategoryHashes } from 'data/d2/generated-enums';
+import { ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import { ActionType, Reducer, getType } from 'typesafe-actions';
 import * as actions from './actions';
 import { compareNameQuery } from './compare-utils';
@@ -14,7 +14,7 @@ export interface CompareSession {
    * A list of itemCategoryHashes must be provided in order to limit the type of items which can be compared.
    * This list should match the item category drill-down from Organizer's ItemTypeSelector.
    */
-  readonly itemCategoryHashes: number[];
+  readonly itemCategoryHashes: ItemCategoryHashes[];
   /**
    * The query further filters the items to be shown. Since this query is modified
    * when adding or removing items, external queries must be parenthesized first
@@ -258,11 +258,14 @@ function getItemCategoryHashesFromExampleItem(item: DimItem) {
 
   // Dive two layers down (weapons/armor => type)
   for (const node of itemSelectionTree.subCategories!) {
-    if (item.itemCategoryHashes.includes(node.itemCategoryHash)) {
+    if (node.itemCategoryHash && item.itemCategoryHashes.includes(node.itemCategoryHash)) {
       hashes.push(node.itemCategoryHash);
       if (node.subCategories) {
         for (const subNode of node.subCategories) {
-          if (item.itemCategoryHashes.includes(subNode.itemCategoryHash)) {
+          if (
+            subNode.itemCategoryHash &&
+            item.itemCategoryHashes.includes(subNode.itemCategoryHash)
+          ) {
             hashes.push(subNode.itemCategoryHash);
             break;
           }

--- a/src/app/destiny1/d1-manifest-types.ts
+++ b/src/app/destiny1/d1-manifest-types.ts
@@ -22,6 +22,7 @@ import {
   TierType,
   TransferStatuses,
 } from 'bungie-api-ts/destiny2';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 
 export interface AllD1DestinyManifestComponents {
   DestinyRecordDefinition: { [hash: number]: D1RecordDefinition };
@@ -140,7 +141,7 @@ export interface D1InventoryItemDefinition {
   itemSubType: DestinyItemSubType;
   classType: DestinyClass;
   sources: D1ItemSourceDefinition[];
-  itemCategoryHashes: number[];
+  itemCategoryHashes: ItemCategoryHashes[];
   sourceHashes: number[];
   nonTransferrable: boolean;
   exclusive: BungieMembershipType;

--- a/src/app/dim-ui/svgs/itemCategory.ts
+++ b/src/app/dim-ui/svgs/itemCategory.ts
@@ -117,11 +117,11 @@ const bucketHashToItemCategoryHash: LookupTable<BucketHashes, ItemCategoryHashes
 } as const;
 
 /** an SVG of the weapon's type, if determinable */
-export function getWeaponTypeSvgIconFromCategoryHashes(itemCategoryHashes: number[]) {
+export function getWeaponTypeSvgIconFromCategoryHashes(itemCategoryHashes: ItemCategoryHashes[]) {
   // reverse through the ICHs because most specific is last,
   // i.e. Weapon, Fusion Rifle, Linear Fusion Rifle
   for (const ich of itemCategoryHashes.toReversed()) {
-    const svg = weaponTypeSvgByCategoryHash[ich as ItemCategoryHashes];
+    const svg = weaponTypeSvgByCategoryHash[ich];
     if (svg) {
       return svg;
     }
@@ -136,7 +136,7 @@ export function getWeaponTypeSvgIcon(item: DimItem) {
 /** an SVG of the weapon's slot, if possible */
 export function getWeaponSlotSvgIcon(item: DimItem) {
   for (const ich of item.itemCategoryHashes.toReversed()) {
-    const svg = weaponSlotSvgByCategoryHash[ich as ItemCategoryHashes];
+    const svg = weaponSlotSvgByCategoryHash[ich];
     if (svg) {
       return svg;
     }
@@ -146,7 +146,7 @@ export function getWeaponSlotSvgIcon(item: DimItem) {
 /** an SVG of the armor's slot, if determinable */
 export function getArmorSlotSvgIcon(item: DimItem) {
   for (const ich of item.itemCategoryHashes.toReversed()) {
-    const svg = armorSlotSvgByCategoryHash[ich as ItemCategoryHashes];
+    const svg = armorSlotSvgByCategoryHash[ich];
     if (svg) {
       return svg;
     }

--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -20,6 +20,7 @@ import {
   DestinySocketCategoryDefinition,
   DestinyStat,
 } from 'bungie-api-ts/destiny2';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { DimBucketType, InventoryBucket } from './inventory-buckets';
 
 /**
@@ -53,7 +54,7 @@ export interface DimItem {
   /** The bucket the item normally resides in (even though it may currently be elsewhere, such as in the postmaster). */
   bucket: InventoryBucket;
   /** Hashes of DestinyItemCategoryDefinitions this item belongs to */
-  itemCategoryHashes: number[];
+  itemCategoryHashes: ItemCategoryHashes[];
   /** A readable English name for the rarity of the item (e.g. "Exotic", "Rare"). */
   tier: ItemTierName;
   /** Is this an Exotic item? */

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -801,8 +801,8 @@ function buildPursuitInfo(
   }
 }
 
-function getItemCategoryHashes(itemDef: DestinyInventoryItemDefinition): number[] {
-  let itemCategoryHashes = itemDef.itemCategoryHashes || emptyArray();
+function getItemCategoryHashes(itemDef: DestinyInventoryItemDefinition): ItemCategoryHashes[] {
+  let itemCategoryHashes: ItemCategoryHashes[] = itemDef.itemCategoryHashes || emptyArray();
 
   if (
     itemCategoryHashes.includes(ItemCategoryHashes.Weapon) &&

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -105,7 +105,7 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
     if (!terminal) {
       return emptyArray<DimItem>();
     }
-    const categoryHashes = categories.map((s) => s.itemCategoryHash).filter(Boolean);
+    const categoryHashes = categories.map((s) => s.itemCategoryHash).filter((h) => h !== 0);
     // a top level class-specific category implies armor
     if (armorTopLevelCatHashes.some((h) => categoryHashes.includes(h))) {
       categoryHashes.push(ItemCategoryHashes.Armor);

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -7,6 +7,7 @@ import { setSearchQuery } from 'app/shell/actions';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { usePageTitle } from 'app/utils/hooks';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
@@ -25,7 +26,7 @@ interface Props {
  */
 function drillToSelection(
   selectionTree: ItemCategoryTreeNode | undefined,
-  selectedItemCategoryHashes: number[],
+  selectedItemCategoryHashes: ItemCategoryHashes[],
 ): ItemCategoryTreeNode[] {
   const selectedItemCategoryHash = selectedItemCategoryHashes[0];
 

--- a/src/app/settings/vault-grouping.test.ts
+++ b/src/app/settings/vault-grouping.test.ts
@@ -1,5 +1,6 @@
 import { DimItem } from 'app/inventory/item-types';
 import store from 'app/store/store';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import { getTestDefinitions, getTestStores } from 'testing/test-utils';
 import { vaultWeaponGroupingSelector, vaultWeaponGroupingSettingSelector } from './vault-grouping';
 
@@ -45,7 +46,7 @@ describe('vaultWeaponGroupingSelector', () => {
       {
         ...firstItem,
         typeName: undefined as unknown as string,
-        itemCategoryHashes: [0],
+        itemCategoryHashes: [0 as ItemCategoryHashes],
       },
       {
         ...firstItem,

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -5,7 +5,7 @@ import { D2ItemTiers } from 'app/search/d2-known-values';
 import { ItemSortSettings } from 'app/settings/item-sort';
 import { isD1Item } from 'app/utils/item-utils';
 import { DestinyAmmunitionType, DestinyDamageTypeDefinition } from 'bungie-api-ts/destiny2';
-import { BucketHashes } from 'data/d2/generated-enums';
+import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { TagValue, tagConfig, vaultGroupTagOrder } from '../inventory/dim-item-info';
 import { Comparator, chainComparator, compareBy, reverseComparator } from '../utils/comparators';
@@ -123,7 +123,7 @@ interface VaultGroupIconTag {
 
 interface VaultGroupIconTypeName {
   type: 'typeName';
-  itemCategoryHashes: number[];
+  itemCategoryHashes: ItemCategoryHashes[];
 }
 
 interface VaultGroupIconAmmoType {

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -364,8 +364,8 @@ export function getBreakerTypeHash(item: DimItem): number | undefined {
     return item.breakerType.hash;
   } else if (item.bucket.inWeapons) {
     for (const ich of item.itemCategoryHashes) {
-      if (ichToBreakerType[ich as ItemCategoryHashes]) {
-        return ichToBreakerType[ich as ItemCategoryHashes];
+      if (ichToBreakerType[ich]) {
+        return ichToBreakerType[ich];
       }
     }
   }


### PR DESCRIPTION
It seemed like it would be nice for `DimItem#itemCategoryHashes` to actually be typed `ItemCategoryHash[]`. TS is weirdly loose about this - it doesn't catch the special inverted item category hashes we use (e.g. for grenade launchers) but it's still an improvement.