### PR TITLE
Add error boundaries to more places

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -57,13 +57,64 @@ export default function App() {
         <ErrorBoundary name="DIM Code">
           <Suspense fallback={<ShowPageLoading message={t('Loading.Code')} />}>
             <Routes>
-              <Route path="about" element={<About />} />
-              <Route path="privacy" element={<Privacy />} />
-              <Route path="whats-new" element={<WhatsNew />} />
-              <Route path="login" element={<Login />} />
-              <Route path="settings" element={<SettingsPage />} />
-              <Route path="debug" element={<Debug />} />
-              {$DIM_FLAVOR === 'dev' && <Route path="developer" element={<Developer />} />}
+              <Route
+                path="about"
+                element={
+                  <ErrorBoundary name="about" key="about">
+                    <About />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="privacy"
+                element={
+                  <ErrorBoundary name="privacy" key="privacy">
+                    <Privacy />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="whats-new"
+                element={
+                  <ErrorBoundary name="whatsNew" key="whatsNew">
+                    <WhatsNew />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="login"
+                element={
+                  <ErrorBoundary name="login" key="login">
+                    <Login />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="settings"
+                element={
+                  <ErrorBoundary name="settings" key="settings">
+                    <SettingsPage />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="debug"
+                element={
+                  <ErrorBoundary name="debug" key="debug">
+                    <Debug />
+                  </ErrorBoundary>
+                }
+              />
+              {$DIM_FLAVOR === 'dev' && (
+                <Route
+                  path="developer"
+                  element={
+                    <ErrorBoundary name="developer" key="developer">
+                      <Developer />
+                    </ErrorBoundary>
+                  }
+                />
+              )}
               {needsLogin ? (
                 <Route
                   path="*"
@@ -77,7 +128,14 @@ export default function App() {
                 />
               ) : (
                 <>
-                  <Route path="search-history" element={<SearchHistory />} />
+                  <Route
+                    path="search-history"
+                    element={
+                      <ErrorBoundary name="searchHistory" key="searchHistory">
+                        <SearchHistory />
+                      </ErrorBoundary>
+                    }
+                  />
                   <Route path="armory/*" element={<DefaultAccount />} />
                   <Route path=":membershipId/:destinyVersion/*" element={<Destiny />} />
                   <Route path="*" element={<DefaultAccount />} />

--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -51,10 +51,8 @@ const logThrottle = (timesThrottled: number, waitTime: number, url: string) =>
 export const authenticatedHttpClient = dimErrorHandledHttpClient(
   responsivelyThrottleHttpClient(
     createHttpClient(
-      createFetchWithNonStoppingTimeout(
-        rateLimitedFetch(fetchWithBungieOAuth),
-        TIMEOUT,
-        notifyTimeout,
+      rateLimitedFetch(
+        createFetchWithNonStoppingTimeout(fetchWithBungieOAuth, TIMEOUT, notifyTimeout),
       ),
       API_KEY,
     ),

--- a/src/app/dim-ui/CollapsibleTitle.tsx
+++ b/src/app/dim-ui/CollapsibleTitle.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import { toggleCollapsedSection } from '../settings/actions';
 import { AppIcon, collapseIcon } from '../shell/icons';
 import styles from './CollapsibleTitle.m.scss';
+import ErrorBoundary from './ErrorBoundary';
 
 export const Title = forwardRef(function Title(
   {
@@ -114,7 +115,9 @@ export default function CollapsibleTitle({
         onClick={toggle}
       />
       <CollapsedSection collapsed={collapsed} headerId={headerId} contentId={contentId}>
-        {children}
+        <ErrorBoundary name={`collapse-${sectionId}`} key={contentId}>
+          {children}
+        </ErrorBoundary>
       </CollapsedSection>
     </>
   );

--- a/src/app/dim-ui/ErrorBoundary.tsx
+++ b/src/app/dim-ui/ErrorBoundary.tsx
@@ -26,6 +26,12 @@ export default class ErrorBoundary extends Component<Props, State> {
     reportException(name, error, errorInfo);
   }
 
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (prevProps.name !== this.props.name) {
+      this.setState({ error: undefined });
+    }
+  }
+
   render() {
     const { error } = this.state;
     const { children } = this.props;

--- a/src/app/dim-ui/PageWithMenu.tsx
+++ b/src/app/dim-ui/PageWithMenu.tsx
@@ -1,6 +1,7 @@
 import useResizeObserver from '@react-hook/resize-observer';
 import clsx from 'clsx';
 import React, { useRef, useState } from 'react';
+import ErrorBoundary from './ErrorBoundary';
 import styles from './PageWithMenu.m.scss';
 
 function PageWithMenu({ children, className }: { children: React.ReactNode; className?: string }) {
@@ -50,7 +51,11 @@ PageWithMenu.Contents = function Contents({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <div className={clsx(className, styles.contents)}>{children}</div>;
+  return (
+    <div className={clsx(className, styles.contents)}>
+      <ErrorBoundary name="pageWithMenu-contents">{children}</ErrorBoundary>
+    </div>
+  );
 };
 
 /** A header for a section of links (MenuButtons) within a Menu. */

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -22,6 +22,7 @@ import React, {
   useState,
 } from 'react';
 import { AppIcon, disabledIcon } from '../shell/icons';
+import ErrorBoundary from './ErrorBoundary';
 import { PressTipRoot } from './PressTip';
 import styles from './Sheet.m.scss';
 import { useFixOverscrollBehavior } from './useFixOverscrollBehavior';
@@ -299,7 +300,9 @@ export default function Sheet({
           style={frozenHeight ? { flexBasis: frozenHeight } : undefined}
           ref={sheetContents}
         >
-          {typeof children === 'function' ? children({ onClose: triggerClose }) : children}
+          <ErrorBoundary name="sheet-contents">
+            {typeof children === 'function' ? children({ onClose: triggerClose }) : children}
+          </ErrorBoundary>
         </div>
 
         {Boolean(footer) && (

--- a/src/app/inventory-page/Inventory.tsx
+++ b/src/app/inventory-page/Inventory.tsx
@@ -1,5 +1,4 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
-import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import GearPower from 'app/gear-power/GearPower';
 import { t } from 'app/i18next-t';
@@ -18,11 +17,11 @@ export default function Inventory({ account }: { account: DestinyAccount }) {
   }
 
   return (
-    <ErrorBoundary name="Inventory">
+    <>
       <Stores />
       <DragPerformanceFix />
       {account.destinyVersion === 2 && <GearPower />}
       {account.destinyVersion === 2 && <MaterialCountsSheet />}
-    </ErrorBoundary>
+    </>
   );
 }

--- a/src/app/organizer/Organizer.tsx
+++ b/src/app/organizer/Organizer.tsx
@@ -1,5 +1,4 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
-import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
@@ -121,10 +120,8 @@ export default function Organizer({ account }: Props) {
 
   return (
     <div className={styles.organizer}>
-      <ErrorBoundary name="Organizer">
-        <ItemTypeSelector selection={selection} selectionTree={types} onSelection={onSelection} />
-        <ItemTable categories={selection} />
-      </ErrorBoundary>
+      <ItemTypeSelector selection={selection} selectionTree={types} onSelection={onSelection} />
+      <ItemTable categories={selection} />
     </div>
   );
 }

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -119,141 +119,129 @@ export default function Progress({ account }: { account: DestinyAccount }) {
   ]);
 
   return (
-    <ErrorBoundary name="Progress">
-      <PageWithMenu>
-        <PageWithMenu.Menu>
-          {selectedStore && (
-            <CharacterSelect
-              stores={stores}
-              selectedStore={selectedStore}
-              onCharacterChanged={setSelectedStoreId}
-            />
+    <PageWithMenu>
+      <PageWithMenu.Menu>
+        {selectedStore && (
+          <CharacterSelect
+            stores={stores}
+            selectedStore={selectedStore}
+            onCharacterChanged={setSelectedStoreId}
+          />
+        )}
+        {!isPhonePortrait && (
+          <div className={styles.menuLinks}>
+            {menuItems.map((menuItem) => (
+              <PageWithMenu.MenuButton key={menuItem.id} anchor={menuItem.id}>
+                <span>{menuItem.title}</span>
+              </PageWithMenu.MenuButton>
+            ))}
+          </div>
+        )}
+      </PageWithMenu.Menu>
+
+      <PageWithMenu.Contents className={styles.progress}>
+        <motion.div className="horizontal-swipable" onPanEnd={handleSwipe}>
+          <section id="ranks">
+            <CollapsibleTitle title={t('Progress.CrucibleRank')} sectionId="profile-ranks">
+              <div className="progress-row">
+                <Ranks profileInfo={profileInfo} />
+              </div>
+            </CollapsibleTitle>
+          </section>
+
+          <section id="trackedTriumphs">
+            <CollapsibleTitle title={t('Progress.TrackedTriumphs')} sectionId="trackedTriumphs">
+              <div className="progress-row">
+                <TrackedTriumphs searchQuery={searchQuery} />
+              </div>
+            </CollapsibleTitle>
+          </section>
+
+          {eventCard && (
+            <section id="event">
+              <CollapsibleTitle title={eventCard.displayProperties.name} sectionId="event">
+                <div className="progress-row">
+                  <Event card={eventCard} store={selectedStore} buckets={buckets} />
+                </div>
+              </CollapsibleTitle>
+            </section>
           )}
-          {!isPhonePortrait && (
-            <div className={styles.menuLinks}>
-              {menuItems.map((menuItem) => (
-                <PageWithMenu.MenuButton key={menuItem.id} anchor={menuItem.id}>
-                  <span>{menuItem.title}</span>
-                </PageWithMenu.MenuButton>
-              ))}
-            </div>
-          )}
-        </PageWithMenu.Menu>
 
-        <PageWithMenu.Contents className={styles.progress}>
-          <motion.div className="horizontal-swipable" onPanEnd={handleSwipe}>
-            <section id="ranks">
-              <CollapsibleTitle title={t('Progress.CrucibleRank')} sectionId="profile-ranks">
-                <div className="progress-row">
-                  <ErrorBoundary name="CrucibleRanks">
-                    <Ranks profileInfo={profileInfo} />
-                  </ErrorBoundary>
-                </div>
-              </CollapsibleTitle>
-            </section>
+          <section id="milestones">
+            <CollapsibleTitle title={t('Progress.Milestones')} sectionId="milestones">
+              <div className="progress-row">
+                <Milestones buckets={buckets} profileInfo={profileInfo} store={selectedStore} />
+              </div>
+            </CollapsibleTitle>
+          </section>
 
-            <section id="trackedTriumphs">
-              <CollapsibleTitle title={t('Progress.TrackedTriumphs')} sectionId="trackedTriumphs">
-                <div className="progress-row">
-                  <ErrorBoundary name={t('Progress.TrackedTriumphs')}>
-                    <TrackedTriumphs searchQuery={searchQuery} />
-                  </ErrorBoundary>
-                </div>
-              </CollapsibleTitle>
-            </section>
-
-            {eventCard && (
-              <section id="event">
-                <CollapsibleTitle title={eventCard.displayProperties.name} sectionId="event">
-                  <div className="progress-row">
-                    <ErrorBoundary name={eventCard.displayProperties.name}>
-                      <Event card={eventCard} store={selectedStore} buckets={buckets} />
-                    </ErrorBoundary>
-                  </div>
-                </CollapsibleTitle>
-              </section>
-            )}
-
-            <section id="milestones">
-              <CollapsibleTitle title={t('Progress.Milestones')} sectionId="milestones">
-                <div className="progress-row">
-                  <ErrorBoundary name="Milestones">
-                    <Milestones buckets={buckets} profileInfo={profileInfo} store={selectedStore} />
-                  </ErrorBoundary>
-                </div>
-              </CollapsibleTitle>
-            </section>
-
-            {paleHeartPathfinderNode && (
-              <ErrorBoundary name={t('Progress.PaleHeartPathfinder')}>
-                <Pathfinder
-                  id="paleHeartPathfinder"
-                  name={t('Progress.PaleHeartPathfinder')}
-                  presentationNode={paleHeartPathfinderNode}
-                  store={selectedStore}
-                />
-              </ErrorBoundary>
-            )}
-
-            {gambitPathfinderNode && (
-              <ErrorBoundary name={t('Progress.GambitPathfinder')}>
-                <Pathfinder
-                  id="gambitPathfinder"
-                  name={t('Progress.GambitPathfinder')}
-                  presentationNode={gambitPathfinderNode}
-                  store={selectedStore}
-                />
-              </ErrorBoundary>
-            )}
-
-            {cruciblePathfinderNode && (
-              <ErrorBoundary name={t('Progress.CruciblePathfinder')}>
-                <Pathfinder
-                  id="cruciblePathfinder"
-                  name={t('Progress.CruciblePathfinder')}
-                  presentationNode={cruciblePathfinderNode}
-                  store={selectedStore}
-                />
-              </ErrorBoundary>
-            )}
-            {vanguardPathfinderNode && (
-              <ErrorBoundary name={t('Progress.VanguardPathfinder')}>
-                <Pathfinder
-                  id="vanguardPathfinder"
-                  name={t('Progress.VanguardPathfinder')}
-                  presentationNode={vanguardPathfinderNode}
-                  store={selectedStore}
-                />
-              </ErrorBoundary>
-            )}
-
-            {seasonalChallengesPresentationNode && (
-              <ErrorBoundary name="SeasonalChallenges">
-                <SeasonalChallenges
-                  seasonalChallengesPresentationNode={seasonalChallengesPresentationNode}
-                  store={selectedStore}
-                />
-              </ErrorBoundary>
-            )}
-
-            <ErrorBoundary name="Pursuits">
-              <Pursuits store={selectedStore} />
+          {paleHeartPathfinderNode && (
+            <ErrorBoundary name={t('Progress.PaleHeartPathfinder')}>
+              <Pathfinder
+                id="paleHeartPathfinder"
+                name={t('Progress.PaleHeartPathfinder')}
+                presentationNode={paleHeartPathfinderNode}
+                store={selectedStore}
+              />
             </ErrorBoundary>
+          )}
 
-            {raidNode && (
-              <section id="raids">
-                <CollapsibleTitle title={raidTitle} sectionId="raids">
-                  <div className="progress-row">
-                    <ErrorBoundary name="Raids">
-                      <Raids store={selectedStore} profileInfo={profileInfo} />
-                    </ErrorBoundary>
-                  </div>
-                </CollapsibleTitle>
-              </section>
-            )}
-          </motion.div>
-        </PageWithMenu.Contents>
-      </PageWithMenu>
-    </ErrorBoundary>
+          {gambitPathfinderNode && (
+            <ErrorBoundary name={t('Progress.GambitPathfinder')}>
+              <Pathfinder
+                id="gambitPathfinder"
+                name={t('Progress.GambitPathfinder')}
+                presentationNode={gambitPathfinderNode}
+                store={selectedStore}
+              />
+            </ErrorBoundary>
+          )}
+
+          {cruciblePathfinderNode && (
+            <ErrorBoundary name={t('Progress.CruciblePathfinder')}>
+              <Pathfinder
+                id="cruciblePathfinder"
+                name={t('Progress.CruciblePathfinder')}
+                presentationNode={cruciblePathfinderNode}
+                store={selectedStore}
+              />
+            </ErrorBoundary>
+          )}
+          {vanguardPathfinderNode && (
+            <ErrorBoundary name={t('Progress.VanguardPathfinder')}>
+              <Pathfinder
+                id="vanguardPathfinder"
+                name={t('Progress.VanguardPathfinder')}
+                presentationNode={vanguardPathfinderNode}
+                store={selectedStore}
+              />
+            </ErrorBoundary>
+          )}
+
+          {seasonalChallengesPresentationNode && (
+            <ErrorBoundary name="SeasonalChallenges">
+              <SeasonalChallenges
+                seasonalChallengesPresentationNode={seasonalChallengesPresentationNode}
+                store={selectedStore}
+              />
+            </ErrorBoundary>
+          )}
+
+          <ErrorBoundary name="Pursuits">
+            <Pursuits store={selectedStore} />
+          </ErrorBoundary>
+
+          {raidNode && (
+            <section id="raids">
+              <CollapsibleTitle title={raidTitle} sectionId="raids">
+                <div className="progress-row">
+                  <Raids store={selectedStore} profileInfo={profileInfo} />
+                </div>
+              </CollapsibleTitle>
+            </section>
+          )}
+        </motion.div>
+      </PageWithMenu.Contents>
+    </PageWithMenu>
   );
 }

--- a/src/app/records/Records.tsx
+++ b/src/app/records/Records.tsx
@@ -148,9 +148,7 @@ export default function Records({ account }: Props) {
       <PageWithMenu.Contents className={styles.page}>
         <section id="trackedTriumphs">
           <CollapsibleTitle title={t('Progress.TrackedTriumphs')} sectionId="trackedTriumphs">
-            <ErrorBoundary name={t('Progress.TrackedTriumphs')}>
-              <TrackedTriumphs searchQuery={searchQuery} />
-            </ErrorBoundary>
+            <TrackedTriumphs searchQuery={searchQuery} />
           </CollapsibleTitle>
         </section>
         {nodeHashes
@@ -161,20 +159,18 @@ export default function Records({ account }: Props) {
                 title={overrideTitles[nodeDef.hash] || nodeDef.displayProperties.name}
                 sectionId={`p_${nodeDef.hash}`}
               >
-                <ErrorBoundary name={nodeDef.displayProperties.name}>
-                  <PresentationNodeRoot
-                    presentationNodeHash={nodeDef.hash}
-                    profileResponse={profileResponse}
-                    ownedItemHashes={ownedItemHashes.accountWideOwned}
-                    openedPresentationHash={presentationNodeHash}
-                    searchQuery={searchQuery}
-                    searchFilter={searchFilter}
-                    overrideName={overrideTitles[nodeDef.hash]}
-                    isTriumphs={nodeDef.hash === recordsRootHash}
-                    showPlugSets={nodeDef.hash === collectionsRootHash}
-                    completedRecordsHidden={completedRecordsHidden}
-                  />
-                </ErrorBoundary>
+                <PresentationNodeRoot
+                  presentationNodeHash={nodeDef.hash}
+                  profileResponse={profileResponse}
+                  ownedItemHashes={ownedItemHashes.accountWideOwned}
+                  openedPresentationHash={presentationNodeHash}
+                  searchQuery={searchQuery}
+                  searchFilter={searchFilter}
+                  overrideName={overrideTitles[nodeDef.hash]}
+                  isTriumphs={nodeDef.hash === recordsRootHash}
+                  showPlugSets={nodeDef.hash === collectionsRootHash}
+                  completedRecordsHidden={completedRecordsHidden}
+                />
               </CollapsibleTitle>
             </section>
           ))}

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -9,6 +9,7 @@ import {
 import ArmoryPage from 'app/armory/ArmoryPage';
 import CompareContainer from 'app/compare/CompareContainer';
 import { settingSelector } from 'app/dim-api/selectors';
+import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import Farming from 'app/farming/Farming';
 import { useHotkey, useHotkeys } from 'app/hotkeys/useHotkey';
@@ -191,51 +192,125 @@ export default function Destiny() {
       <SingleVendorSheetContainer>
         <div className={styles.content}>
           <Routes>
-            <Route path="inventory" element={<Inventory account={account} />} />
+            <Route
+              path="inventory"
+              element={
+                <ErrorBoundary name="inventory" key="inventory">
+                  <Inventory account={account} />
+                </ErrorBoundary>
+              }
+            />
             {account.destinyVersion === 2 && (
-              <Route path="progress" element={<Progress account={account} />} />
+              <Route
+                path="progress"
+                element={
+                  <ErrorBoundary name="progress" key="progress">
+                    <Progress account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             {account.destinyVersion === 2 && (
-              <Route path="records" element={<Records account={account} />} />
+              <Route
+                path="records"
+                element={
+                  <ErrorBoundary name="records" key="records">
+                    <Records account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             <Route
               path="optimizer"
               element={
-                account.destinyVersion === 2 ? (
-                  <LoadoutBuilderContainer account={account} />
-                ) : (
-                  <D1LoadoutBuilder account={account} />
-                )
+                <ErrorBoundary name="optimizer" key="optimizer">
+                  {account.destinyVersion === 2 ? (
+                    <LoadoutBuilderContainer account={account} />
+                  ) : (
+                    <D1LoadoutBuilder account={account} />
+                  )}
+                </ErrorBoundary>
               }
             />
             {account.destinyVersion === 2 && (
-              <Route path="loadouts" element={<Loadouts account={account} />} />
+              <Route
+                path="loadouts"
+                element={
+                  <ErrorBoundary name="loadouts" key="loadouts">
+                    <Loadouts account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
-            <Route path="organizer" element={<Organizer account={account} />} />
+            <Route
+              path="organizer"
+              element={
+                <ErrorBoundary name="organizer" key="organizer">
+                  <Organizer account={account} />
+                </ErrorBoundary>
+              }
+            />
             {account.destinyVersion === 2 && (
-              <Route path="vendors/:vendorHash" element={<SingleVendorPage account={account} />} />
+              <Route
+                path="vendors/:vendorHash"
+                element={
+                  <ErrorBoundary name="singleVendor" key="singleVendor">
+                    <SingleVendorPage account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             <Route
               path="vendors"
               element={
-                account.destinyVersion === 2 ? (
-                  <Vendors account={account} />
-                ) : (
-                  <D1Vendors account={account} />
-                )
+                <ErrorBoundary name="vendors" key="vendors">
+                  {account.destinyVersion === 2 ? (
+                    <Vendors account={account} />
+                  ) : (
+                    <D1Vendors account={account} />
+                  )}
+                </ErrorBoundary>
               }
             />
             {account.destinyVersion === 2 && (
-              <Route path="armory/:itemHash" element={<ArmoryPage account={account} />} />
+              <Route
+                path="armory/:itemHash"
+                element={
+                  <ErrorBoundary name="armory" key="armory">
+                    <ArmoryPage account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             {account.destinyVersion === 2 && (
-              <Route path="item-feed" element={<ItemFeedPage account={account} />} />
+              <Route
+                path="item-feed"
+                element={
+                  <ErrorBoundary name="itemFeed" key="itemFeed">
+                    <ItemFeedPage account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             {account.destinyVersion === 1 && (
-              <Route path="record-books" element={<RecordBooks account={account} />} />
+              <Route
+                path="record-books"
+                element={
+                  <ErrorBoundary name="recordBooks" key="recordBooks">
+                    <RecordBooks account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             {account.destinyVersion === 1 && (
-              <Route path="activities" element={<Activities account={account} />} />
+              <Route
+                path="activities"
+                element={
+                  <ErrorBoundary name="activities" key="activities">
+                    <Activities account={account} />
+                  </ErrorBoundary>
+                }
+              />
             )}
             <Route path="*" element={<Navigate to="inventory" />} />
           </Routes>

--- a/src/app/vendors/single-vendor/SingleVendor.tsx
+++ b/src/app/vendors/single-vendor/SingleVendor.tsx
@@ -1,6 +1,5 @@
 import { DestinyAccount } from 'app/accounts/destiny-account';
 import Countdown from 'app/dim-ui/Countdown';
-import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { useDynamicStringReplacer } from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { t } from 'app/i18next-t';
@@ -147,7 +146,7 @@ export default function SingleVendor({
   }
 
   return (
-    <ErrorBoundary name="SingleVendor">
+    <>
       <div className={styles.featuredHeader}>
         <h1>
           {displayName} <VendorLocation>{placeString}</VendorLocation>
@@ -169,6 +168,6 @@ export default function SingleVendor({
           characterId={characterId}
         />
       )}
-    </ErrorBoundary>
+    </>
   );
 }


### PR DESCRIPTION
This adds error boundaries around every page, so that if an error occurs, you can still navigate to other pages. It also adds error boundaries to sheet contents and collapsible sections by default, which again should narrow how much of the page could break.

I also reordered our fetch wrappers to count only time-in-request for "bungie is slow", not time-in-queue.