### PR TITLE
Fix D1 inventory

### DIFF
--- a/src/app/inventory/store/d1-item-factory.ts
+++ b/src/app/inventory/store/d1-item-factory.ts
@@ -88,13 +88,16 @@ export function processItems(
 }
 
 const getClassTypeNameLocalized = memoize(
-  (type: DestinyClass, defs: D1ManifestDefinitions): string => {
+  ([type, defs]: [type: DestinyClass, defs: D1ManifestDefinitions]): string => {
     const klass = Object.values(defs.Class.getAll()).find((c) => c.classType === type);
     if (klass) {
       return klass.className;
     } else {
       return t('Loadouts.Any');
     }
+  },
+  {
+    getCacheKey: ([type]) => `${type}`,
   },
 );
 
@@ -319,7 +322,7 @@ function makeItem(
     maxStackSize: itemDef.maxStackSize > 0 ? itemDef.maxStackSize : 1,
     // 0: titan, 1: hunter, 2: warlock, 3: any
     classType: itemDef.classType,
-    classTypeNameLocalized: getClassTypeNameLocalized(itemDef.classType, defs),
+    classTypeNameLocalized: getClassTypeNameLocalized([itemDef.classType, defs]),
     element,
     ammoType: getAmmoType(normalBucket.hash),
     sourceHashes: itemDef.sourceHashes,


### PR DESCRIPTION
`es-toolkit`'s `memoize` behaves a bit weirdly - it only accepts a single argument, not multiple. Their types don't prevent you from using it incorrectly either. This was causing us to error out on D1 inventory creation.