### PR TITLE
Massage incoming loadouts' stat constraints

### DIFF
--- a/src/app/loadout/loadout-share/loadout-import.ts
+++ b/src/app/loadout/loadout-share/loadout-import.ts
@@ -98,6 +98,14 @@ function preprocessReceivedLoadout(loadout: Loadout): Loadout {
     id: item.id === '0' ? generateMissingLoadoutItemId() : item.id,
     hash: Number(item.hash),
   }));
+  for (const constraint of loadout.parameters?.statConstraints ?? []) {
+    if (constraint.minTier) {
+      constraint.minTier = Math.min(10, Math.floor(constraint.minTier));
+    }
+    if (constraint.maxTier) {
+      constraint.maxTier = Math.min(10, Math.ceil(constraint.maxTier));
+    }
+  }
 
   return loadout;
 }


### PR DESCRIPTION
D2AP is now sending half-tiers in shared loadouts. Just floor/ceil them into an integer.