### PR TITLE
Allow loadout history searches to be selected

### DIFF
--- a/src/app/search/SearchHistory.m.scss
+++ b/src/app/search/SearchHistory.m.scss
@@ -17,6 +17,10 @@
     padding: 16px 8px;
   }
 
+  td {
+    user-select: text;
+  }
+
   tr:nth-child(2n) {
     td {
       background-color: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
It was an oversight that the search history wasn't explicitly marked as selectable text.