### PR TITLE
Components that use a global class need to import the file that defines the global class

### DIFF
--- a/src/app/armory/ItemGrid.tsx
+++ b/src/app/armory/ItemGrid.tsx
@@ -4,6 +4,7 @@
 
 import ItemPopup from 'app/item-popup/ItemPopup';
 import React, { JSX, useCallback, useRef, useState } from 'react';
+import '../inventory-page/StoreBucket.scss';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
 

--- a/src/app/infuse/InfusionFinder.tsx
+++ b/src/app/infuse/InfusionFinder.tsx
@@ -15,6 +15,7 @@ import { useCallback, useDeferredValue, useEffect, useReducer } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import Sheet from '../dim-ui/Sheet';
+import '../inventory-page/StoreBucket.scss';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector, currentStoreSelector, getTagSelector } from '../inventory/selectors';

--- a/src/app/inventory-page/StoreBucketDropTarget.tsx
+++ b/src/app/inventory-page/StoreBucketDropTarget.tsx
@@ -7,6 +7,7 @@ import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import React from 'react';
 import { useDrop } from 'react-dnd';
+import '../inventory-page/StoreBucket.scss';
 import styles from './StoreBucketDropTarget.m.scss';
 
 interface Props {

--- a/src/app/item-picker/ItemPicker.tsx
+++ b/src/app/item-picker/ItemPicker.tsx
@@ -10,6 +10,7 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } f
 import { mergeProps, useKeyboard, useLongPress, usePress } from 'react-aria';
 import { useSelector } from 'react-redux';
 import Sheet from '../dim-ui/Sheet';
+import '../inventory-page/StoreBucket.scss';
 import ConnectedInventoryItem from '../inventory/ConnectedInventoryItem';
 import { DimItem } from '../inventory/item-types';
 import { allItemsSelector } from '../inventory/selectors';

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -24,6 +24,7 @@ import clsx from 'clsx';
 import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
 import { memo, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import '../inventory-page/StoreBucket.scss';
 import styles from './SocketDetails.m.scss';
 import SocketDetailsSelectedPlug from './SocketDetailsSelectedPlug';
 

--- a/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditBucket.tsx
@@ -19,6 +19,7 @@ import { BucketHashes } from 'data/d2/generated-enums';
 import { partition } from 'es-toolkit';
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import '../../inventory-page/StoreBucket.scss';
 import FashionDrawer from '../fashion/FashionDrawer';
 import { BucketPlaceholder } from '../loadout-ui/BucketPlaceholder';
 import { FashionMods } from '../loadout-ui/FashionMods';

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -24,6 +24,7 @@ import clsx from 'clsx';
 import { partition } from 'es-toolkit';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import '../../inventory-page/StoreBucket.scss';
 import { BucketPlaceholder } from './BucketPlaceholder';
 import { FashionMods } from './FashionMods';
 import styles from './LoadoutItemCategorySection.m.scss';

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -11,11 +11,12 @@ import { compact } from 'app/utils/collections';
 import Cost from 'app/vendors/Cost';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { useCallback, useMemo, useState } from 'react';
-import ModPicker from '../ModPicker';
+import '../../inventory-page/StoreBucket.scss';
 import PlugDef from '../loadout-ui/PlugDef';
 import Sockets from '../loadout-ui/Sockets';
 import { fitMostMods } from '../mod-assignment-utils';
 import { createGetModRenderKey } from '../mod-utils';
+import ModPicker from '../ModPicker';
 import styles from './ModAssignmentDrawer.m.scss';
 import { useEquippedLoadoutArmorAndSubclass, useLoadoutMods } from './selectors';
 

--- a/src/app/search/SearchResults.tsx
+++ b/src/app/search/SearchResults.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { memo } from 'react';
 import { useSelector } from 'react-redux';
 import Sheet from '../dim-ui/Sheet';
+import '../inventory-page/StoreBucket.scss';
 import { DimItem } from '../inventory/item-types';
 import { itemSorterSelector } from '../settings/item-sort';
 import styles from './SearchResults.m.scss';

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -24,6 +24,7 @@ import { range } from 'es-toolkit';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import ErrorBoundary from '../dim-ui/ErrorBoundary';
+import '../inventory-page/StoreBucket.scss';
 import InventoryItem from '../inventory/InventoryItem';
 import { AppIcon, faGrid, faList, lockIcon, unlockedIcon } from '../shell/icons';
 import CharacterOrderEditor from './CharacterOrderEditor';


### PR DESCRIPTION
This is one of the reasons we are trying to eradicate global classes in favor of CSS modules.