### PR TITLE
Fix crashes on Loadouts page

### DIFF
--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -78,7 +78,7 @@ export default function LoadoutEditBucket({
             key={bucket.hash}
             bucket={bucket}
             classType={classType}
-            items={itemsByBucket[bucket.hash]}
+            items={itemsByBucket[bucket.hash] ?? emptyArray()}
             onClickPlaceholder={onClickPlaceholder}
             onClickWarnItem={onClickWarnItem}
             onRemoveItem={onRemoveItem}

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -107,7 +107,7 @@ export default function LoadoutItemCategorySection({
               key={bucket.hash}
               storeId={store.id}
               bucketHash={bucket.hash}
-              items={itemsByBucket.get(bucket.hash)!}
+              items={itemsByBucket.get(bucket.hash) ?? emptyArray()}
               modsForBucket={modsByBucket[bucket.hash] ?? emptyArray()}
             />
           ))}


### PR DESCRIPTION
lodash's partition allows partitioning nullish values too (returning two empty arrays), while the es-toolkit replacement does not. We relied on lodash's behavior in at least two places.