### PR TITLE
Only suppress pointer events for images on mobile

### DIFF
--- a/src/app/main.scss
+++ b/src/app/main.scss
@@ -156,7 +156,9 @@ label {
 // Use this to make images not tappable (Android Chrome will show a download menu)
 .no-pointer-events,
 .app-icon {
-  pointer-events: none;
+  @include phone-portrait {
+    pointer-events: none;
+  }
 }
 
 a {


### PR DESCRIPTION
We suppressed pointer events on all bungie images in order to prevent Android's weird download menu, but that also got rid of all native hover tooltips. This restores them by making the no-pointer-events rule only apply to mobile.