### PR TITLE
Use displayProperties for stats, remove D1 stuff

### DIFF
--- a/i18next-scanner.config.cjs
+++ b/i18next-scanner.config.cjs
@@ -55,7 +55,6 @@ module.exports = {
     // prettier-ignore
     const keys = {
       buckets: { list: ['General', 'Inventory', 'Postmaster', 'Progress', 'Unknown'] },
-      cooldowns: { list: ['Grenade', 'Melee', 'Super'] },
       difficulty: { list: ['Normal', 'Hard'] },
       progress: { list: ['Bounties', 'Items', 'Quests'] },
       sockets: { list: ['Mod', 'Ability', 'Shader', 'Ornament', 'Fragment', 'Aspect', 'Projection', 'Transmat', 'Super'] }

--- a/src/app/destiny1/loadout-builder/GeneratedSet.tsx
+++ b/src/app/destiny1/loadout-builder/GeneratedSet.tsx
@@ -1,10 +1,12 @@
 import { t } from 'app/i18next-t';
+import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import { applyLoadout } from 'app/loadout-drawer/loadout-apply';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import { Loadout } from 'app/loadout/loadout-types';
-import D1CharacterStats from 'app/store-stats/D1CharacterStats';
+import { D1CharacterStats } from 'app/store-stats/D1CharacterStats';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { filterMap } from 'app/utils/collections';
+import { BucketHashes } from 'data/d2/generated-enums';
 import { useState } from 'react';
 import { D1Item } from '../../inventory/item-types';
 import { DimStore } from '../../inventory/store-types';
@@ -26,6 +28,7 @@ interface Props {
 export default function GeneratedSet({ setType, store, activesets, excludeItem }: Props) {
   const [collapsed, setCollapsed] = useState(true);
   const dispatch = useThunkDispatch();
+  const subclass = findItemsByBucket(store, BucketHashes.Subclass).find((i) => i.equipped);
 
   const toggle = () => setCollapsed((collapsed) => !collapsed);
 
@@ -64,7 +67,7 @@ export default function GeneratedSet({ setType, store, activesets, excludeItem }
           </>
         )}{' '}
         <div className="dim-stats">
-          <D1CharacterStats stats={setType.tiers[activesets].stats} />
+          <D1CharacterStats stats={setType.tiers[activesets].stats} subclassHash={subclass?.hash} />
         </div>
       </div>
       <div className="loadout-builder-section">

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -1,8 +1,8 @@
+import { characterStatFromStatDef } from 'app/inventory/store/character-utils';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { sumBy } from 'app/utils/collections';
 import { infoLog } from 'app/utils/log';
 import { delay } from 'app/utils/promises';
-import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import { D1Item } from '../../inventory/item-types';
 import { D1ManifestDefinitions } from '../d1-definitions';
@@ -94,33 +94,9 @@ export async function getSetBucketsStep(
   }
 
   let processedCount = 0;
-  const intellect = defs.Stat.get(StatHashes.Intellect);
-  const intellectDisplayProperties: DestinyDisplayPropertiesDefinition = {
-    name: intellect.statName,
-    description: intellect.statDescription,
-    icon: intellect.icon,
-    hasIcon: Boolean(intellect.icon),
-    iconSequences: [],
-    highResIcon: '',
-  };
-  const strength = defs.Stat.get(StatHashes.Strength);
-  const strengthDisplayProperties: DestinyDisplayPropertiesDefinition = {
-    name: strength.statName,
-    description: strength.statDescription,
-    icon: strength.icon,
-    hasIcon: Boolean(strength.icon),
-    iconSequences: [],
-    highResIcon: '',
-  };
-  const discipline = defs.Stat.get(StatHashes.Discipline);
-  const disciplineDisplayProperties: DestinyDisplayPropertiesDefinition = {
-    name: discipline.statName,
-    description: discipline.statDescription,
-    icon: discipline.icon,
-    hasIcon: Boolean(discipline.icon),
-    iconSequences: [],
-    highResIcon: '',
-  };
+  const intellect = characterStatFromStatDef(defs.Stat.get(StatHashes.Intellect), 0);
+  const strength = characterStatFromStatDef(defs.Stat.get(StatHashes.Strength), 0);
+  const discipline = characterStatFromStatDef(defs.Stat.get(StatHashes.Discipline), 0);
 
   for (const helm of helms) {
     for (const gauntlet of gauntlets) {
@@ -148,21 +124,9 @@ export async function getSetBucketsStep(
                       [BucketHashes.Ghost]: ghost,
                     },
                     stats: {
-                      [StatHashes.Intellect]: {
-                        hash: StatHashes.Intellect,
-                        value: 0,
-                        displayProperties: intellectDisplayProperties,
-                      },
-                      [StatHashes.Discipline]: {
-                        hash: StatHashes.Discipline,
-                        value: 0,
-                        displayProperties: disciplineDisplayProperties,
-                      },
-                      [StatHashes.Strength]: {
-                        hash: StatHashes.Strength,
-                        value: 0,
-                        displayProperties: strengthDisplayProperties,
-                      },
+                      [StatHashes.Intellect]: { ...intellect },
+                      [StatHashes.Discipline]: { ...discipline },
+                      [StatHashes.Strength]: { ...strength },
                     },
                     setHash: '',
                     includesVendorItems: false,

--- a/src/app/destiny1/loadout-builder/calculate.ts
+++ b/src/app/destiny1/loadout-builder/calculate.ts
@@ -2,6 +2,7 @@ import { D1BucketHashes } from 'app/search/d1-known-values';
 import { sumBy } from 'app/utils/collections';
 import { infoLog } from 'app/utils/log';
 import { delay } from 'app/utils/promises';
+import { DestinyDisplayPropertiesDefinition } from 'bungie-api-ts/destiny2';
 import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import { D1Item } from '../../inventory/item-types';
 import { D1ManifestDefinitions } from '../d1-definitions';
@@ -93,9 +94,33 @@ export async function getSetBucketsStep(
   }
 
   let processedCount = 0;
-  const intellectIcon = defs.Stat.get(StatHashes.Intellect).icon;
-  const strengthIcon = defs.Stat.get(StatHashes.Strength).icon;
-  const disciplineIcon = defs.Stat.get(StatHashes.Discipline).icon;
+  const intellect = defs.Stat.get(StatHashes.Intellect);
+  const intellectDisplayProperties: DestinyDisplayPropertiesDefinition = {
+    name: intellect.statName,
+    description: intellect.statDescription,
+    icon: intellect.icon,
+    hasIcon: Boolean(intellect.icon),
+    iconSequences: [],
+    highResIcon: '',
+  };
+  const strength = defs.Stat.get(StatHashes.Strength);
+  const strengthDisplayProperties: DestinyDisplayPropertiesDefinition = {
+    name: strength.statName,
+    description: strength.statDescription,
+    icon: strength.icon,
+    hasIcon: Boolean(strength.icon),
+    iconSequences: [],
+    highResIcon: '',
+  };
+  const discipline = defs.Stat.get(StatHashes.Discipline);
+  const disciplineDisplayProperties: DestinyDisplayPropertiesDefinition = {
+    name: discipline.statName,
+    description: discipline.statDescription,
+    icon: discipline.icon,
+    hasIcon: Boolean(discipline.icon),
+    iconSequences: [],
+    highResIcon: '',
+  };
 
   for (const helm of helms) {
     for (const gauntlet of gauntlets) {
@@ -126,23 +151,17 @@ export async function getSetBucketsStep(
                       [StatHashes.Intellect]: {
                         hash: StatHashes.Intellect,
                         value: 0,
-                        name: 'Intellect',
-                        description: '',
-                        icon: intellectIcon,
+                        displayProperties: intellectDisplayProperties,
                       },
                       [StatHashes.Discipline]: {
                         hash: StatHashes.Discipline,
                         value: 0,
-                        name: 'Discipline',
-                        description: '',
-                        icon: disciplineIcon,
+                        displayProperties: disciplineDisplayProperties,
                       },
                       [StatHashes.Strength]: {
                         hash: StatHashes.Strength,
                         value: 0,
-                        name: 'Strength',
-                        description: '',
-                        icon: strengthIcon,
+                        displayProperties: strengthDisplayProperties,
                       },
                     },
                     setHash: '',

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -122,9 +122,6 @@ export interface DimCharacterStat {
   /** The current value of the stat. */
   value: number;
 
-  /** D1 Cooldown time for the associated ability. */
-  cooldown?: string;
-
   /** How this stat exactly was calculated. */
   breakdown?: DimCharacterStatChange[];
 }

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -122,9 +122,7 @@ export interface DimCharacterStat {
   /** The current value of the stat. */
   value: number;
 
-  /** A localized description of this stat's effect. */
-  effect?: 'Grenade' | 'Melee' | 'Super';
-  /** Cooldown time for the associated ability. */
+  /** D1 Cooldown time for the associated ability. */
   cooldown?: string;
 
   /** How this stat exactly was calculated. */

--- a/src/app/inventory/store-types.ts
+++ b/src/app/inventory/store-types.ts
@@ -117,15 +117,10 @@ export interface DimCharacterStatChange {
 export interface DimCharacterStat {
   /** The DestinyStatDefinition hash for the stat. */
   hash: number;
-  /** The localized name of the stat. */
-  name: string;
-  /** An icon associated with the stat. */
-  icon: string;
+  displayProperties: DestinyDisplayPropertiesDefinition;
+
   /** The current value of the stat. */
   value: number;
-
-  /** The localized description of the stat. */
-  description: string;
 
   /** A localized description of this stat's effect. */
   effect?: 'Grenade' | 'Melee' | 'Super';

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -123,7 +123,7 @@ export function getCharacterStatsData(
     if (statsWithTiers.includes(stat.hash)) {
       const tier = Math.floor(Math.min(300, stat.value) / 60);
       if (data.peerView) {
-        stat.cooldown = getAbilityCooldown(data.peerView.equipment[0].itemHash, statId, tier);
+        stat.cooldown = getAbilityCooldown(data.peerView.equipment[0].itemHash, stat.hash, tier);
       }
     }
 
@@ -133,9 +133,9 @@ export function getCharacterStatsData(
 }
 
 // following code is from https://github.com/DestinyTrialsReport
-function getAbilityCooldown(subclass: number, ability: string, tier: number) {
-  switch (ability) {
-    case 'STAT_INTELLECT':
+function getAbilityCooldown(subclass: number, statHash: StatHashes, tier: number) {
+  switch (statHash) {
+    case StatHashes.Intellect:
       switch (subclass) {
         case 2007186000: // Defender
         case 4143670656: // Nightstalker
@@ -145,9 +145,9 @@ function getAbilityCooldown(subclass: number, ability: string, tier: number) {
         default:
           return cooldownsSuperB[tier];
       }
-    case 'STAT_DISCIPLINE':
+    case StatHashes.Discipline:
       return cooldownsGrenade[tier];
-    case 'STAT_STRENGTH':
+    case StatHashes.Strength:
       switch (subclass) {
         case 4143670656: // Nightstalker
         case 1716862031: // Gunslinger

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -106,36 +106,19 @@ export function getCharacterStatsData(
       continue;
     }
 
+    const statDef = defs.Stat.get(rawStat.statHash);
     const stat: DimCharacterStat = {
       hash: rawStat.statHash,
       value: rawStat.value,
-      name: '',
-      description: '',
-      icon: '',
+      displayProperties: {
+        name: statDef.statName, // localized name
+        description: statDef.statDescription,
+        icon: statDef.icon,
+        hasIcon: Boolean(statDef.icon),
+        highResIcon: '',
+        iconSequences: [],
+      },
     };
-
-    switch (statId) {
-      case 'STAT_INTELLECT':
-        stat.effect = 'Super';
-        stat.icon = defs.Stat.get(StatHashes.Intellect).icon;
-        break;
-      case 'STAT_DISCIPLINE':
-        stat.effect = 'Grenade';
-        stat.icon = defs.Stat.get(StatHashes.Discipline).icon;
-        break;
-      case 'STAT_STRENGTH':
-        stat.effect = 'Melee';
-        stat.icon = defs.Stat.get(StatHashes.Strength).icon;
-        break;
-      default:
-        break;
-    }
-
-    const statDef = defs.Stat.get(stat.hash);
-    if (statDef) {
-      stat.name = statDef.statName; // localized name
-      stat.description = statDef.statDescription;
-    }
 
     if (statsWithTiers.includes(stat.hash)) {
       const tier = Math.floor(Math.min(300, stat.value) / 60);

--- a/src/app/inventory/store/character-utils.ts
+++ b/src/app/inventory/store/character-utils.ts
@@ -1,10 +1,13 @@
 import { D1ManifestDefinitions } from 'app/destiny1/d1-definitions';
-import { D1Character } from 'app/destiny1/d1-manifest-types';
+import { D1Character, D1StatDefinition } from 'app/destiny1/d1-manifest-types';
 import { ArmorTypes } from 'app/destiny1/loadout-builder/types';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { DimCharacterStat } from '../store-types';
 
+/**
+ * D1 specific armor bonus calculation.
+ */
 // thanks to /u/iihavetoes for the bonuses at each level
 // thanks to /u/tehdaw for the spreadsheet with bonuses
 // https://docs.google.com/spreadsheets/d/1YyFDoHtaiOOeFoqc5Wc_WC2_qyQhBlZckQx5Jd4bJXI/edit?pref=2&pli=1#gid=0
@@ -65,7 +68,7 @@ export function getBonus(light: number, bucketHash: ArmorTypes): number {
 }
 
 /**
- * Compute character-level stats (int, dis, str).
+ * Compute D1 character-level stats (int, dis, str).
  */
 export function getCharacterStatsData(
   defs: D1ManifestDefinitions,
@@ -77,22 +80,26 @@ export function getCharacterStatsData(
     if (!rawStat) {
       continue;
     }
-
     const statDef = defs.Stat.get(rawStat.statHash);
-    const stat: DimCharacterStat = {
-      hash: rawStat.statHash,
-      value: rawStat.value,
-      displayProperties: {
-        name: statDef.statName, // localized name
-        description: statDef.statDescription,
-        icon: statDef.icon,
-        hasIcon: Boolean(statDef.icon),
-        highResIcon: '',
-        iconSequences: [],
-      },
-    };
-
-    ret[stat.hash] = stat;
+    ret[statDef.hash] = characterStatFromStatDef(statDef, rawStat.value);
   }
   return ret;
+}
+
+export function characterStatFromStatDef(
+  statDef: D1StatDefinition,
+  value: number,
+): DimCharacterStat {
+  return {
+    hash: statDef.statHash,
+    displayProperties: {
+      name: statDef.statName,
+      description: statDef.statDescription,
+      icon: statDef.icon,
+      hasIcon: Boolean(statDef.icon),
+      highResIcon: '',
+      iconSequences: [],
+    },
+    value,
+  };
 }

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -230,10 +230,8 @@ export function getCharacterStatsData(
     const value = stats[statHash] || 0;
     const stat: DimCharacterStat = {
       hash: statHash,
-      name: def.displayProperties.name,
-      description: def.displayProperties.description,
+      displayProperties: def.displayProperties,
       value,
-      icon: def.displayProperties.icon,
     };
     ret[statHash] = stat;
   }

--- a/src/app/loadout-builder/filter/StatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/StatConstraintEditor.tsx
@@ -337,8 +337,7 @@ function StatTierBar({
                 stat={{
                   hash: statHash,
                   value: tierNum * 10,
-                  name: statDef.displayProperties.name,
-                  description: statDef.displayProperties.description,
+                  displayProperties: statDef.displayProperties,
                 }}
                 equippedHashes={equippedHashes}
               />

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -63,9 +63,8 @@ export function SetStats({
               <StatTooltip
                 stat={{
                   hash: statHash,
-                  name: statDef.displayProperties.name,
+                  displayProperties: statDef.displayProperties,
                   value,
-                  description: statDef.displayProperties.description,
                   breakdown: getStatsBreakdown()[statHash].breakdown,
                 }}
                 equippedHashes={equippedHashes}

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -300,11 +300,8 @@ export function getLoadoutStats(
 
   // Construct map of stat hash to DimCharacterStat
   const stats: { [hash: number | string]: DimCharacterStat } = {};
-  for (const {
-    hash,
-    displayProperties: { description, icon, name },
-  } of statDefs) {
-    stats[hash] = { hash, description, icon: icon, name, value: 0, breakdown: [] };
+  for (const { hash, displayProperties } of statDefs) {
+    stats[hash] = { hash, displayProperties, value: 0, breakdown: [] };
   }
 
   // Sum the items stats into the stats

--- a/src/app/store-stats/CharacterStats.tsx
+++ b/src/app/store-stats/CharacterStats.tsx
@@ -173,10 +173,10 @@ function CharacterStats({
             className={clsx('stat', {
               boostedValue: stat.breakdown?.some((change) => change.source === 'runtimeEffect'),
             })}
-            aria-label={`${stat.name} ${stat.value}`}
+            aria-label={`${stat.displayProperties.name} ${stat.value}`}
             role="group"
           >
-            <BungieImage src={stat.icon} alt={stat.name} />
+            <BungieImage src={stat.displayProperties.icon} alt={stat.displayProperties.name} />
             <div>{stat.value}</div>
           </div>
         </PressTip>

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -22,7 +22,7 @@ export default function D1CharacterStats({ stats }: Props) {
         progress: tier === 5 ? stat.value : stat.value % 60,
         tier,
         nextTier: tier + 1,
-        statName: stat.name,
+        statName: stat.displayProperties.name,
       });
 
       let cooldown = stat.cooldown || '';
@@ -41,7 +41,7 @@ export default function D1CharacterStats({ stats }: Props) {
       {statList.map((stat, index) => (
         <PressTip key={stat.hash} tooltip={tooltips[index]}>
           <div className="stat">
-            <BungieImage src={stat.icon} alt={stat.name} />
+            <BungieImage src={stat.displayProperties.icon} alt={stat.displayProperties.name} />
             {getD1CharacterStatTiers(stat).map((n, index) => (
               <div key={index} className="bar">
                 <div

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -5,13 +5,10 @@ import type { DimStore } from 'app/inventory/store-types';
 import { getD1CharacterStatTiers, statsWithTiers } from 'app/inventory/store/character-utils';
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
+import { StatHashes } from 'data/d2/generated-enums';
 import './CharacterStats.scss';
 
-interface Props {
-  stats: DimStore['stats'];
-}
-
-export default function D1CharacterStats({ stats }: Props) {
+export default function D1CharacterStats({ stats }: { stats: DimStore['stats'] }) {
   const statList = statsWithTiers.map((h) => stats[h]);
   const tooltips = statList.map((stat) => {
     if (stat) {
@@ -25,14 +22,18 @@ export default function D1CharacterStats({ stats }: Props) {
         statName: stat.displayProperties.name,
       });
 
-      let cooldown = stat.cooldown || '';
+      const cooldown = stat.cooldown || '';
       if (cooldown) {
-        cooldown = t(`Cooldown.${stat.effect!}`, {
-          cooldown,
-          metadata: { keys: 'cooldowns' },
-        });
+        switch (stat.hash) {
+          case StatHashes.Intellect:
+            return next + t('Cooldown.Super', { cooldown });
+          case StatHashes.Discipline:
+            return next + t('Cooldown.Grenade', { cooldown });
+          case StatHashes.Strength:
+            return next + t('Cooldown.Melee', { cooldown });
+        }
       }
-      return next + cooldown;
+      return next;
     }
   });
 

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -1,40 +1,49 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
-import type { DimStore } from 'app/inventory/store-types';
-import { getD1CharacterStatTiers, statsWithTiers } from 'app/inventory/store/character-utils';
+import type { DimCharacterStat, DimStore } from 'app/inventory/store-types';
+import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
-import { StatHashes } from 'data/d2/generated-enums';
+import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
 import './CharacterStats.scss';
 
-export default function D1CharacterStats({ stats }: { stats: DimStore['stats'] }) {
-  const statList = statsWithTiers.map((h) => stats[h]);
-  const tooltips = statList.map((stat) => {
-    if (stat) {
-      const tier = Math.floor(Math.min(300, stat.value) / 60);
-      const next = t('Stats.TierProgress', {
-        context: tier === 5 ? 'Max' : '',
-        metadata: { context: ['max'] },
-        progress: tier === 5 ? stat.value : stat.value % 60,
-        tier,
-        nextTier: tier + 1,
-        statName: stat.displayProperties.name,
-      });
+export function D1StoreCharacterStats({ store }: { store: DimStore }) {
+  const subclass = findItemsByBucket(store, BucketHashes.Subclass).find((i) => i.equipped);
+  return <D1CharacterStats stats={store.stats} subclassHash={subclass?.hash} />;
+}
 
-      const cooldown = stat.cooldown || '';
-      if (cooldown) {
-        switch (stat.hash) {
-          case StatHashes.Intellect:
-            return next + t('Cooldown.Super', { cooldown });
-          case StatHashes.Discipline:
-            return next + t('Cooldown.Grenade', { cooldown });
-          case StatHashes.Strength:
-            return next + t('Cooldown.Melee', { cooldown });
-        }
+export function D1CharacterStats({
+  stats,
+  subclassHash,
+}: {
+  stats: DimStore['stats'];
+  subclassHash?: number;
+}) {
+  const statList = Object.values(stats);
+  const tooltips = statList.map((stat) => {
+    const tier = Math.floor(Math.min(300, stat.value) / 60);
+    const next = t('Stats.TierProgress', {
+      context: tier === 5 ? 'Max' : '',
+      metadata: { context: ['max'] },
+      progress: tier === 5 ? stat.value : stat.value % 60,
+      tier,
+      nextTier: tier + 1,
+      statName: stat.displayProperties.name,
+    });
+
+    const cooldown = subclassHash ? getAbilityCooldown(subclassHash, stat.hash, tier) : undefined;
+    if (cooldown) {
+      switch (stat.hash) {
+        case StatHashes.Intellect:
+          return next + t('Cooldown.Super', { cooldown });
+        case StatHashes.Discipline:
+          return next + t('Cooldown.Grenade', { cooldown });
+        case StatHashes.Strength:
+          return next + t('Cooldown.Melee', { cooldown });
       }
-      return next;
     }
+    return next;
   });
 
   return (
@@ -58,4 +67,47 @@ export default function D1CharacterStats({ stats }: { stats: DimStore['stats'] }
       ))}
     </div>
   );
+}
+
+function getD1CharacterStatTiers(stat: DimCharacterStat) {
+  const tiers = new Array<number>(5);
+  let remaining = stat.value;
+  for (let t = 0; t < 5; t++) {
+    remaining -= tiers[t] = remaining > 60 ? 60 : remaining;
+  }
+  return tiers;
+}
+
+// Cooldowns
+const cooldownsSuperA = ['5:00', '4:46', '4:31', '4:15', '3:58', '3:40'];
+const cooldownsSuperB = ['5:30', '5:14', '4:57', '4:39', '4:20', '4:00'];
+const cooldownsGrenade = ['1:00', '0:55', '0:49', '0:42', '0:34', '0:25'];
+const cooldownsMelee = ['1:10', '1:04', '0:57', '0:49', '0:40', '0:29'];
+
+// following code is from https://github.com/DestinyTrialsReport
+function getAbilityCooldown(subclass: number, statHash: StatHashes, tier: number) {
+  switch (statHash) {
+    case StatHashes.Intellect:
+      switch (subclass) {
+        case 2007186000: // Defender
+        case 4143670656: // Nightstalker
+        case 2455559914: // Striker
+        case 3658182170: // Sunsinger
+          return cooldownsSuperA[tier];
+        default:
+          return cooldownsSuperB[tier];
+      }
+    case StatHashes.Discipline:
+      return cooldownsGrenade[tier];
+    case StatHashes.Strength:
+      switch (subclass) {
+        case 4143670656: // Nightstalker
+        case 1716862031: // Gunslinger
+          return cooldownsMelee[tier];
+        default:
+          return cooldownsGrenade[tier];
+      }
+    default:
+      return '';
+  }
 }

--- a/src/app/store-stats/StatTooltip.tsx
+++ b/src/app/store-stats/StatTooltip.tsx
@@ -1,20 +1,12 @@
 import { settingSelector } from 'app/dim-api/selectors';
 import { Tooltip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
-import { DimCharacterStatChange } from 'app/inventory/store-types';
+import { DimCharacterStat } from 'app/inventory/store-types';
 import { statTier } from 'app/loadout-builder/utils';
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
 import ClarityCharacterStat from './ClarityCharacterStat';
 import styles from './StatTooltip.m.scss';
-
-interface Stat {
-  hash: number;
-  name: string;
-  value: number;
-  description: string;
-  breakdown?: DimCharacterStatChange[];
-}
 
 /**
  * A rich tooltip for character-level stats like Mobility, Intellect, etc.
@@ -23,7 +15,7 @@ export default function StatTooltip({
   stat,
   equippedHashes,
 }: {
-  stat: Stat;
+  stat: DimCharacterStat;
   /**
    * Hashes of equipped/selected items and subclass plugs for this character or loadout. Can be limited to
    * exotic armor + subclass plugs - make sure to include default-selected subclass plugs.
@@ -36,13 +28,13 @@ export default function StatTooltip({
 
   return (
     <div>
-      <Tooltip.Header text={stat.name} />
+      <Tooltip.Header text={stat.displayProperties.name} />
       <div className={styles.values}>
         <div className={styles.label}>{t('Stats.Tier', { tier })}</div>
         <div>{`${stat.value}/100`}</div>
       </div>
       <hr />
-      <div>{stat.description}</div>
+      <div>{stat.displayProperties.description}</div>
       {stat.breakdown?.some((contribution) => contribution.source !== 'armorStats') && (
         <>
           <hr />

--- a/src/app/store-stats/StoreStats.tsx
+++ b/src/app/store-stats/StoreStats.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import React from 'react';
 import { PowerFormula, StoreCharacterStats } from '../store-stats/CharacterStats';
 import AccountCurrencies from './AccountCurrencies';
-import D1CharacterStats from './D1CharacterStats';
+import { D1StoreCharacterStats } from './D1CharacterStats';
 import styles from './StoreStats.m.scss';
 import VaultCapacity from './VaultCapacity';
 
@@ -25,7 +25,7 @@ export default function StoreStats({
           {!isPhonePortrait && <VaultCapacity />}
         </div>
       ) : store.destinyVersion === 1 ? (
-        <D1CharacterStats stats={store.stats} />
+        <D1StoreCharacterStats store={store} />
       ) : (
         <div className="stat-bars destiny2">
           <PowerFormula storeId={store.id} />


### PR DESCRIPTION
This refactors the DimCharacterStat structure to use displayProperties instead of broken-out name/description/icon. It also removes some D1-specific info that could be more easily computed where it's displayed. Along the way I made it so D1 stats will show their cooldowns in more places than they did before.