### PR TITLE
Fix overwriting the wrong loadout

### DIFF
--- a/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
+++ b/src/app/destiny1/loadout-drawer/D1LoadoutDrawer.tsx
@@ -36,7 +36,6 @@ import './loadout-drawer.scss';
 export default function D1LoadoutDrawer({
   initialLoadout,
   storeId,
-  isNew,
   showClass,
   onClose,
 }: {
@@ -47,7 +46,6 @@ export default function D1LoadoutDrawer({
    * mods are enabled, which subclass items to show, etc.
    */
   storeId: string;
-  isNew: boolean;
   showClass: boolean;
   onClose: () => void;
 }) {
@@ -117,7 +115,6 @@ export default function D1LoadoutDrawer({
   const footer = ({ onClose }: { onClose: () => void }) => (
     <LoadoutDrawerFooter
       loadout={loadout}
-      isNew={isNew}
       onSaveLoadout={(e, isNew) =>
         isNew ? saveAsNew(e, onClose) : onSaveLoadout(e, loadout, onClose)
       }

--- a/src/app/item-triage/ItemTriage.tsx
+++ b/src/app/item-triage/ItemTriage.tsx
@@ -148,9 +148,7 @@ function LoadoutsTriageSection({ item }: { item: DimItem }) {
           const edit =
             isDimLoadout &&
             (() => {
-              editLoadout(loadout, item.owner, {
-                isNew: false,
-              });
+              editLoadout(loadout, item.owner);
               hideItemPopup();
             });
           return (

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -105,7 +105,6 @@ export default memo(function LoadoutBuilder({
       loadout,
       resolvedStatConstraints,
       strictUpgradesStatConstraints,
-      isEditingExistingLoadout,
       pinnedItems,
       excludedItems,
       selectedStoreId,
@@ -461,7 +460,6 @@ export default memo(function LoadoutBuilder({
             loadouts={loadouts}
             armorEnergyRules={result.armorEnergyRules}
             autoStatMods={autoStatMods}
-            isEditingExistingLoadout={isEditingExistingLoadout}
             equippedHashes={equippedHashes}
           />
         ) : (

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -46,7 +46,6 @@ export default memo(function GeneratedSet({
   armorEnergyRules,
   equippedHashes,
   autoStatMods,
-  isEditingExistingLoadout,
 }: {
   originalLoadout: Loadout;
   set: ArmorSet;
@@ -61,7 +60,6 @@ export default memo(function GeneratedSet({
   armorEnergyRules: ArmorEnergyRules;
   equippedHashes: Set<number>;
   autoStatMods: boolean;
-  isEditingExistingLoadout: boolean;
 }) {
   const defs = useD2Definitions()!;
 
@@ -183,7 +181,6 @@ export default memo(function GeneratedSet({
           items={displayedItems}
           lockedMods={lockedMods}
           store={selectedStore}
-          isEditingExistingLoadout={isEditingExistingLoadout}
           canCompareLoadouts={canCompareLoadouts}
           halfTierMods={halfTierMods}
           lbDispatch={lbDispatch}

--- a/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetButtons.tsx
@@ -4,9 +4,11 @@ import { DimStore } from 'app/inventory/store-types';
 import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { Loadout } from 'app/loadout/loadout-types';
+import { loadoutSavedSelector } from 'app/loadout/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { Dispatch } from 'react';
+import { useSelector } from 'react-redux';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
 import { ArmorSet } from '../types';
 import { updateLoadoutWithArmorSet } from '../updated-loadout';
@@ -20,7 +22,6 @@ export default function GeneratedSetButtons({
   store,
   set,
   items,
-  isEditingExistingLoadout,
   lockedMods,
   canCompareLoadouts,
   halfTierMods,
@@ -32,7 +33,6 @@ export default function GeneratedSetButtons({
   /** The list of items to use - these are chosen from the set's options and match what's displayed. */
   items: DimItem[];
   lockedMods: PluggableInventoryItemDefinition[];
-  isEditingExistingLoadout: boolean;
   canCompareLoadouts: boolean;
   halfTierMods: PluggableInventoryItemDefinition[];
   lbDispatch: Dispatch<LoadoutBuilderAction>;
@@ -40,12 +40,12 @@ export default function GeneratedSetButtons({
   const defs = useD2Definitions()!;
   const dispatch = useThunkDispatch();
   const loadout = () => updateLoadoutWithArmorSet(defs, originalLoadout, set, items, lockedMods);
+  const isSaved = useSelector(loadoutSavedSelector(originalLoadout.id));
 
   // Opens the loadout menu for the generated set
   const openLoadout = () =>
     editLoadout(loadout(), store.id, {
       showClass: false,
-      isNew: !isEditingExistingLoadout || originalLoadout.id === 'equipped',
     });
 
   // Automatically equip items for this generated set to the active store
@@ -71,7 +71,7 @@ export default function GeneratedSetButtons({
   return (
     <div className={styles.buttons}>
       <button type="button" className="dim-button" onClick={openLoadout}>
-        {isEditingExistingLoadout ? t('Loadouts.UpdateLoadout') : t('Loadouts.SaveLoadout')}
+        {isSaved ? t('Loadouts.UpdateLoadout') : t('Loadouts.SaveLoadout')}
       </button>
       {canCompareLoadouts && (
         <button

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -35,7 +35,6 @@ export default function GeneratedSets({
   armorEnergyRules,
   loadout,
   autoStatMods,
-  isEditingExistingLoadout,
 }: {
   selectedStore: DimStore;
   sets: readonly ArmorSet[];
@@ -49,7 +48,6 @@ export default function GeneratedSets({
   armorEnergyRules: ArmorEnergyRules;
   loadout: Loadout;
   autoStatMods: boolean;
-  isEditingExistingLoadout: boolean;
 }) {
   const params = loadout.parameters!;
   const halfTierMods = useHalfTierMods(
@@ -80,7 +78,6 @@ export default function GeneratedSets({
           originalLoadout={loadout}
           equippedHashes={equippedHashes}
           autoStatMods={autoStatMods}
-          isEditingExistingLoadout={isEditingExistingLoadout}
         />
       )}
     </WindowVirtualList>

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -72,12 +72,6 @@ interface LoadoutBuilderConfiguration {
    * stats.
    */
   loadout: Loadout;
-  /**
-   * Are we editing an existing loadout, or a new one? The loadout may never
-   * have been saved (e.g. coming from a loadout share) but this still
-   * distinguishes between "clean slate" and when we started with a loadout.
-   */
-  isEditingExistingLoadout: boolean;
 
   /**
    * If we are editing an existing loadout via the "better stats available"
@@ -152,8 +146,6 @@ const lbConfigInit = ({
   const storeMatchingClass = pickBackingStore(stores, storeId, classTypeFromPreloadedLoadout);
   const initialLoadoutParameters = preloadedLoadout?.parameters;
 
-  const isEditingExistingLoadout = Boolean(preloadedLoadout && preloadedLoadout.id !== 'equipped');
-
   // If we requested a specific class type but the user doesn't have it, we
   // need to pick some different store, but ensure that class-specific stuff
   // doesn't end up in LO parameters.
@@ -224,7 +216,6 @@ const lbConfigInit = ({
 
   return {
     loadout,
-    isEditingExistingLoadout,
     resolvedStatConstraints: resolveStatConstraints(loadoutParameters.statConstraints!),
     strictUpgradesStatConstraints,
     pinnedItems,

--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -57,7 +57,6 @@ import { filterLoadoutToAllowedItems } from './loadout-utils';
 export default function LoadoutDrawer({
   initialLoadout,
   storeId,
-  isNew,
   fromExternal,
   onClose,
 }: {
@@ -68,7 +67,6 @@ export default function LoadoutDrawer({
    * mods are enabled, which subclass items to show, etc.
    */
   storeId: string;
-  isNew: boolean;
   fromExternal: boolean;
   onClose: () => void;
 }) {
@@ -210,7 +208,6 @@ export default function LoadoutDrawer({
   const footer = ({ onClose }: { onClose: () => void }) => (
     <LoadoutDrawerFooter
       loadout={loadout}
-      isNew={isNew}
       onSaveLoadout={(e, saveAsNew) => handleSaveLoadout(e, onClose, saveAsNew)}
       onDeleteLoadout={() => handleDeleteLoadout(onClose)}
       undo={undo}

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -101,7 +101,6 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
           setInitialLoadout({
             loadout: draftLoadout,
             storeId: owner.id,
-            isNew: true,
             showClass: true,
             fromExternal: true,
           });
@@ -129,7 +128,6 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
         setInitialLoadout({
           loadout: parsedLoadout,
           storeId,
-          isNew: true,
           showClass: false,
           fromExternal: true,
         });
@@ -163,7 +161,6 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
           <LoadoutDrawer
             initialLoadout={initialLoadout.loadout}
             storeId={initialLoadout.storeId}
-            isNew={initialLoadout.isNew}
             onClose={handleDrawerClose}
             fromExternal={initialLoadout.fromExternal}
           />
@@ -171,7 +168,6 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
           <D1LoadoutDrawer
             initialLoadout={initialLoadout.loadout}
             storeId={initialLoadout.storeId}
-            isNew={initialLoadout.isNew}
             showClass={initialLoadout.showClass}
             onClose={handleDrawerClose}
           />

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -2,6 +2,7 @@ import { ConfirmButton } from 'app/dim-ui/ConfirmButton';
 import { PressTip } from 'app/dim-ui/PressTip';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
+import { loadoutSavedSelector } from 'app/loadout/selectors';
 import { AppIcon, deleteIcon, redoIcon, undoIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
 import { isClassCompatible } from 'app/utils/item-utils';
@@ -31,7 +32,6 @@ const clashingLoadoutSelector = currySelector(
 
 export default function LoadoutDrawerFooter({
   loadout,
-  isNew,
   onSaveLoadout,
   onDeleteLoadout,
   undo,
@@ -40,7 +40,6 @@ export default function LoadoutDrawerFooter({
   hasRedo,
 }: {
   loadout: Readonly<Loadout>;
-  isNew: boolean;
   undo?: () => void;
   redo?: () => void;
   hasUndo?: boolean;
@@ -48,6 +47,7 @@ export default function LoadoutDrawerFooter({
   onSaveLoadout: (e: React.FormEvent, saveAsNew: boolean) => void;
   onDeleteLoadout: () => void;
 }) {
+  const isSaved = useSelector(loadoutSavedSelector(loadout.id));
   const clashingLoadout = useSelector(clashingLoadoutSelector(loadout));
   // There's an existing loadout with the same name & class and it's not the loadout we are currently editing
   const clashesWithAnotherLoadout = clashingLoadout && clashingLoadout.id !== loadout.id;
@@ -75,7 +75,7 @@ export default function LoadoutDrawerFooter({
   const saveDisabled = saveDisabledReasons.length > 0;
 
   // Don't show "Save as New" if this is a new loadout or we haven't changed the name
-  const showSaveAsNew = !isNew;
+  const showSaveAsNew = isSaved;
 
   const saveAsNewDisabled =
     saveDisabled ||
@@ -84,7 +84,7 @@ export default function LoadoutDrawerFooter({
 
   return (
     <div className={styles.loadoutOptions}>
-      <form onSubmit={(e) => onSaveLoadout(e, isNew)}>
+      <form onSubmit={(e) => onSaveLoadout(e, !isSaved)}>
         <PressTip
           tooltip={
             saveDisabledReasons.length > 0
@@ -93,7 +93,7 @@ export default function LoadoutDrawerFooter({
           }
         >
           <button className="dim-button" type="submit" disabled={saveDisabled}>
-            {isNew ? t('Loadouts.Save') : t('Loadouts.Update')}
+            {isSaved ? t('Loadouts.Update') : t('Loadouts.Save')}
           </button>
         </PressTip>
         {showSaveAsNew && (
@@ -117,7 +117,7 @@ export default function LoadoutDrawerFooter({
             </button>
           </PressTip>
         )}
-        {!isNew && (
+        {isSaved && (
           <ConfirmButton key="delete" danger onClick={onDeleteLoadout}>
             <AppIcon icon={deleteIcon} title={t('Loadouts.Delete')} />
           </ConfirmButton>

--- a/src/app/loadout-drawer/loadout-events.ts
+++ b/src/app/loadout-drawer/loadout-events.ts
@@ -12,11 +12,6 @@ export interface EditLoadoutState {
 
 export const editLoadout$ = new EventBus<EditLoadoutState>();
 export const addItem$ = new EventBus<DimItem>();
-export const copyAndEditLoadout$ = new EventBus<{
-  loadout: Loadout;
-  showClass?: boolean;
-  storeId: string;
-}>();
 
 /**
  * Start editing a loadout.
@@ -55,6 +50,10 @@ export function copyAndEditLoadout(
   storeId: string,
   { showClass = true }: { showClass?: boolean } = {},
 ) {
-  const copiedLoadout = { ...loadout, name: `${loadout.name} - Copy` };
+  const copiedLoadout = {
+    ...loadout,
+    name: `${loadout.name} - Copy`,
+    id: globalThis.crypto.randomUUID(),
+  };
   editLoadout(copiedLoadout, storeId, { showClass, isNew: true });
 }

--- a/src/app/loadout-drawer/loadout-events.ts
+++ b/src/app/loadout-drawer/loadout-events.ts
@@ -5,7 +5,6 @@ import { Loadout } from '../loadout/loadout-types';
 export interface EditLoadoutState {
   loadout: Loadout;
   showClass: boolean;
-  isNew: boolean;
   storeId: string;
   fromExternal: boolean;
 }
@@ -21,16 +20,14 @@ export function editLoadout(
   storeId: string,
   {
     showClass = true,
-    isNew = true,
     /** Is this from an external source (e.g. a loadout share)? */
     fromExternal = false,
-  }: { showClass?: boolean; isNew?: boolean; fromExternal?: boolean } = {},
+  }: { showClass?: boolean; fromExternal?: boolean } = {},
 ) {
   editLoadout$.next({
     storeId,
     loadout,
     showClass,
-    isNew,
     fromExternal,
   });
 }
@@ -53,7 +50,7 @@ export function copyAndEditLoadout(
   const copiedLoadout = {
     ...loadout,
     name: `${loadout.name} - Copy`,
-    id: globalThis.crypto.randomUUID(),
+    id: globalThis.crypto.randomUUID(), // Give it a new ID so it's a new loadout
   };
-  editLoadout(copiedLoadout, storeId, { showClass, isNew: true });
+  editLoadout(copiedLoadout, storeId, { showClass });
 }

--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -156,7 +156,7 @@ function Loadouts({ account }: { account: DestinyAccount }) {
 
   const handleNewLoadout = () => {
     const loadout = newLoadout('', [], selectedStore.classType);
-    editLoadout(loadout, selectedStore.id, { isNew: true });
+    editLoadout(loadout, selectedStore.id);
   };
 
   // Insert season headers if we're sorting by edit time

--- a/src/app/loadout/LoadoutsRow.tsx
+++ b/src/app/loadout/LoadoutsRow.tsx
@@ -36,7 +36,7 @@ export default memo(function LoadoutRow({
     const handleApply = () =>
       dispatch(applyLoadout(store, loadout, { allowUndo: true, onlyMatchingClass: true }));
 
-    const handleEdit = () => editLoadout(loadout, store.id, { isNew: !saved });
+    const handleEdit = () => editLoadout(loadout, store.id);
     const handleShare = () => onShare(loadout);
     const handleCopyAndEdit = () => copyAndEditLoadout(loadout, store.id);
 

--- a/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutDetailsSheet.tsx
@@ -41,7 +41,7 @@ export function InGameLoadoutDetails({
   const allItems = useSelector(allItemsSelector);
   const handleSaveAsDIM = () => {
     const dimLoadout = convertInGameLoadoutToDimLoadout(loadout, store.classType, allItems);
-    editLoadout(dimLoadout, store.id, { isNew: true });
+    editLoadout(dimLoadout, store.id);
   };
 
   const handleShare = () => {

--- a/src/app/loadout/ingame/InGameLoadoutStrip.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.tsx
@@ -86,7 +86,7 @@ function InGameLoadoutTile({
 
   const handleSaveAsDIM = () => {
     const dimLoadout = convertInGameLoadoutToDimLoadout(gameLoadout, store.classType, allItems);
-    editLoadout(dimLoadout, store.id, { isNew: true });
+    editLoadout(dimLoadout, store.id);
   };
   const handleShare = () => {
     const dimLoadout = convertInGameLoadoutToDimLoadout(gameLoadout, store.classType, allItems);

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -116,8 +116,7 @@ export default function LoadoutPopup({
     }
   };
 
-  const makeNewLoadout = () =>
-    editLoadout(newLoadout('', [], dimStore.classType), dimStore.id, { isNew: true });
+  const makeNewLoadout = () => editLoadout(newLoadout('', [], dimStore.classType), dimStore.id);
 
   const applySavedLoadout = (loadout: Loadout, { filterToEquipped = false } = {}) => {
     if (filterToEquipped) {
@@ -330,7 +329,7 @@ export default function LoadoutPopup({
             <span
               className={styles.altButton}
               title={t('Loadouts.Edit')}
-              onClick={() => editLoadout(loadout, dimStore.id, { isNew: false })}
+              onClick={() => editLoadout(loadout, dimStore.id)}
             >
               <AppIcon icon={editIcon} />
             </span>
@@ -412,7 +411,7 @@ function createRandomLoadout(store: DimStore): ThunkResult {
     const unlockedPlugs = unlockedPlugSetItemsSelector(store.id)(getState());
     let loadout = newLoadout(t('Loadouts.Random'), [], store.classType);
     loadout = randomizeFullLoadout(defs, store, allItems, searchFilter, unlockedPlugs)(loadout);
-    editLoadout(loadout, store.id, { isNew: true });
+    editLoadout(loadout, store.id);
   };
 }
 

--- a/src/app/loadout/loadout-share/LoadoutImportSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutImportSheet.tsx
@@ -42,7 +42,7 @@ export default function LoadoutImportSheet({
         const loadout = await getDecodedLoadout(decodedUrl);
         if (!canceled) {
           setState('ok');
-          editLoadout(loadout, currentStoreId, { isNew: true, fromExternal: true });
+          editLoadout(loadout, currentStoreId, { fromExternal: true });
           onClose();
         }
       } catch (e) {

--- a/src/app/loadout/selectors.ts
+++ b/src/app/loadout/selectors.ts
@@ -1,3 +1,4 @@
+import { currentProfileSelector } from 'app/dim-api/selectors';
 import { DimItem } from 'app/inventory/item-types';
 import { getHashtagsFromNote } from 'app/inventory/note-hashtags';
 import {
@@ -141,3 +142,10 @@ export const selectedLoadoutStoreSelector = createSelector(
     return stores.find((store) => store.id === selectedLoadoutStoreId) ?? defaultStore;
   },
 );
+
+/**
+ * Is this loadout ID saved to the user's profile? This doesn't mean it's been
+ * flushed to DIM Sync yet but just that it's been saved locally.
+ */
+export const loadoutSavedSelector = (loadoutId: string) => (state: RootState) =>
+  Boolean(currentProfileSelector(state)?.loadouts[loadoutId]);

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -893,9 +893,7 @@ function LoadoutsCell({
           ) : (
             <a
               data-filter-value={loadout.id}
-              onClick={(e: React.MouseEvent) =>
-                !e.shiftKey && editLoadout(loadout, owner, { isNew: false })
-              }
+              onClick={(e: React.MouseEvent) => !e.shiftKey && editLoadout(loadout, owner)}
             >
               {loadout.name}
             </a>


### PR DESCRIPTION
https://github.com/DestinyItemManager/DIM/issues/10767 is just the latest in a long line of loadout editing bugs where we lose track of whether we are dealing with a new loadout, or a previously saved loadout. We tried to solve this by plumbing state all over the app, but we keep missing stuff. This PR fixes the root problem by directly querying our local storage to see if the loadout is saved or not, at the point where it's needed. No more plumbing, and it's always correct. This works for the special "equipped" loadout too. And "Edit Copy" works by just setting a new loadout ID at the point where the edit starts.