### PR TITLE
Ignore invalid item IDs more broadly

### DIFF
--- a/src/app/loadout/loadout-type-converters.ts
+++ b/src/app/loadout/loadout-type-converters.ts
@@ -53,12 +53,7 @@ function convertDimLoadoutItemToLoadoutItem(item: DimLoadoutItem): LoadoutItem {
   const result: LoadoutItem = {
     hash: item.hash,
   };
-  if (
-    item.id &&
-    item.id !== '0' &&
-    // Vendor items have an invalid item ID
-    !item.id.includes('-')
-  ) {
+  if (item.id && item.id !== '0' && /^\d{1,32}$/.test(item.id)) {
     result.id = item.id;
   }
   if (item.amount > 1) {


### PR DESCRIPTION
D2ArmorPicker seems to have invented a new kind of invalid item ID (`"c" + itemHash`). This aligns the check we do on the server with the client, and just silently omit any invalid item hash.