### PR TITLE
Don't ever look up wishlist for definition-only items

### DIFF
--- a/src/app/inventory/item-types.ts
+++ b/src/app/inventory/item-types.ts
@@ -567,6 +567,8 @@ export interface DimSockets {
   allSockets: DimSocket[];
   /** Sockets grouped by category. */
   categories: DimSocketCategory[];
+  /** Were these built from definitions, or from live data? */
+  fromDefinitions: boolean;
 }
 
 /**

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -165,6 +165,7 @@ function buildInstancedSockets(
       itemDef.inventory?.bucketTypeHash === BucketHashes.Subclass
         ? categories.sort(compareBy((c) => c.category?.index))
         : categories, // Sockets organized by category
+    fromDefinitions: false,
   };
 }
 
@@ -215,6 +216,7 @@ function buildDefinedSockets(
       itemDef.inventory?.bucketTypeHash === BucketHashes.Subclass
         ? categories.sort(compareBy((c) => c.category?.index))
         : categories, // Sockets organized by category
+    fromDefinitions: true,
   };
 }
 

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -85,7 +85,13 @@ export function toVendor(
     return undefined;
   }
 
-  const vendorItems = getVendorItems(context, vendorDef, characterId, sales);
+  const vendorItems = getVendorItems(
+    context,
+    vendorDef,
+    characterId,
+    sales,
+    vendor?.nextRefreshDate,
+  );
   vendorItems.sort(
     chainComparator(
       compareBy(
@@ -178,18 +184,19 @@ function getVendorItems(
         [key: string]: DestinyVendorSaleItemComponent;
       }
     | undefined,
+  nextRefreshDate?: string,
 ): VendorItem[] {
   if (sales) {
     const components = Object.values(sales);
     return components.map((component) =>
-      vendorItemForSaleItem(context, vendorDef, component, characterId),
+      vendorItemForSaleItem(context, vendorDef, component, characterId, nextRefreshDate),
     );
   } else if (vendorDef.returnWithVendorRequest) {
     // If the sales should come from the server, don't show anything until we have them
     return [];
   } else {
     return vendorDef.itemList.map((i, index) =>
-      vendorItemForDefinitionItem(context, i, characterId, index),
+      vendorItemForDefinitionItem(context, i, characterId, index, nextRefreshDate),
     );
   }
 }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -196,11 +196,5 @@ export function vendorItemForDefinitionItem(
     characterId,
     vendorItemIndex,
   );
-  // items from vendors must have a unique ID, which causes makeItem
-  // to think there's gotta be socket info, but there's not for vendors
-  // set up statically through defs
-  if (item.item) {
-    item.item.missingSockets = false;
-  }
   return item;
 }

--- a/src/app/vendors/vendor-item.ts
+++ b/src/app/vendors/vendor-item.ts
@@ -76,6 +76,7 @@ function makeVendorItem(
   characterId: string,
   // the index in the vendor's items array
   vendorItemIndex: number,
+  nextRefreshDate?: string,
 ): VendorItem {
   const { defs, profileResponse } = context;
 
@@ -118,7 +119,7 @@ function makeVendorItem(
 
     // override the DimItem.id for vendor items, so they are each unique enough to identify
     // (otherwise they'd get their vendor index as an id, which is only unique per-vendor)
-    vendorItem.item.id = `${vendorHash}-${vendorItem.vendorItemIndex}`;
+    vendorItem.item.id = `${vendorHash}-${vendorItem.vendorItemIndex}-${nextRefreshDate ?? '0'}`;
     vendorItem.item.index = vendorItem.item.id;
     vendorItem.item.instanced = false;
     // These would normally be false already, but certain rules like "finishers
@@ -156,6 +157,7 @@ export function vendorItemForSaleItem(
   saleItem: DestinyVendorSaleItemComponent,
   /** all DIM vendor calls are character-specific. any sale item should have an associated character. */
   characterId: string,
+  nextRefreshDate?: string,
 ): VendorItem {
   const vendorItemDef = vendorDef.itemList[saleItem.vendorItemIndex];
   const failureStrings =
@@ -172,6 +174,7 @@ export function vendorItemForSaleItem(
     saleItem,
     characterId,
     saleItem.vendorItemIndex,
+    nextRefreshDate,
   );
 }
 
@@ -185,6 +188,7 @@ export function vendorItemForDefinitionItem(
   characterId: string,
   // the index in the vendor's items array
   vendorItemIndex: number,
+  nextRefreshDate?: string,
 ): VendorItem {
   const item = makeVendorItem(
     context,
@@ -195,6 +199,7 @@ export function vendorItemForDefinitionItem(
     undefined,
     characterId,
     vendorItemIndex,
+    nextRefreshDate,
   );
   return item;
 }

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -28,7 +28,11 @@ export const wishListFunctionSelector = createSelector(
     // Cache of inventory item id to roll. For this to work, make sure vendor/collections rolls have unique ids.
     const cache = new Map<string, InventoryWishListRoll | null>();
     return (item: DimItem) => {
-      if (!($featureFlags.wishLists && wishlists && item.wishListEnabled)) {
+      if (
+        !($featureFlags.wishLists && wishlists && item.wishListEnabled) ||
+        !item.sockets ||
+        item.sockets.fromDefinitions
+      ) {
         return undefined;
       }
       const cachedRoll = cache.get(item.id);


### PR DESCRIPTION
We had an issue where vendor items would load with no live perk info, and thus fall back to definitions, which have every possible perk. This would match every wishlist entry, and that would then get cached in the wishlists cache. Then when the real live info loaded, the cache wouldn't get invalidated.

This changes to ignore wishlist status on definition-based perks entirely, and skip the cache.

Before:
<img width="301" alt="Screenshot 2024-12-10 at 10 23 25 PM" src="https://github.com/user-attachments/assets/60919cab-0cc7-409b-a33c-5193bc5ec9bf">

After:
<img width="320" alt="Screenshot 2024-12-10 at 10 22 27 PM" src="https://github.com/user-attachments/assets/546c667a-7c90-49ea-8661-52d67a586890">

I also fixed #8327 by plumbing the vendor next refresh date into the item IDs. This means when the vendor refreshes, the wishlist cache should get new entries.

Fixes #8327