### PR TITLE
Fix stream deck button / selection module for #10865

### DIFF
--- a/src/app/item-actions/ItemAccessoryButtons.tsx
+++ b/src/app/item-actions/ItemAccessoryButtons.tsx
@@ -2,7 +2,6 @@ import { DimItem } from 'app/inventory/item-types';
 import { ItemActionsModel } from 'app/item-popup/item-popup-actions';
 import OpenOnStreamDeckButton from 'app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton';
 import { streamDeckEnabledSelector } from 'app/stream-deck/selectors';
-import { Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import {
   CompareActionButton,
@@ -52,11 +51,7 @@ export default function ItemAccessoryButtons({
       {actionsModel.infusable && (
         <InfuseActionButton item={item} label={showLabel} actionModel={actionsModel} />
       )}
-      {streamDeckEnabled && (
-        <Suspense>
-          <OpenOnStreamDeckButton label={showLabel} item={item} />
-        </Suspense>
-      )}
+      {streamDeckEnabled && <OpenOnStreamDeckButton label={showLabel} item={item} />}
     </>
   );
 }

--- a/src/app/loadout/LoadoutsRow.tsx
+++ b/src/app/loadout/LoadoutsRow.tsx
@@ -7,7 +7,7 @@ import { deleteLoadout } from 'app/loadout/actions';
 import { Loadout } from 'app/loadout/loadout-types';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { useStreamDeckSelection } from 'app/stream-deck/stream-deck';
+import { useStreamDeckSelection } from 'app/stream-deck/useStreamDeckSelection';
 import { ReactNode, memo, useMemo } from 'react';
 import LoadoutView from './LoadoutView';
 
@@ -34,9 +34,7 @@ export default memo(function LoadoutRow({
   const streamDeckDeepLink = $featureFlags.elgatoStreamDeck
     ? // eslint-disable-next-line
       useStreamDeckSelection({
-        type: 'loadout',
-        loadout,
-        store,
+        options: { type: 'loadout' as const, loadout, store },
         equippable,
       })
     : undefined;

--- a/src/app/loadout/LoadoutsRow.tsx
+++ b/src/app/loadout/LoadoutsRow.tsx
@@ -7,7 +7,7 @@ import { deleteLoadout } from 'app/loadout/actions';
 import { Loadout } from 'app/loadout/loadout-types';
 import { AppIcon, deleteIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { useStreamDeckSelection } from 'app/stream-deck/useStreamDeckSelection';
+import { useStreamDeckSelection } from 'app/stream-deck/stream-deck';
 import { ReactNode, memo, useMemo } from 'react';
 import LoadoutView from './LoadoutView';
 

--- a/src/app/loadout/ingame/InGameLoadoutStrip.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.tsx
@@ -10,7 +10,7 @@ import { InGameLoadout, Loadout } from 'app/loadout/loadout-types';
 import { AppIcon, faCheckCircle, faExclamationCircle, saveIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { RootState } from 'app/store/types';
-import { useStreamDeckSelection } from 'app/stream-deck/stream-deck';
+import { useStreamDeckSelection } from 'app/stream-deck/useStreamDeckSelection';
 import { compact } from 'app/utils/collections';
 import clsx from 'clsx';
 import React from 'react';
@@ -96,9 +96,11 @@ function InGameLoadoutTile({
   const streamDeckDeepLink = $featureFlags.elgatoStreamDeck
     ? // eslint-disable-next-line
       useStreamDeckSelection({
-        type: 'in-game-loadout',
+        options: {
+          type: 'in-game-loadout' as const,
+          loadout: gameLoadout,
+        },
         equippable: true,
-        loadout: gameLoadout,
       })
     : undefined;
 

--- a/src/app/loadout/ingame/InGameLoadoutStrip.tsx
+++ b/src/app/loadout/ingame/InGameLoadoutStrip.tsx
@@ -10,7 +10,7 @@ import { InGameLoadout, Loadout } from 'app/loadout/loadout-types';
 import { AppIcon, faCheckCircle, faExclamationCircle, saveIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { RootState } from 'app/store/types';
-import { useStreamDeckSelection } from 'app/stream-deck/useStreamDeckSelection';
+import { useStreamDeckSelection } from 'app/stream-deck/stream-deck';
 import { compact } from 'app/utils/collections';
 import clsx from 'clsx';
 import React from 'react';

--- a/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
+++ b/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
@@ -3,14 +3,22 @@ import { DimItem } from 'app/inventory/item-types';
 import ActionButton from 'app/item-actions/ActionButton';
 import { BucketHashes } from 'data/d2/generated-enums';
 import streamDeckIcon from 'images/streamDeck.svg';
-import { useStreamDeckSelection } from '../stream-deck';
+import { useMemo } from 'react';
+import { useStreamDeckSelection } from '../useStreamDeckSelection';
 import styles from './OpenOnStreamDeckButton.m.scss';
 
 export default function OpenOnStreamDeckButton({ item, label }: { item: DimItem; label: boolean }) {
+  const options = useMemo(
+    () => ({
+      type: 'item' as const,
+      item,
+      isSubClass: item.bucket.hash === BucketHashes.Subclass,
+    }),
+    [item],
+  );
+
   const deepLink = useStreamDeckSelection({
-    type: 'item',
-    item,
-    isSubClass: item.bucket.hash === BucketHashes.Subclass,
+    options,
     equippable: !item.notransfer,
   });
 

--- a/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
+++ b/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
@@ -4,7 +4,7 @@ import ActionButton from 'app/item-actions/ActionButton';
 import { BucketHashes } from 'data/d2/generated-enums';
 import streamDeckIcon from 'images/streamDeck.svg';
 import { useMemo } from 'react';
-import { useStreamDeckSelection } from '../useStreamDeckSelection';
+import { useStreamDeckSelection } from '../stream-deck';
 import styles from './OpenOnStreamDeckButton.m.scss';
 
 export default function OpenOnStreamDeckButton({ item, label }: { item: DimItem; label: boolean }) {

--- a/src/app/stream-deck/StreamDeckButton/StreamDeckButton.tsx
+++ b/src/app/stream-deck/StreamDeckButton/StreamDeckButton.tsx
@@ -3,7 +3,7 @@ import { t } from 'app/i18next-t';
 import { AppIcon, banIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import streamDeckIcon from 'images/streamDeck.svg';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { streamDeckSelector } from '../selectors';
 import { streamDeckAuthorizationInit } from '../util/authorization';
@@ -70,6 +70,11 @@ export default function StreamDeckButton() {
       setVersion(undefined);
     }
   };
+
+  useEffect(() => {
+    updateVersion();
+  }, []);
+
   const error = !checkStreamDeckVersion(version);
   const needSetup = auth === undefined;
   const dispatch = useThunkDispatch();

--- a/src/app/stream-deck/async-module.ts
+++ b/src/app/stream-deck/async-module.ts
@@ -6,6 +6,7 @@ import { streamDeckConnected, streamDeckDisconnected } from 'app/stream-deck/act
 import { SendToStreamDeckArgs, StreamDeckMessage } from 'app/stream-deck/interfaces';
 import { handleStreamDeckMessage } from 'app/stream-deck/msg-handlers';
 import packager from 'app/stream-deck/util/packager';
+import useSelection from './useStreamDeckSelection';
 
 const STREAM_DECK_FARMING_OBSERVER_ID = 'stream-deck-farming-observer';
 
@@ -151,4 +152,5 @@ function start(): ThunkResult {
 export default {
   start,
   stop,
+  useSelection,
 };

--- a/src/app/stream-deck/async-module.ts
+++ b/src/app/stream-deck/async-module.ts
@@ -6,7 +6,6 @@ import { streamDeckConnected, streamDeckDisconnected } from 'app/stream-deck/act
 import { SendToStreamDeckArgs, StreamDeckMessage } from 'app/stream-deck/interfaces';
 import { handleStreamDeckMessage } from 'app/stream-deck/msg-handlers';
 import packager from 'app/stream-deck/util/packager';
-export { default as useStreamDeckSelection } from './useStreamDeckSelection';
 
 const STREAM_DECK_FARMING_OBSERVER_ID = 'stream-deck-farming-observer';
 

--- a/src/app/stream-deck/interfaces.ts
+++ b/src/app/stream-deck/interfaces.ts
@@ -53,11 +53,6 @@ export interface MaxPowerAction {
 export interface PullItemAction {
   action: 'pullItem';
   itemId: string;
-  /**
-   * @deprecated to be removed in future plugin update
-   * @see type
-   */
-  equip: boolean;
   type: 'equip' | 'pull' | 'vault';
 }
 

--- a/src/app/stream-deck/msg-handlers.ts
+++ b/src/app/stream-deck/msg-handlers.ts
@@ -186,7 +186,7 @@ function pullItemHandler({ msg, state, store }: HandlerArgs<PullItemAction>): Th
     const allItems = allItemsSelector(state);
     const [item] = allItems.filter((it) => it.index.startsWith(msg.itemId));
     const targetStore = msg.type === 'vault' ? vaultSelector(state) : store;
-    const shouldEquip = msg.type === 'equip' || msg.equip;
+    const shouldEquip = msg.type === 'equip';
     if (targetStore) {
       await dispatch(moveItemTo(item, targetStore, shouldEquip, item.amount));
     }
@@ -235,6 +235,7 @@ export function handleStreamDeckMessage(msg: StreamDeckMessage, token: string): 
       });
       throw new Error(!msg.token ? 'missing-token' : 'invalid-token');
     }
+
     if (store) {
       // handle stream deck actions
       const handler = handlers[msg.action] as (args: HandlerArgs<StreamDeckMessage>) => ThunkResult;

--- a/src/app/stream-deck/stream-deck.ts
+++ b/src/app/stream-deck/stream-deck.ts
@@ -1,10 +1,8 @@
 import { ThunkResult } from 'app/store/types';
-import { type UseStreamDeckSelectionFn } from './useStreamDeckSelection';
 
 export interface LazyStreamDeck {
   start?: () => ThunkResult;
   stop?: () => ThunkResult;
-  useSelection?: UseStreamDeckSelectionFn;
 }
 
 const lazyLoaded: LazyStreamDeck = {};
@@ -25,6 +23,3 @@ export const lazyLoadStreamDeck = async () => {
 export const startStreamDeckConnection = () => lazyLoaded.start!();
 
 export const stopStreamDeckConnection = () => lazyLoaded.stop!();
-
-export const useStreamDeckSelection: UseStreamDeckSelectionFn = (...args) =>
-  lazyLoaded.useSelection?.(...args);

--- a/src/app/stream-deck/stream-deck.ts
+++ b/src/app/stream-deck/stream-deck.ts
@@ -1,8 +1,10 @@
 import { ThunkResult } from 'app/store/types';
+import { UseStreamDeckSelection } from './useStreamDeckSelection';
 
 export interface LazyStreamDeck {
   start?: () => ThunkResult;
   stop?: () => ThunkResult;
+  useSelection?: UseStreamDeckSelection;
 }
 
 const lazyLoaded: LazyStreamDeck = {};
@@ -23,3 +25,6 @@ export const lazyLoadStreamDeck = async () => {
 export const startStreamDeckConnection = () => lazyLoaded.start!();
 
 export const stopStreamDeckConnection = () => lazyLoaded.stop!();
+
+export const useStreamDeckSelection: UseStreamDeckSelection = (...args) =>
+  lazyLoaded.useSelection?.(...args);

--- a/src/app/stream-deck/stream-deck.ts
+++ b/src/app/stream-deck/stream-deck.ts
@@ -1,10 +1,10 @@
 import { ThunkResult } from 'app/store/types';
-import { UseStreamDeckSelection } from './useStreamDeckSelection';
+import { type UseStreamDeckSelectionFn } from './useStreamDeckSelection';
 
 export interface LazyStreamDeck {
   start?: () => ThunkResult;
   stop?: () => ThunkResult;
-  useSelection?: UseStreamDeckSelection;
+  useSelection?: UseStreamDeckSelectionFn;
 }
 
 const lazyLoaded: LazyStreamDeck = {};
@@ -26,5 +26,5 @@ export const startStreamDeckConnection = () => lazyLoaded.start!();
 
 export const stopStreamDeckConnection = () => lazyLoaded.stop!();
 
-export const useStreamDeckSelection: UseStreamDeckSelection = (...args) =>
+export const useStreamDeckSelection: UseStreamDeckSelectionFn = (...args) =>
   lazyLoaded.useSelection?.(...args);

--- a/src/app/stream-deck/useStreamDeckSelection.ts
+++ b/src/app/stream-deck/useStreamDeckSelection.ts
@@ -104,12 +104,13 @@ export interface UseStreamDeckSelectionArgs {
   equippable: boolean;
 }
 
-export function useStreamDeckSelection({
-  equippable,
-  options,
-}: UseStreamDeckSelectionArgs): string | undefined {
+function useSelection({ equippable, options }: UseStreamDeckSelectionArgs): string | undefined {
   const type = options.type === 'item' ? 'item' : 'loadout';
   const selection = useSelector(streamDeckSelectionSelector);
   const canSelect = Boolean((equippable || options.isSubClass) && selection === type);
   return useSelector(toSelectionHref(canSelect, options));
 }
+
+export default useSelection;
+
+export type UseStreamDeckSelection = typeof useSelection;

--- a/src/app/stream-deck/useStreamDeckSelection.ts
+++ b/src/app/stream-deck/useStreamDeckSelection.ts
@@ -99,18 +99,17 @@ const toSelectionHref =
     return `${STREAM_DECK_DEEP_LINK}/selection?${query.toString()}`;
   };
 
-export type UseStreamDeckSelectionArgs = StreamDeckSelectionOptions & {
+export interface UseStreamDeckSelectionArgs {
+  options: StreamDeckSelectionOptions;
   equippable: boolean;
-  isSubClass?: boolean;
-};
-export type UseStreamDeckSelectionFn = typeof useSelection;
-
-function useSelection({ equippable, ...props }: UseStreamDeckSelectionArgs): string | undefined {
-  const type = props.type === 'item' ? 'item' : 'loadout';
-  const selection = useSelector(streamDeckSelectionSelector);
-  const canSelect = Boolean((equippable || props.isSubClass) && selection === type);
-  // TODO: This selector is unstable because `props` is always a new object every time the hook is invoked
-  return useSelector(toSelectionHref(canSelect, props));
 }
 
-export default { useSelection };
+export function useStreamDeckSelection({
+  equippable,
+  options,
+}: UseStreamDeckSelectionArgs): string | undefined {
+  const type = options.type === 'item' ? 'item' : 'loadout';
+  const selection = useSelector(streamDeckSelectionSelector);
+  const canSelect = Boolean((equippable || options.isSubClass) && selection === type);
+  return useSelector(toSelectionHref(canSelect, options));
+}

--- a/src/app/stream-deck/useStreamDeckSelection.ts
+++ b/src/app/stream-deck/useStreamDeckSelection.ts
@@ -113,4 +113,4 @@ function useSelection({ equippable, options }: UseStreamDeckSelectionArgs): stri
 
 export default useSelection;
 
-export type UseStreamDeckSelection = typeof useSelection;
+export type UseStreamDeckSelectionFn = typeof useSelection;


### PR DESCRIPTION
Fix:

- `StreamDeckButton` initial version check (with `useEffect`)
- `useStreamDeckSelection` added to the single async-module
- `useStreamDeckSelection` props change, now the selector should be stable since `options` is a reference to a memo

```diff
- function useSelection({ equippable, ...props }: UseStreamDeckSelectionArgs): string | undefined {
+ export function useStreamDeckSelection({ equippable, options }: UseStreamDeckSelectionArgs): string | undefined {
- return useSelector(toSelectionHref(canSelect, props));
+ return useSelector(toSelectionHref(canSelect, options));
```