### PR TITLE
Fix i18n workflow (hopefully)

### DIFF
--- a/src/@types/i18next.d.ts
+++ b/src/@types/i18next.d.ts
@@ -1,5 +1,5 @@
 // import the original type declarations
-import type en from 'config/i18n.json' assert { type: 'json' };
+import type en from 'config/i18n.json' with { type: 'json' };
 import 'i18next';
 
 declare module 'i18next' {

--- a/src/build-browsercheck-utils.js
+++ b/src/build-browsercheck-utils.js
@@ -1,19 +1,19 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import fs from 'node:fs';
 
-import de from './locale/de.json' assert { type: 'json' };
-import en from './locale/en.json' assert { type: 'json' };
-import es from './locale/es.json' assert { type: 'json' };
-import esMX from './locale/esMX.json' assert { type: 'json' };
-import fr from './locale/fr.json' assert { type: 'json' };
-import it from './locale/it.json' assert { type: 'json' };
-import ja from './locale/ja.json' assert { type: 'json' };
-import ko from './locale/ko.json' assert { type: 'json' };
-import pl from './locale/pl.json' assert { type: 'json' };
-import ptBR from './locale/ptBR.json' assert { type: 'json' };
-import ru from './locale/ru.json' assert { type: 'json' };
-import zhCHS from './locale/zhCHS.json' assert { type: 'json' };
-import zhCHT from './locale/zhCHT.json' assert { type: 'json' };
+import de from './locale/de.json' with { type: 'json' };
+import en from './locale/en.json' with { type: 'json' };
+import es from './locale/es.json' with { type: 'json' };
+import esMX from './locale/esMX.json' with { type: 'json' };
+import fr from './locale/fr.json' with { type: 'json' };
+import it from './locale/it.json' with { type: 'json' };
+import ja from './locale/ja.json' with { type: 'json' };
+import ko from './locale/ko.json' with { type: 'json' };
+import pl from './locale/pl.json' with { type: 'json' };
+import ptBR from './locale/ptBR.json' with { type: 'json' };
+import ru from './locale/ru.json' with { type: 'json' };
+import zhCHS from './locale/zhCHS.json' with { type: 'json' };
+import zhCHT from './locale/zhCHT.json' with { type: 'json' };
 
 /**
  * @param {string} key


### PR DESCRIPTION
Our i18n workflow for pulling translations from Crowdin seems to have failed for the last 8 months due to Node 22 rejecting the deprecated import assertions syntax, so let's fix that