### PR TITLE
Attempt to show crafted/enhanced items' masterwork stat in Compare/ItemPopup views

### DIFF
--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -42,11 +42,9 @@ export default function ItemSocketsWeapons({
   }
 
   // Separate out perks from sockets.
-  const { intrinsicSocket, perks, modSocketsByCategory } = getWeaponSockets(
-    item,
-    /* excludeEmptySockets */ false,
-    /* includeFakeMasterwork */ Boolean(item.crafted),
-  )!;
+  const { intrinsicSocket, perks, modSocketsByCategory } = getWeaponSockets(item, {
+    includeFakeMasterwork: Boolean(item.crafted),
+  })!;
 
   // Improve this when we use iterator-helpers
   const mods = [...modSocketsByCategory.values()].flat();
@@ -159,11 +157,9 @@ export function ItemModSockets({
   }
 
   // Separate out perks from sockets.
-  const { modSocketsByCategory } = getWeaponSockets(
-    item,
-    /* excludeEmptySockets */ false,
-    /* includeFakeMasterwork */ Boolean(item.crafted),
-  )!;
+  const { modSocketsByCategory } = getWeaponSockets(item, {
+    includeFakeMasterwork: Boolean(item.crafted),
+  })!;
 
   // Improve this when we use iterator-helpers
   const mods = [...modSocketsByCategory.values()].flat();

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -1,10 +1,6 @@
 import { t } from 'app/i18next-t';
 import { statsMs } from 'app/inventory/store/stats';
 import { useD2Definitions } from 'app/manifest/selectors';
-import {
-  D2PlugCategoryByStatHash,
-  weaponMasterworkY2SocketTypeHash,
-} from 'app/search/d2-known-values';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, faGrid, faList } from 'app/shell/icons';
 import { isKillTrackerSocket } from 'app/utils/item-utils';
@@ -12,7 +8,6 @@ import { getSocketsByIndexes, getWeaponSockets } from 'app/utils/socket-utils';
 import { LookupTable } from 'app/utils/util-types';
 import clsx from 'clsx';
 import { ItemCategoryHashes, StatHashes } from 'data/d2/generated-enums';
-import { maxBy } from 'es-toolkit';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { DimItem, DimSocket } from '../inventory/item-types';
@@ -46,42 +41,12 @@ export default function ItemSocketsWeapons({
     return null;
   }
 
-  if (item.crafted) {
-    const y2MasterworkSocket = item.sockets?.allSockets.find(
-      (socket) => socket.socketDefinition.socketTypeHash === weaponMasterworkY2SocketTypeHash,
-    );
-    const plugSet = y2MasterworkSocket?.plugSet;
-    if (y2MasterworkSocket && plugSet) {
-      // const plug = y2MasterworkSocket?.plugSet?.plugs.find(
-      //   (p) => p.plugDef.plug.plugCategoryHash === PlugCategoryHashes.V400PlugsWeaponsMasterworks,
-      // );
-      const mwHash = item.masterworkInfo?.stats?.find((s) => s.isPrimary)?.hash || 0;
-      const newCategory =
-        mwHash in D2PlugCategoryByStatHash
-          ? D2PlugCategoryByStatHash[mwHash as keyof typeof D2PlugCategoryByStatHash]
-          : null;
-      let fullMasterworkPlug = newCategory
-        ? maxBy(
-            plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === newCategory),
-            (plugOption) => plugOption.plugDef.investmentStats[0]?.value,
-          )
-        : null;
-      if (fullMasterworkPlug) {
-        fullMasterworkPlug = {
-          ...fullMasterworkPlug,
-          plugDef: { ...fullMasterworkPlug.plugDef, iconWatermark: '', investmentStats: [] },
-        };
-        y2MasterworkSocket.plugged = fullMasterworkPlug;
-        y2MasterworkSocket.plugOptions = [fullMasterworkPlug];
-        y2MasterworkSocket.visibleInGame = true;
-        y2MasterworkSocket.reusablePlugItems = [];
-        y2MasterworkSocket.isPerk = true;
-      }
-    }
-  }
-
   // Separate out perks from sockets.
-  const { intrinsicSocket, perks, modSocketsByCategory } = getWeaponSockets(item)!;
+  const { intrinsicSocket, perks, modSocketsByCategory } = getWeaponSockets(
+    item,
+    false,
+    Boolean(item.crafted),
+  )!;
 
   // Improve this when we use iterator-helpers
   const mods = [...modSocketsByCategory.values()].flat();
@@ -194,7 +159,7 @@ export function ItemModSockets({
   }
 
   // Separate out perks from sockets.
-  const { modSocketsByCategory } = getWeaponSockets(item)!;
+  const { modSocketsByCategory } = getWeaponSockets(item, false, Boolean(item.crafted))!;
 
   // Improve this when we use iterator-helpers
   const mods = [...modSocketsByCategory.values()].flat();

--- a/src/app/item-popup/ItemSocketsWeapons.tsx
+++ b/src/app/item-popup/ItemSocketsWeapons.tsx
@@ -44,8 +44,8 @@ export default function ItemSocketsWeapons({
   // Separate out perks from sockets.
   const { intrinsicSocket, perks, modSocketsByCategory } = getWeaponSockets(
     item,
-    false,
-    Boolean(item.crafted),
+    /* excludeEmptySockets */ false,
+    /* includeFakeMasterwork */ Boolean(item.crafted),
   )!;
 
   // Improve this when we use iterator-helpers
@@ -159,7 +159,11 @@ export function ItemModSockets({
   }
 
   // Separate out perks from sockets.
-  const { modSocketsByCategory } = getWeaponSockets(item, false, Boolean(item.crafted))!;
+  const { modSocketsByCategory } = getWeaponSockets(
+    item,
+    /* excludeEmptySockets */ false,
+    /* includeFakeMasterwork */ Boolean(item.crafted),
+  )!;
 
   // Improve this when we use iterator-helpers
   const mods = [...modSocketsByCategory.values()].flat();

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -146,11 +146,11 @@ export const D2PlugCategoryByStatHash = new Map<StatHashes, PlugCategoryHashes>(
   [StatHashes.Impact, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDamage],
   [StatHashes.DrawTime, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDrawTime],
   [StatHashes.Handling, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHandling],
-  [StatHashes.Speed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed],
   [StatHashes.Range, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange],
   [StatHashes.ReloadSpeed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload],
   [StatHashes.Stability, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability],
   [StatHashes.Velocity, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed],
+  [StatHashes.ShieldDuration, PlugCategoryHashes.V600PlugsWeaponsMasterworksStatShieldDuration],
 ]);
 
 export const swordStatsByName = {

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -139,6 +139,19 @@ export const D2WeaponStatHashByName = {
   accuracy: StatHashes.Accuracy,
 };
 
+export const D2PlugCategoryByStatHash = {
+  [StatHashes.Accuracy]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatAccuracy,
+  [StatHashes.BlastRadius]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatBlastRadius,
+  [StatHashes.ChargeTime]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatChargeTime,
+  [StatHashes.Impact]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDamage,
+  [StatHashes.DrawTime]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDrawTime,
+  [StatHashes.Handling]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHandling,
+  [StatHashes.Speed]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed,
+  [StatHashes.Range]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange,
+  [StatHashes.ReloadSpeed]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload,
+  [StatHashes.Stability]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability,
+};
+
 export const swordStatsByName = {
   swingspeed: StatHashes.SwingSpeed,
   guardefficiency: StatHashes.GuardEfficiency,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -139,18 +139,18 @@ export const D2WeaponStatHashByName = {
   accuracy: StatHashes.Accuracy,
 };
 
-export const D2PlugCategoryByStatHash = {
-  [StatHashes.Accuracy]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatAccuracy,
-  [StatHashes.BlastRadius]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatBlastRadius,
-  [StatHashes.ChargeTime]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatChargeTime,
-  [StatHashes.Impact]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDamage,
-  [StatHashes.DrawTime]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDrawTime,
-  [StatHashes.Handling]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHandling,
-  [StatHashes.Speed]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed,
-  [StatHashes.Range]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange,
-  [StatHashes.ReloadSpeed]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload,
-  [StatHashes.Stability]: PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability,
-};
+export const D2PlugCategoryByStatHash = new Map<StatHashes, PlugCategoryHashes>([
+  [StatHashes.Accuracy, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatAccuracy],
+  [StatHashes.BlastRadius, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatBlastRadius],
+  [StatHashes.ChargeTime, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatChargeTime],
+  [StatHashes.Impact, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDamage],
+  [StatHashes.DrawTime, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDrawTime],
+  [StatHashes.Handling, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHandling],
+  [StatHashes.Speed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed],
+  [StatHashes.Range, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange],
+  [StatHashes.ReloadSpeed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload],
+  [StatHashes.Stability, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability],
+]);
 
 export const swordStatsByName = {
   swingspeed: StatHashes.SwingSpeed,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -150,6 +150,7 @@ export const D2PlugCategoryByStatHash = new Map<StatHashes, PlugCategoryHashes>(
   [StatHashes.Range, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange],
   [StatHashes.ReloadSpeed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload],
   [StatHashes.Stability, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability],
+  [StatHashes.Velocity, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed],
 ]);
 
 export const swordStatsByName = {

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -472,11 +472,11 @@ export function getWeaponSockets(
         return socket;
       }
       const mwHash = item.masterworkInfo?.stats?.find((s) => s.isPrimary)?.hash || 0;
-      const newCategory = D2PlugCategoryByStatHash.get(mwHash);
+      const plugCategory = D2PlugCategoryByStatHash.get(mwHash);
       let fullMasterworkPlug =
-        newCategory &&
+        plugCategory &&
         maxBy(
-          plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === newCategory),
+          plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === plugCategory),
           (plugOption) => plugOption.plugDef.investmentStats[0]?.value,
         );
       if (!fullMasterworkPlug) {

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -485,7 +485,11 @@ export function getWeaponSockets(
       }
       fullMasterworkPlug = {
         ...fullMasterworkPlug,
-        plugDef: { ...fullMasterworkPlug.plugDef, iconWatermark: '', investmentStats: [] },
+        plugDef: {
+          ...fullMasterworkPlug.plugDef,
+          iconWatermark: '', // remove the '10' in the top left of the icon
+          investmentStats: [], // remove the stats from the fake plug
+        },
       };
       return {
         ...socket,

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -467,16 +467,13 @@ export function getWeaponSockets(
       if (socket.socketDefinition.socketTypeHash !== weaponMasterworkY2SocketTypeHash) {
         return socket;
       }
-      const plugSet = socket.plugSet;
-      if (!plugSet) {
-        return socket;
-      }
       const mwHash = item.masterworkInfo?.stats?.find((s) => s.isPrimary)?.hash || 0;
       const plugCategory = D2PlugCategoryByStatHash.get(mwHash);
       let fullMasterworkPlug =
+        socket.plugSet &&
         plugCategory &&
         maxBy(
-          plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === plugCategory),
+          socket.plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === plugCategory),
           (plugOption) => plugOption.plugDef.investmentStats[0]?.value,
         );
       if (!fullMasterworkPlug) {

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -493,7 +493,7 @@ export function getWeaponSockets(
         plugOptions: [fullMasterworkPlug],
         visibleInGame: true,
         reusablePlugItems: [],
-        isPerk: true,
+        isPerk: true, // isPerk is required to prevent the socket from being selectable/modifiable
       };
     });
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -319,7 +319,7 @@ export function getDisplayedItemSockets(
   excludeEmptySockets = false,
 ): DisplayedSockets | undefined {
   if (item.bucket.inWeapons) {
-    return getWeaponSockets(item, excludeEmptySockets);
+    return getWeaponSockets(item, { excludeEmptySockets });
   } else {
     return getGeneralSockets(item, excludeEmptySockets);
   }
@@ -428,9 +428,13 @@ export function getSocketsByType(
 
 export function getWeaponSockets(
   item: DimItem,
-  excludeEmptySockets = false,
-  includeFakeMasterwork = false,
+  options: {
+    excludeEmptySockets?: boolean;
+    includeFakeMasterwork?: boolean;
+  },
 ): DisplayedSockets | undefined {
+  const { excludeEmptySockets = false, includeFakeMasterwork = false } = options;
+
   if (!item.sockets) {
     return undefined;
   }

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -461,46 +461,46 @@ export function getWeaponSockets(
     PlugCategoryHashes.V300WeaponDamageTypeKinetic,
   ];
 
-  const moddedSockets: DimSockets = !includeFakeMasterwork
-    ? item.sockets
-    : {
-        ...item.sockets,
-        allSockets: item.sockets.allSockets.map((socket) => {
-          if (socket.socketDefinition.socketTypeHash !== weaponMasterworkY2SocketTypeHash) {
-            return socket;
-          }
-          const plugSet = socket.plugSet;
-          if (!plugSet) {
-            return socket;
-          }
-          const mwHash = item.masterworkInfo?.stats?.find((s) => s.isPrimary)?.hash || 0;
-          const newCategory =
-            mwHash in D2PlugCategoryByStatHash
-              ? D2PlugCategoryByStatHash[mwHash as keyof typeof D2PlugCategoryByStatHash]
-              : null;
-          let fullMasterworkPlug = newCategory
-            ? maxBy(
-                plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === newCategory),
-                (plugOption) => plugOption.plugDef.investmentStats[0]?.value,
-              )
-            : null;
-          if (!fullMasterworkPlug) {
-            return socket;
-          }
-          fullMasterworkPlug = {
-            ...fullMasterworkPlug,
-            plugDef: { ...fullMasterworkPlug.plugDef, iconWatermark: '', investmentStats: [] },
-          };
-          return {
-            ...socket,
-            plugged: fullMasterworkPlug,
-            plugOptions: [fullMasterworkPlug],
-            visibleInGame: true,
-            reusablePlugItems: [],
-            isPerk: true,
-          };
-        }),
+  let moddedSockets: DimSockets = item.sockets;
+  if (includeFakeMasterwork) {
+    const allSockets = item.sockets.allSockets.map((socket) => {
+      if (socket.socketDefinition.socketTypeHash !== weaponMasterworkY2SocketTypeHash) {
+        return socket;
+      }
+      const plugSet = socket.plugSet;
+      if (!plugSet) {
+        return socket;
+      }
+      const mwHash = item.masterworkInfo?.stats?.find((s) => s.isPrimary)?.hash || 0;
+      const newCategory = D2PlugCategoryByStatHash.get(mwHash);
+      let fullMasterworkPlug =
+        newCategory &&
+        maxBy(
+          plugSet.plugs.filter((p) => p.plugDef.plug.plugCategoryHash === newCategory),
+          (plugOption) => plugOption.plugDef.investmentStats[0]?.value,
+        );
+      if (!fullMasterworkPlug) {
+        return socket;
+      }
+      fullMasterworkPlug = {
+        ...fullMasterworkPlug,
+        plugDef: { ...fullMasterworkPlug.plugDef, iconWatermark: '', investmentStats: [] },
       };
+      return {
+        ...socket,
+        plugged: fullMasterworkPlug,
+        plugOptions: [fullMasterworkPlug],
+        visibleInGame: true,
+        reusablePlugItems: [],
+        isPerk: true,
+      };
+    });
+
+    moddedSockets = {
+      ...item.sockets,
+      allSockets,
+    };
+  }
 
   const modSocketsByCategory = filterSocketCategories(
     moddedSockets.categories.toReversed(),

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -461,11 +461,11 @@ export function getWeaponSockets(
     PlugCategoryHashes.V300WeaponDamageTypeKinetic,
   ];
 
-  const moddedSockets: DimSockets = {
-    ...item.sockets,
-    allSockets: !includeFakeMasterwork
-      ? item.sockets.allSockets
-      : item.sockets.allSockets.map((socket) => {
+  const moddedSockets: DimSockets = !includeFakeMasterwork
+    ? item.sockets
+    : {
+        ...item.sockets,
+        allSockets: item.sockets.allSockets.map((socket) => {
           if (socket.socketDefinition.socketTypeHash !== weaponMasterworkY2SocketTypeHash) {
             return socket;
           }
@@ -500,7 +500,7 @@ export function getWeaponSockets(
             isPerk: true,
           };
         }),
-  };
+      };
 
   const modSocketsByCategory = filterSocketCategories(
     moddedSockets.categories.toReversed(),


### PR DESCRIPTION
Not clickable thanks to isPerk, shows no stats thanks to the socket itself not having any stats despite the franken-plug having them.

The dummy plug does not show up in Organizer.

<img width="486" alt="Screenshot 2025-01-29 at 5 40 32 AM" src="https://github.com/user-attachments/assets/c319f6c7-6dc2-4f07-bbde-ccecf3dce52b" />
<img width="525" alt="Screenshot 2025-01-29 at 5 49 45 AM" src="https://github.com/user-attachments/assets/c673db1d-a681-447b-9660-f34995ce6002" />
<img width="459" alt="Screenshot 2025-01-29 at 6 06 07 AM" src="https://github.com/user-attachments/assets/d98c30cb-d363-4ea5-b795-53083ec57e3a" />
