### PR TITLE
Move search history under destiny profile

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -28,9 +28,6 @@ const WhatsNew = lazy(() => import(/* webpackChunkName: "whatsNew" */ './whats-n
 const SettingsPage = lazy(
   () => import(/* webpackChunkName: "settings" */ './settings/SettingsPage'),
 );
-const SearchHistory = lazy(
-  () => import(/* webpackChunkName: "searchHistory" */ './search/SearchHistory'),
-);
 const Debug = lazy(() => import(/* webpackChunkName: "debug" */ './debug/Debug'));
 
 export default function App() {
@@ -128,14 +125,6 @@ export default function App() {
                 />
               ) : (
                 <>
-                  <Route
-                    path="search-history"
-                    element={
-                      <ErrorBoundary name="searchHistory" key="searchHistory">
-                        <SearchHistory />
-                      </ErrorBoundary>
-                    }
-                  />
                   <Route path="armory/*" element={<DefaultAccount />} />
                   <Route path=":membershipId/:destinyVersion/*" element={<Destiny />} />
                   <Route path="*" element={<DefaultAccount />} />

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -74,6 +74,10 @@ const Activities = lazy(
 const Records = lazy(() => import(/* webpackChunkName: "records" */ 'app/records/Records'));
 const Loadouts = lazy(() => import(/* webpackChunkName: "loadouts" */ 'app/loadout/Loadouts'));
 
+const SearchHistory = lazy(
+  () => import(/* webpackChunkName: "searchHistory" */ '../search/SearchHistory'),
+);
+
 /**
  * Base view for pages that show Destiny content.
  */
@@ -312,6 +316,15 @@ export default function Destiny() {
                 }
               />
             )}
+
+            <Route
+              path="search-history"
+              element={
+                <ErrorBoundary name="searchHistory" key="searchHistory">
+                  <SearchHistory />
+                </ErrorBoundary>
+              }
+            />
             <Route path="*" element={<Navigate to="../inventory" />} />
           </Routes>
         </div>


### PR DESCRIPTION
Searches are now stored under a profile membership ID, which means the search history also needs to be loaded under an account. Otherwise, deletes are rejected by the DIM Sync server.