### PR TITLE
Show tonic info

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 * If you click "Edit Copy" on a loadout, then click "Optimize Armor", then save the loadout from Loadout Optimizer, it will now save the copy, not the original loadout.
+* Tonics in the Tonic Capsule now show what their rewards or what artifact perk they affect is.
 
 ## 8.44.0 <span class="changelog-date">(2024-10-27)</span>
 

--- a/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.m.scss
@@ -125,3 +125,16 @@
 .insertLabel {
   width: 100%;
 }
+
+.perk {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 2px 0 0 0;
+
+  img {
+    width: 17px;
+    height: 17px;
+    margin-right: 4px;
+  }
+}

--- a/src/app/item-popup/SocketDetailsSelectedPlug.m.scss.d.ts
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.m.scss.d.ts
@@ -11,6 +11,7 @@ interface CssExports {
   'modIcon': string;
   'modRequirement': string;
   'modStats': string;
+  'perk': string;
   'selectedPlug': string;
   'source': string;
 }

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -239,6 +239,14 @@ export default function SocketDetailsSelectedPlug({
   const hideRequirements =
     plug.traitHashes?.includes(TraitHashes.ItemExoticCatalyst) && item.masterwork;
 
+  const showPerks = [
+    PlugCategoryHashes.Season25PotionsLoot,
+    PlugCategoryHashes.Season25PotionsCombat,
+    PlugCategoryHashes.Season25PotionsPlaceholder,
+    PlugCategoryHashes.Season25PotionsReagents,
+    PlugCategoryHashes.Season25PotionsFormula,
+  ].includes(plug.plug.plugCategoryHash);
+
   return (
     <div className={clsx(styles.selectedPlug, { [styles.hasStats]: stats.length > 0 })}>
       <div className={styles.modIcon}>
@@ -265,6 +273,21 @@ export default function SocketDetailsSelectedPlug({
             )}
           </React.Fragment>
         ))}
+        {showPerks &&
+          plug.perks.map((perk) => {
+            const def = defs.SandboxPerk.get(perk.perkHash);
+            if (!def) {
+              return null;
+            }
+            return (
+              <div className={styles.perk} key={perk.perkHash}>
+                <BungieImage src={def.displayProperties.icon} alt="" />
+                <RichDestinyText
+                  text={def.displayProperties.name || def.displayProperties.description}
+                />
+              </div>
+            );
+          })}
       </div>
 
       {stats.length > 0 && (


### PR DESCRIPTION
A quick one to show the full info for tonics in the (terribly overloaded by now) socket picker:

<img width="332" alt="Screenshot 2024-10-27 at 9 47 03 PM" src="https://github.com/user-attachments/assets/8bd880ec-bdd8-4bb1-8336-6219c3075ec8">

Fixes #10760