### PR TITLE
Don't show "1x" next to single mods/fragments in stat tooltip

### DIFF
--- a/src/app/store-stats/StatTooltip.tsx
+++ b/src/app/store-stats/StatTooltip.tsx
@@ -49,6 +49,8 @@ export default function StatTooltip({
                 <span>
                   {contribution.source !== 'armorStats' &&
                     contribution.source !== 'subclassPlug' &&
+                    contribution.count !== undefined &&
+                    contribution.count > 1 &&
                     `${contribution.count}x`}
                 </span>
                 <span>


### PR DESCRIPTION
It just seems unnecessary until you hit a stack of 2 or more.