### PR TITLE
Correctly reverse failed save search / revamp dim-api tests

### DIFF
--- a/src/app/dim-api/api-types.ts
+++ b/src/app/dim-api/api-types.ts
@@ -9,7 +9,7 @@ import {
 type AddUpdateInfo<U> = U extends ProfileUpdate
   ? U & {
       /** The state before this update - if it fails we can use this to roll back */
-      before?: U['payload'];
+      before: U['payload'] | undefined;
       /** The account (if any) this update refers to */
       platformMembershipId?: string;
       destinyVersion?: DestinyVersion;

--- a/src/app/dim-api/api-types.ts
+++ b/src/app/dim-api/api-types.ts
@@ -1,8 +1,10 @@
 import {
   DeleteLoadoutUpdate,
+  DeleteSearchUpdate,
   DestinyVersion,
   Loadout,
   ProfileUpdate,
+  SearchType,
 } from '@destinyitemmanager/dim-api-types';
 
 // https://stackoverflow.com/questions/51691235/typescript-map-union-type-to-another-union-type
@@ -22,9 +24,20 @@ export interface DeleteLoadoutUpdateWithRollback extends DeleteLoadoutUpdate {
   destinyVersion: DestinyVersion;
 }
 
+export interface DeleteSearchUpdateWithRollback extends DeleteSearchUpdate {
+  before: {
+    query: string;
+    type: SearchType;
+    saved: boolean;
+  };
+  platformMembershipId: string;
+  destinyVersion: DestinyVersion;
+}
+
 /**
  * A version of ProfileUpdate that also includes rollback info in a "before" property.
  */
 export type ProfileUpdateWithRollback =
+  | DeleteSearchUpdateWithRollback
   | DeleteLoadoutUpdateWithRollback
   | AddUpdateInfo<ProfileUpdate>;


### PR DESCRIPTION
In investigating #10809 I found that there were a number of bugs related to reversing DIM Sync actions if they fail. The one that was causing this user to get stuck was a failed "save search" for a search that was too long - because it threw an error every time, it just kept trying the update. I both fixed the logic and put a protective try/catch around the reverse logic, as it isn't critical.

I then overhauled the tests for the dim-api reducer and added in assertions that reversing actions after a failure would return the state to the initial version, and fixed a handful of related bugs.

Fixes #10809