### PR TITLE
Don't always say vendor items are missing sockets

### DIFF
--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -68,6 +68,7 @@ export function buildSockets(
   itemDef: DestinyInventoryItemDefinition,
 ): { sockets: DimItem['sockets']; missingSockets: DimItem['missingSockets'] } {
   let sockets: DimSockets | null = null;
+  let missingSockets: DimItem['missingSockets'] = false;
   if ($featureFlags.simulateMissingSockets) {
     itemComponents = undefined;
   }
@@ -102,14 +103,14 @@ export function buildSockets(
     const isInstanced = Boolean(item.itemInstanceId && item.itemInstanceId.length > 14);
 
     // If this really *should* have live sockets, but didn't...
-    if (item.itemInstanceId !== '0' && !socketData) {
-      return { sockets: null, missingSockets: isInstanced ? 'missing' : 'not-loaded' };
+    if (isInstanced && !socketData) {
+      missingSockets = isInstanced ? 'missing' : 'not-loaded';
     }
 
     sockets = buildDefinedSockets(defs, itemDef);
   }
 
-  return { sockets, missingSockets: false };
+  return { sockets, missingSockets };
 }
 
 /**


### PR DESCRIPTION
In https://github.com/DestinyItemManager/DIM/pull/10430 we changed the missing sockets check, but this seems to have resulted in many vendor items showing "Perk and stat data have not loaded for this item" forever.

<img width="485" alt="Screenshot 2024-12-07 at 6 29 18 PM" src="https://github.com/user-attachments/assets/7c27571c-0dcc-4f55-82b1-7ea8e010c5dd">
<img width="933" alt="Screenshot 2024-12-07 at 6 29 22 PM" src="https://github.com/user-attachments/assets/2669d89f-0d1d-4b8b-8a08-b4390f32a3dd">

This change makes it so these items, which I think will never have socket data (?) still show the perks from their definitions:

<img width="435" alt="Screenshot 2024-12-07 at 6 30 36 PM" src="https://github.com/user-attachments/assets/ede194ee-f4c2-4b4e-a249-ceee54e21fd6">
<img width="957" alt="Screenshot 2024-12-07 at 6 30 42 PM" src="https://github.com/user-attachments/assets/c4652b0d-59d8-488f-bba8-4fc096b193b4">


