### PR TITLE
Don't return early if one wishlist can't be fetched

### DIFF
--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -9,7 +9,7 @@ import { ThunkResult } from 'app/store/types';
 import { errorMessage } from 'app/utils/errors';
 import { errorLog, infoLog } from 'app/utils/log';
 import { once } from 'es-toolkit';
-import { loadWishLists, touchWishLists } from './actions';
+import { clearWishLists, loadWishLists, touchWishLists } from './actions';
 import type { WishListsState } from './reducer';
 import { wishListsSelector } from './selectors';
 import { WishListAndInfo } from './types';
@@ -39,7 +39,7 @@ export function fetchWishList(newWishlistSource?: string, manualRefresh?: boolea
 
     // a blank source was submitted, indicating an intention to clear the wishlist
     if (newWishlistSource === '' && newWishlistSource !== existingWishListSource) {
-      dispatch(setSettingAction('wishListSource', newWishlistSource));
+      dispatch(clearWishLists());
       return;
     }
 

--- a/src/app/wishlists/wishlist-fetch.ts
+++ b/src/app/wishlists/wishlist-fetch.ts
@@ -93,7 +93,6 @@ export function fetchWishList(newWishlistSource?: string, manualRefresh?: boolea
           body: t('WishListRoll.ImportError', { url, error: errorMessage(result.reason) }),
         });
         errorLog(TAG, 'Unable to load wish list', url, result.reason);
-        return;
       } else if (result.status === 'fulfilled') {
         hasSuccess = true;
         wishLists.push([url, result.value]);


### PR DESCRIPTION
This may fix some cases where you can't delete a wishlist because another wishlist is missing.