### PR TITLE
Allow dragging items from Item Feed to any bucket, similar to postmaster items

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Allow dragging Item Feed items to any slot, removing the need to scroll to a specific item slot to drag them to a character. They will automatically go to the correct slot on the given character (in the same way Postmaster items function).
+
 ## 8.43.0 <span class="changelog-date">(2024-10-20)</span>
 
 ## 8.42.0 <span class="changelog-date">(2024-10-13)</span>

--- a/src/app/inventory/DraggableInventoryItem.tsx
+++ b/src/app/inventory/DraggableInventoryItem.tsx
@@ -10,12 +10,13 @@ import { DimItem } from './item-types';
 
 interface Props {
   item: DimItem;
+  anyBucket?: boolean;
   children?: React.ReactNode;
 }
 
 let dragTimeout: number | null = null;
 
-export default function DraggableInventoryItem({ children, item }: Props) {
+export default function DraggableInventoryItem({ children, item, anyBucket = false }: Props) {
   const selectionProps = $featureFlags.elgatoStreamDeck
     ? // eslint-disable-next-line
       useStreamDeckSelection({
@@ -33,11 +34,12 @@ export default function DraggableInventoryItem({ children, item }: Props) {
 
   const [_collect, dragRef] = useDrag<DimItem>(
     () => ({
-      type: item.location.inPostmaster
-        ? 'postmaster'
-        : item.notransfer
-          ? `${item.owner}-${item.bucket.hash}`
-          : item.bucket.hash.toString(),
+      type:
+        item.location.inPostmaster || anyBucket
+          ? 'postmaster'
+          : item.notransfer
+            ? `${item.owner}-${item.bucket.hash}`
+            : item.bucket.hash.toString(),
       item: () => {
         hideItemPopup();
 

--- a/src/app/item-feed/ItemFeed.tsx
+++ b/src/app/item-feed/ItemFeed.tsx
@@ -33,7 +33,9 @@ const Item = memo(function Item({ item, tag }: { item: DimItem; tag: TagValue | 
       {isPhonePortrait ? (
         itemIcon
       ) : (
-        <DraggableInventoryItem item={item}>{itemIcon}</DraggableInventoryItem>
+        <DraggableInventoryItem item={item} anyBucket={true}>
+          {itemIcon}
+        </DraggableInventoryItem>
       )}
       <div className={styles.info}>
         <div className={styles.title}>


### PR DESCRIPTION
As a convenience, this allows moving Item Feed items to any character without having to scroll up/down to the specific slot for that item.