### PR TITLE
Misc early November display fixes

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1109,6 +1109,7 @@
     "Milestones": "Milestones & Challenges",
     "PaleHeartPathfinder": "Pale Heart Pathfinder",
     "PercentPrestige": "{{pct}}% to reset",
+    "PercentMax": "{{pct}}% to maximum",
     "PointsUsed": "1 point used",
     "PointsUsed_plural": "{{count}} points used",
     "PowerBonusHeader": "+{{powerBonus}} Power Rewards",

--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -137,7 +137,7 @@ export default function Armory({
                   season: season.seasonNumber,
                   year: getItemYear(item) ?? '?',
                 })}
-                ){Boolean(event) && <span> - {D2EventInfo[getEvent(item)!].name}</span>}
+                ){Boolean(event) && ` - ${D2EventInfo[getEvent(item)!].name}`}
               </div>
             )}
           </div>

--- a/src/app/progress/ReputationRank.m.scss
+++ b/src/app/progress/ReputationRank.m.scss
@@ -50,6 +50,9 @@
 
 .factionLevel {
   color: var(--theme-text-secondary);
+  &.max {
+    color: var(--theme-accent-primary);
+  }
 }
 
 .rankIcon {

--- a/src/app/progress/ReputationRank.m.scss.d.ts
+++ b/src/app/progress/ReputationRank.m.scss.d.ts
@@ -10,6 +10,7 @@ interface CssExports {
   'factionLevel': string;
   'factionName': string;
   'gridLayout': string;
+  'max': string;
   'rankIcon': string;
   'winStreak': string;
 }

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -523,7 +523,7 @@ function SearchBar(
           <AnimatePresence>
             {children}
 
-            {liveQuery.length > 0 && (saveable || saved) && !isPhonePortrait && (
+            {liveQuery.length > 0 && valid && (saveable || saved) && !isPhonePortrait && (
               <motion.button
                 variants={searchButtonAnimateVariants}
                 exit="hidden"

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1102,6 +1102,7 @@
     "NoEventChallenges": "You have completed all event challenges",
     "NoTrackedTriumph": "You have no tracked triumphs. Track as many as you like in DIM.",
     "PaleHeartPathfinder": "Pale Heart Pathfinder",
+    "PercentMax": "{{pct}}% to maximum",
     "PercentPrestige": "{{pct}}% to reset",
     "PointsUsed": "1 point used",
     "PointsUsed_plural": "{{count}} points used",


### PR DESCRIPTION
Stop advertising comp rank as resettable (↓after)
![image](https://github.com/user-attachments/assets/16778168-491b-443d-811e-fe5bc8494125)

Highlight ranks that are maxed out (↓after)
![image](https://github.com/user-attachments/assets/60a01094-e4fb-4b54-8e45-a0063a8d72fc)

Fix this spacing error (↓before)
![image](https://github.com/user-attachments/assets/8fd6e0f5-672a-4bac-a674-cdd73e633ecc)

When a search is invalid, but canonicalizes down to a valid saved search, stop indicating it's saved (↓before)
![image](https://github.com/user-attachments/assets/dd2e3117-68de-4936-a622-20b2ec5ff0c5)
