### PR TITLE
Exclude items explicitly marked as Dummy from Compare and LO vendors

### DIFF
--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -12,6 +12,7 @@ import { querySelector } from 'app/shell/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
 import { currySelector } from 'app/utils/selectors';
+import { ItemCategoryHashes } from 'data/d2/generated-enums';
 import _ from 'lodash';
 import { createSelector } from 'reselect';
 import {
@@ -120,7 +121,8 @@ export const characterVendorItemsSelector = createSelector(
       vendorGroups
         .flatMap((vg) => vg.vendors)
         .concat(Object.values(subVendors))
-        .flatMap((vs) => vs.items.map((vi) => vi.item)),
+        .flatMap((vs) => vs.items.map((vi) => vi.item))
+        .filter((i) => !i?.itemCategoryHashes.includes(ItemCategoryHashes.Dummies)),
     );
   },
 );


### PR DESCRIPTION
We wait for all vendor item perks to load in the background before offering them to LO. However, some dummy items (e.g. class items) don't get perks returned by the API at all and this makes DIM think the load hasn't completed. Excluding them here is a simple fix and dummy items are generally irrelevant anyway. A holistic fix would probably involve changing this background load logic to identify items for which we're not expected to get API perks but I don't know how the API decides this