### PR TITLE
Only use "capped" style for completed bounties, not completed items

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -39,8 +39,9 @@ export function getItemImageStyles(item: DimItem, className?: string) {
       (item.bucket.hash === BucketHashes.Subclass ||
         item.itemCategoryHashes.includes(ItemCategoryHashes.Packages))) ||
     item.isEngram;
+  const isBounty = Boolean(!item.primaryStat && item.objectives);
   const itemImageStyles = clsx('item-img', className, {
-    [styles.complete]: item.complete || isCapped,
+    [styles.complete]: (isBounty && item.complete) || isCapped,
     [styles.borderless]: borderless,
     [styles.masterwork]: item.masterwork,
     [styles.deepsight]: item.deepsightInfo,

--- a/src/app/item-popup/ItemTalentGrid.tsx
+++ b/src/app/item-popup/ItemTalentGrid.tsx
@@ -1,3 +1,4 @@
+import { percent } from 'app/shell/formatters';
 import { maxOf } from 'app/utils/collections';
 import clsx from 'clsx';
 import { memo } from 'react';
@@ -82,7 +83,7 @@ export default memo(function ItemTalentGrid({
                 transform="rotate(-90)"
                 className="talent-node-xp"
                 strokeWidth={node.xp ? 2 : 0}
-                strokeDasharray={`${(100 * node.xp) / node.xpRequired} 100`}
+                strokeDasharray={`${percent(node.xp / node.xpRequired)} 100`}
               />
               <image
                 className="talent-node-img"


### PR DESCRIPTION
This is pretty subtle, and I'm not sure it was always there, but I don't think completed D1 items (e.g. items that have had all their perks unlocked) should have a yellow border. I think that's only meant for bounties.

Before:
<img width="245" alt="Screenshot 2025-02-09 at 10 04 24 PM" src="https://github.com/user-attachments/assets/aa5c6fcb-6786-427d-a968-810896fc14ad" />

After:
<img width="244" alt="Screenshot 2025-02-09 at 10 04 28 PM" src="https://github.com/user-attachments/assets/39980fdf-d093-4a8c-ba19-295d504b99c1" />

I also improved the accuracy of the talent grid completion circles so they actually close:

Before:
<img width="229" alt="Screenshot 2025-02-09 at 10 06 51 PM" src="https://github.com/user-attachments/assets/be89d3d8-5ce4-491e-8851-5057402646fc" />

After:
<img width="231" alt="Screenshot 2025-02-09 at 10 06 59 PM" src="https://github.com/user-attachments/assets/b37d2a9b-8eb6-4faa-8d84-7f9465a58119" />
