### PR TITLE
Organizer: Separate traits into two columns

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -995,7 +995,9 @@ function D1PerksCell({ item }: { item: D1Item }) {
                       <BungieImage src={p.icon} />
                     </div>{' '}
                     {p.name}
-                    {(!p.unlocked || p.xp < p.xpRequired) && <> ({percent(p.xp / p.xpRequired)})</>}
+                    {p.xpRequired > 0 && (!p.unlocked || p.xp < p.xpRequired) && (
+                      <> ({percent(p.xp / p.xpRequired)})</>
+                    )}
                   </div>
                 </PressTip>
               ),

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -1027,10 +1027,7 @@ function perkString(sockets: DimSocket[]): string | undefined {
     .join(',');
 }
 
-function getSockets(
-  item: DimItem,
-  type?: 'all' | 'traits' | 'barrel' | 'shaders' | 'origin',
-): DimSocket[] {
+function getSockets(item: DimItem, type?: 'all' | 'traits' | 'shaders' | 'origin'): DimSocket[] {
   if (!item.sockets) {
     return [];
   }

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -196,6 +196,12 @@ $content-cells: 5;
     display: flex;
     flex-direction: column;
   }
+
+  .destiny1 & {
+    > *:nth-last-child(n + 2) {
+      margin-bottom: 4px;
+    }
+  }
 }
 
 .modPerks {

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -181,20 +181,17 @@ $content-cells: 5;
 
 .perks,
 .traits,
-.barrels,
 .intrinsics,
 .originTrait,
 .shaders {
   padding-top: calc(var(--item-size) * 0.5 * 0.5 - 5px) !important;
 }
-.perks {
+.perks,
+.traits {
   columns: 2;
   height: 100%;
   box-sizing: border-box;
   column-gap: 8px;
-  > *:nth-last-child(n + 2) {
-    margin-bottom: 4px;
-  }
   &.header {
     display: flex;
     flex-direction: column;

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -196,11 +196,8 @@ $content-cells: 5;
     display: flex;
     flex-direction: column;
   }
-
-  .destiny1 & {
-    > *:nth-last-child(n + 2) {
-      margin-bottom: 4px;
-    }
+  > *:nth-last-child(n + 2) {
+    margin-bottom: 4px;
   }
 }
 

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -4,7 +4,6 @@ interface CssExports {
   'archetype': string;
   'base2715839340': string;
   'customstat': string;
-  'destiny1': string;
   'dmg': string;
   'energy': string;
   'enhancedArrow': string;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -4,6 +4,7 @@ interface CssExports {
   'archetype': string;
   'base2715839340': string;
   'customstat': string;
+  'destiny1': string;
   'dmg': string;
   'energy': string;
   'enhancedArrow': string;

--- a/src/app/organizer/ItemTable.m.scss.d.ts
+++ b/src/app/organizer/ItemTable.m.scss.d.ts
@@ -2,7 +2,6 @@
 // Please do not change this file!
 interface CssExports {
   'archetype': string;
-  'barrels': string;
   'base2715839340': string;
   'customstat': string;
   'dmg': string;

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -442,7 +442,11 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
   return (
     <>
       <div
-        className={clsx(styles.table, shiftHeld && styles.shiftHeld)}
+        className={clsx(
+          styles.table,
+          shiftHeld && styles.shiftHeld,
+          destinyVersion === 1 && styles.destiny1,
+        )}
         style={{ gridTemplateColumns: gridSpec }}
         role="table"
         ref={tableRef}

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -442,11 +442,7 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
   return (
     <>
       <div
-        className={clsx(
-          styles.table,
-          shiftHeld && styles.shiftHeld,
-          destinyVersion === 1 && styles.destiny1,
-        )}
+        className={clsx(styles.table, shiftHeld && styles.shiftHeld)}
         style={{ gridTemplateColumns: gridSpec }}
         role="table"
         ref={tableRef}


### PR DESCRIPTION
Fixes https://github.com/DestinyItemManager/DIM/issues/10829

Rather than fix the separation of columns, I just made the "Traits" column two wide. For D1, I *did* fix the separation of columns.

<img width="1257" alt="Screenshot 2024-12-07 at 6 58 09 PM" src="https://github.com/user-attachments/assets/7d74ad08-040e-4f90-93a1-d4c7fcc76d93">
<img width="772" alt="Screenshot 2024-12-07 at 6 57 52 PM" src="https://github.com/user-attachments/assets/8671faa6-4681-4604-9d61-7124ee3facb1">
