### PR TITLE
Fix loadout stat editor arrows

### DIFF
--- a/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.m.scss
@@ -133,6 +133,13 @@
     opacity: 0.9;
     color: #555;
   }
+
+  // We must remove pointer events from the icon or else the wacky event
+  // delegation in useButtonSensor won't work because the event target will be
+  // the icon, not the button.
+  > :global(.app-icon) {
+    pointer-events: none;
+  }
 }
 
 .dragging {


### PR DESCRIPTION
A bit ago I made a change that removed `pointer-events: none` from icons. This messed up the weird event delegation pattern that `@hello-pangea/dnd` forced on us in order to make clicking arrows actually animate reordering. Fixed by making them transparent to events again, but only in this one place.