### PR TITLE
Remove the 15-second window where you can't refresh

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -135,8 +135,6 @@ export function loadStores(): ThunkResult<DimStore[] | undefined> {
   };
 }
 
-/** time in milliseconds after which we could expect Bnet to return an updated response */
-const BUNGIE_CACHE_TTL = 15_000;
 /** How old the profile can be and still trigger cleanup of tags. */
 const FRESH_ENOUGH_TO_CLEAN_INFOS = 90_000; // 90 seconds
 
@@ -187,22 +185,9 @@ function loadProfile(
       }
     }
 
-    let cachedProfileMintedDate = new Date(0);
-
-    // If our cached profile is up to date
-    if (cachedProfileResponse) {
-      // TODO: need to make sure we still load at the right frequency / for manual cache busts?
-      cachedProfileMintedDate = new Date(cachedProfileResponse.responseMintedTimestamp ?? 0);
-      const profileAge = Date.now() - cachedProfileMintedDate.getTime();
-      if (!storesLoadedSelector(getState()) && profileAge > 0 && profileAge < BUNGIE_CACHE_TTL) {
-        warnLog(
-          TAG,
-          `Cached profile is only ${profileAge / 1000}s old, skipping remote load.`,
-          profileAge,
-        );
-        return { profile: cachedProfileResponse, live: false };
-      }
-    }
+    const cachedProfileMintedDate = cachedProfileResponse
+      ? new Date(cachedProfileResponse.responseMintedTimestamp ?? 0)
+      : new Date(0);
 
     try {
       const remoteProfileResponse = await getStores(account);


### PR DESCRIPTION
We currently refuse to refresh the user's profile from Bungie.net unless it's been at least 15 seconds since the last time the profile was updated (according to Bungie's timestamp). This PR removes that limit - they clearly have their own caching to protect against excess traffic, and this just makes it more frustrating to try and load updated data. If users want to bang on the refresh button continuously, we can let them.