### PR TITLE
Remove event delegation from SortOrderEditor

### DIFF
--- a/src/app/settings/SortOrderEditor.m.scss
+++ b/src/app/settings/SortOrderEditor.m.scss
@@ -31,10 +31,10 @@
   flex: 1;
 }
 
-:global(.sort-forward) {
+.sortForward {
   color: var(--theme-accent-primary);
 }
-:global(.sort-reverse) {
+.sortReverse {
   color: var(--theme-accent-secondary);
 }
 

--- a/src/app/settings/SortOrderEditor.m.scss.d.ts
+++ b/src/app/settings/SortOrderEditor.m.scss.d.ts
@@ -7,6 +7,8 @@ interface CssExports {
   'grip': string;
   'item': string;
   'name': string;
+  'sortForward': string;
+  'sortReverse': string;
 }
 export const cssExports: CssExports;
 export default cssExports;


### PR DESCRIPTION
In https://github.com/DestinyItemManager/DIM/pull/10785 I removed the `pointer-events: none` from `.app-icon`. But the tortured event delegation code in SortOrderEditor *depended* on icons not receiving events. I replaced all that with normal event handlers.

Fixes #10791