### PR TITLE
Forget previous path when explicitly logging out

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+* Restored a workaround for laggy dragging in Chrome on Windows when using some high-DPI and/or Logitech mice.
+* DIM now recognizes exotic weapons that grant intrinsic breaker abilities through a perk.
+* Logging out now properly "forgets" the page you were on, so when you log in again it doesn't try to go back to that page.
+
 ## 8.54.0 <span class="changelog-date">(2025-01-12)</span>
 
 ## 8.53.0 <span class="changelog-date">(2025-01-05)</span>

--- a/src/app/accounts/MenuAccounts.tsx
+++ b/src/app/accounts/MenuAccounts.tsx
@@ -4,7 +4,7 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import { AppIcon, signOutIcon } from '../shell/icons';
 import Account from './Account';
 import styles from './MenuAccounts.m.scss';
@@ -22,8 +22,12 @@ export default function MenuAccounts({
   const dispatch = useThunkDispatch();
   const currentAccount = useSelector(currentAccountSelector);
   const accounts = useSelector(accountsSelector);
+  const navigate = useNavigate();
 
-  const onLogOut = () => dispatch(logOut());
+  const onLogOut = async () => {
+    await dispatch(logOut());
+    await navigate('/login');
+  };
 
   const sortedAccounts = accounts.toSorted(
     chainComparator(

--- a/src/app/accounts/SelectAccount.tsx
+++ b/src/app/accounts/SelectAccount.tsx
@@ -4,7 +4,7 @@ import { AppIcon, signOutIcon } from 'app/shell/icons';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { chainComparator, compareBy, reverseComparator } from 'app/utils/comparators';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 import Account from './Account';
 import styles from './SelectAccount.m.scss';
 import { logOut } from './platforms';
@@ -25,7 +25,11 @@ export default function SelectAccount({ path }: { path?: string }) {
   const bungieName = sortedAccounts[0].displayName;
 
   const dispatch = useThunkDispatch();
-  const onLogOut = () => dispatch(logOut());
+  const navigate = useNavigate();
+  const onLogOut = async () => {
+    await dispatch(logOut());
+    await navigate('/login');
+  };
 
   return (
     <div className={styles.accountSelect}>


### PR DESCRIPTION
This prevents the situation where you log out, log in to another account, and it tells you it can't find the old account's info. The problem was the login action caused the router to automatically redirect to `/login`, but it captured the old path, and we don't want that in an explicit logout.