### PR TITLE
Fix layout of engrams

### DIFF
--- a/src/app/inventory-page/Stores.scss
+++ b/src/app/inventory-page/Stores.scss
@@ -82,7 +82,6 @@
 
   // Engrams. D1 uses this same bucket hash for "Missions"
   .destiny2 .bucket-375726501 & {
-    --engram-size: calc(var(--character-column-width) / 10);
     padding-bottom: 8px;
 
     .empty-engram {
@@ -94,7 +93,7 @@
 
     .sub-bucket {
       min-height: 0;
-      grid-template-columns: repeat(auto-fill, var(--engram-size));
+      grid-template-columns: repeat(10, 1fr);
       gap: 0;
       padding: 4px 0 0 0;
 
@@ -105,11 +104,8 @@
 
     .item-drag-container,
     .empty-engram {
-      --item-size: var(--engram-size);
-
-      @include phone-portrait {
-        --item-size: calc((100vw - (2 * var(--inventory-column-padding))) / 10);
-      }
+      --item-size: 100%;
+      aspect-ratio: 1 / 1;
     }
   }
 


### PR DESCRIPTION
Not sure when this broke, but the magic of grid and `aspect-ratio` makes this a lot simpler.

Before:
<img width="345" alt="Screenshot 2024-11-16 at 12 16 36 AM" src="https://github.com/user-attachments/assets/2ae3ebae-012d-4117-9d49-0bbe32743199">

After:
<img width="317" alt="Screenshot 2024-11-16 at 12 16 58 AM" src="https://github.com/user-attachments/assets/c7f4bdb0-e84d-4c1c-943d-1298c9c28fdd">
