### PR TITLE
Fix routing

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -136,9 +136,7 @@ export default function App() {
                       </ErrorBoundary>
                     }
                   />
-                  <Route path="armory">
-                    <Route path="*" element={<DefaultAccount />} />
-                  </Route>
+                  <Route path="armory/*" element={<DefaultAccount />} />
                   <Route path=":membershipId/:destinyVersion/*" element={<Destiny />} />
                   <Route path="*" element={<DefaultAccount />} />
                 </>

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -312,7 +312,7 @@ export default function Destiny() {
                 }
               />
             )}
-            <Route path="*" element={<Navigate to="inventory" />} />
+            <Route path="*" element={<Navigate to="../inventory" />} />
           </Routes>
         </div>
         <LoadoutDrawerContainer account={account} />


### PR DESCRIPTION
React Router v7 switched routing to a different set of rules that I find very unintuitive. This caused us to, in some circumstances, infinitely redirect to /inventory/inventory/inventory/...