### PR TITLE
Fix masks to compare with other helmets.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added Clan Reputation, Engram Ensiders, and Xûr Rank to the Progress page.
 * Slimmed down Bungie's Destiny database to fit within Firefox's storage limits.
 * Stream Deck selection now relies on buttons, not drag and drop.
+* Masks are now counted as helmets properly in Compare.
 
 ## 8.44.0 <span class="changelog-date">(2024-10-27)</span>
 

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -808,28 +808,25 @@ function getItemCategoryHashes(itemDef: DestinyInventoryItemDefinition): ItemCat
 
   if (
     itemCategoryHashes.includes(ItemCategoryHashes.Weapon) &&
-    !itemCategoryHashes.includes(ItemCategoryHashes.Dummies)
+    !itemCategoryHashes.includes(ItemCategoryHashes.Dummies) &&
+    itemCategoryHashes.includes(ItemCategoryHashes.GrenadeLaunchers) &&
+    !itemCategoryHashes.includes(ItemCategoryHashes.PowerWeapon)
   ) {
-    if (
-      itemCategoryHashes.includes(ItemCategoryHashes.GrenadeLaunchers) &&
-      !itemCategoryHashes.includes(ItemCategoryHashes.PowerWeapon)
-    ) {
-      // Special grenade launchers
-      itemCategoryHashes = [
-        // Special grenade launchers are not heavy grenade launchers
-        ...itemCategoryHashes.filter((ich) => ich !== ItemCategoryHashes.GrenadeLaunchers),
-        -ItemCategoryHashes.GrenadeLaunchers,
-      ];
-    }
+    // Special grenade launchers
+    itemCategoryHashes = [
+      // Special grenade launchers are not heavy grenade launchers
+      ...itemCategoryHashes.filter((ich) => ich !== ItemCategoryHashes.GrenadeLaunchers),
+      -ItemCategoryHashes.GrenadeLaunchers,
+    ];
+  }
 
-    if (itemDef.hash in extendedICH) {
-      const additionalICH = extendedICH[itemDef.hash]!;
-      itemCategoryHashes = [...itemCategoryHashes, additionalICH];
+  if (itemDef.hash in extendedICH) {
+    const additionalICH = extendedICH[itemDef.hash]!;
+    itemCategoryHashes = [...itemCategoryHashes, additionalICH];
 
-      // Masks are helmets too
-      if (additionalICH === ItemCategoryHashes.Mask) {
-        itemCategoryHashes = [...itemCategoryHashes, ItemCategoryHashes.Helmets];
-      }
+    // Masks are helmets too
+    if (additionalICH === ItemCategoryHashes.Mask) {
+      itemCategoryHashes = [...itemCategoryHashes, ItemCategoryHashes.Helmets];
     }
   }
 


### PR DESCRIPTION
The logic was there, but it had fallen inside a check that only applied to weapons.