### PR TITLE
Fix autocomplete for incomplete terms like `memento:`

### DIFF
--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -31,6 +31,8 @@ describe('autocompleteTermSuggestions', () => {
     ['is:bow is:v|oid', 'is:bow is:void'],
     ['season:>outl', 'season:>outlaw'],
     ['not(', 'Expected failure'],
+    ['memento:', 'memento:any'],
+    ['foo memento:', 'foo memento:any'],
   ];
 
   const plainStringCases: [query: string, mockCandidate: string][] = [['jotu', 'jötunn']];

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -4,7 +4,7 @@ import { compact, uniqBy } from 'app/utils/collections';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { ArmoryEntry, getArmorySuggestions } from './armory-search';
 import { canonicalFilterFormats } from './filter-types';
-import { QueryLexerOpenQuotesError, lexer, makeCommentString, parseQuery } from './query-parser';
+import { lexer, makeCommentString, parseQuery, QueryLexerError } from './query-parser';
 import { FiltersMap, SearchConfig, Suggestion } from './search-config';
 import { plainString } from './text-utils';
 
@@ -281,7 +281,7 @@ function findLastFilter(queryUpToCaret: string): number[] | null {
     }
   } catch (e) {
     // If the lexer failed because of unmatched quotes, that's *definitely* something to autocomplete!
-    if (e instanceof QueryLexerOpenQuotesError) {
+    if (e instanceof QueryLexerError) {
       incompleteFilterIndices = [e.startIndex];
     }
   }


### PR DESCRIPTION
In https://github.com/DestinyItemManager/DIM/pull/9204, I added errors to the lexer and caught them in the autocompleter to support autocompleting within unclosed quotes. But I didn't catch the case where the filter was invalid because it didn't have an argument. This caused there to be no suggestions, when there could've been. By catching the parent error, we get those suggestions back.

Fixes #10787