### PR TITLE
New color scale for compare

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -378,7 +378,10 @@ function getAllStats(comparisonItems: DimItem[], compareBaseStats: boolean): Sta
   for (const item of comparisonItems) {
     if (item.stats) {
       for (const stat of item.stats) {
-        const val = (compareBaseStats ? (stat.base ?? stat.value) : stat.value) || 0;
+        let val = (compareBaseStats ? (stat.base ?? stat.value) : stat.value) || 0;
+        if (stat.statHash === StatHashes.RecoilDirection) {
+          val = recoilValue(val);
+        }
         let statInfo = statsByHash[stat.statHash];
         if (statInfo) {
           statInfo.min = Math.min(statInfo.min, val);

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -76,10 +76,10 @@ function statRange(
     return -1;
   }
 
-  const statValue = (compareBaseStats ? stat.base : stat.value) ?? stat.value;
+  let statValue = (compareBaseStats ? stat.base : stat.value) ?? stat.value;
 
   if (statInfo.stat.statHash === StatHashes.RecoilDirection) {
-    return recoilValue(statValue);
+    statValue = recoilValue(statValue);
   }
 
   if (statInfo.stat.smallerIsBetter) {

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -2,7 +2,7 @@ import AnimatedNumber from 'app/dim-ui/AnimatedNumber';
 import { EnergyCostIcon } from 'app/dim-ui/ElementIcon';
 import { t } from 'app/i18next-t';
 import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
-import { getColor, percent } from 'app/shell/formatters';
+import { getCompareColor, percent } from 'app/shell/formatters';
 import { StatHashes } from 'data/d2/generated-enums';
 import { D1Stat, DimItem, DimStat } from '../inventory/item-types';
 import { MinimalStat, StatInfo } from './Compare';
@@ -22,14 +22,18 @@ export default function CompareStat({
   const { stat, getStat } = statInfo;
   const itemStat = getStat(item);
 
-  const color = getColor(statRange(itemStat, statInfo, compareBaseStats), 'color');
+  const color = getCompareColor(statRange(itemStat, statInfo, compareBaseStats));
 
   const statValue = itemStat
     ? ((compareBaseStats ? itemStat.base : itemStat.value) ?? itemStat.value)
     : 0;
 
   return (
-    <div onPointerEnter={() => setHighlight(stat.statHash)} className={styles.stat} style={color}>
+    <div
+      onPointerEnter={() => setHighlight(stat.statHash)}
+      className={styles.stat}
+      style={{ color }}
+    >
       {statValue !== 0 && stat.bar && item.bucket.sort === 'Armor' && (
         <span className={styles.bar}>
           <span style={{ width: percent(statValue / stat.maximumValue) }} />

--- a/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
+++ b/src/app/destiny1/loadout-builder/D1LoadoutBuilder.tsx
@@ -7,7 +7,7 @@ import { useLoadStores } from 'app/inventory/store/hooks';
 import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { useD1Definitions } from 'app/manifest/selectors';
 import { D1_StatHashes, D1BucketHashes } from 'app/search/d1-known-values';
-import { getColor } from 'app/shell/formatters';
+import { getD1QualityColor } from 'app/shell/formatters';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { uniqBy } from 'app/utils/collections';
 import { compareBy, reverseComparator } from 'app/utils/comparators';
@@ -612,7 +612,7 @@ export default function D1LoadoutBuilder({ account }: { account: DestinyAccount 
                       {item.stats?.map((stat) => (
                         <div
                           key={stat.statHash}
-                          style={getColor(
+                          style={getD1QualityColor(
                             item.normalStats![stat.statHash].qualityPercentage,
                             'color',
                           )}

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -1,5 +1,5 @@
 import { TOTAL_STAT_HASH } from 'app/search/d2-known-values';
-import { getColor } from 'app/shell/formatters';
+import { getD1QualityColor } from 'app/shell/formatters';
 import { enhancedIcon, shapedIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { isD1Item } from 'app/utils/item-utils';
@@ -93,7 +93,10 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
       })}
     >
       {isD1Item(item) && item.quality && (
-        <div className={styles.quality} style={getColor(item.quality.min, 'backgroundColor')}>
+        <div
+          className={styles.quality}
+          style={getD1QualityColor(item.quality.min, 'backgroundColor')}
+        >
           {item.quality.min}%
         </div>
       )}

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -8,7 +8,7 @@ import { I18nKey, t, tl } from 'app/i18next-t';
 import { D1Item, D1Stat, DimItem, DimSocket, DimStat } from 'app/inventory/item-types';
 import { statsMs } from 'app/inventory/store/stats';
 import { TOTAL_STAT_HASH, armorStats, statfulOrnaments } from 'app/search/d2-known-values';
-import { getColor, percent } from 'app/shell/formatters';
+import { getD1QualityColor, percent } from 'app/shell/formatters';
 import { AppIcon, helpIcon } from 'app/shell/icons';
 import { userGuideUrl } from 'app/shell/links';
 import { sumBy } from 'app/utils/collections';
@@ -172,7 +172,10 @@ export default function ItemStat({ stat, item }: { stat: DimStat; item?: DimItem
         isD1Stat(item, stat) &&
         stat.qualityPercentage &&
         stat.qualityPercentage.min !== 0 && (
-          <div className={styles.quality} style={getColor(stat.qualityPercentage.min, 'color')}>
+          <div
+            className={styles.quality}
+            style={getD1QualityColor(stat.qualityPercentage.min, 'color')}
+          >
             ({stat.qualityPercentage.range})
           </div>
         )}
@@ -357,7 +360,7 @@ export function D1QualitySummaryStat({ item }: { item: D1Item }) {
   return (
     <>
       <div className={styles.statName}>{t('Stats.Quality')}</div>
-      <div className={styles.qualitySummary} style={getColor(item.quality.min, 'color')}>
+      <div className={styles.qualitySummary} style={getD1QualityColor(item.quality.min, 'color')}>
         {t('Stats.OfMaxRoll', { range: item.quality.range })}
         <ExternalLink
           href={userGuideUrl('View-how-good-the-stat-(Int-Dis-Str)-roll-on-your-armor-is')}

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -29,7 +29,7 @@ import { breakerTypeNames, weaponMasterworkY2SocketTypeHash } from 'app/search/d
 import D2Sources from 'app/search/items/search-filters/d2-sources';
 import { quoteFilterString } from 'app/search/query-parser';
 import { statHashByName } from 'app/search/search-filter-values';
-import { getColor, percent } from 'app/shell/formatters';
+import { getD1QualityColor, percent } from 'app/shell/formatters';
 import {
   AppIcon,
   lockIcon,
@@ -276,7 +276,9 @@ export function getColumns(
               cell: (value: number, item: D1Item) => {
                 const stat = item.stats?.find((s) => s.statHash === statHash);
                 return (
-                  <span style={getColor(stat?.qualityPercentage?.min || 0, 'color')}>{value}%</span>
+                  <span style={getD1QualityColor(stat?.qualityPercentage?.min || 0, 'color')}>
+                    {value}%
+                  </span>
                 );
               },
               csv: (_value, item) => {
@@ -690,7 +692,7 @@ export function getColumns(
         header: t('Organizer.Columns.Quality'),
         csv: '% Quality',
         value: (item) => (isD1Item(item) && item.quality ? item.quality.min : 0),
-        cell: (value) => <span style={getColor(value, 'color')}>{value}%</span>,
+        cell: (value) => <span style={getD1QualityColor(value, 'color')}>{value}%</span>,
         filter: (value) => `quality:>=${value}`,
       }),
     ...(destinyVersion === 2 && isArmor ? customStats : []),

--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -13,9 +13,10 @@ export function percentWithSingleDecimal(val: number): string {
 }
 
 /**
- * Given a value on (or outside) a 0-100 scale, returns a css color key and value for a react `style` attribute
+ * Given a value on (or outside) a 0-100 scale, returns a css color value. This
+ * is used when comparing item stats.
  */
-export function getColor(value: number, property = 'background-color') {
+export function getCompareColor(value: number) {
   let color = '';
   if (value < 0) {
     color = '#e0e0e0';
@@ -29,7 +30,30 @@ export function getColor(value: number, property = 'background-color') {
     color = 'oklch(82.08% 0.1561 215.44)';
   }
 
+  return color;
+}
+
+/**
+ * Given a value on (or outside) a 0-100 scale, returns a css color key and
+ * value for a react `style` attribute. This is the color scale DIM used for a
+ * long time, and it's preserved here for D1 reasons.
+ */
+export function getD1QualityColor(value: number, property = 'background-color') {
+  let color = 0;
+  if (value < 0) {
+    return { [property]: 'white' };
+  } else if (value <= 85) {
+    color = 0;
+  } else if (value <= 90) {
+    color = 20;
+  } else if (value <= 95) {
+    color = 60;
+  } else if (value < 100) {
+    color = 120;
+  } else if (value >= 100) {
+    color = 190;
+  }
   return {
-    [property]: color,
+    [property]: `hsla(${color},65%,50%, 1)`,
   };
 }

--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -16,21 +16,19 @@ export function percentWithSingleDecimal(val: number): string {
  * Given a value on (or outside) a 0-100 scale, returns a css color key and value for a react `style` attribute
  */
 export function getColor(value: number, property = 'background-color') {
-  let color = 0;
+  const hueGood = [75.48, 0.2381, 142.76];
+  const hueBad = [56.45, 0.2009, 26.56];
   if (value < 0) {
     return { [property]: 'white' };
-  } else if (value <= 85) {
-    color = 0;
-  } else if (value <= 90) {
-    color = 20;
-  } else if (value <= 95) {
-    color = 60;
-  } else if (value < 100) {
-    color = 120;
   } else if (value >= 100) {
-    color = 190;
+    return {
+      [property]: `hsl(190,65%,50%)`,
+    };
   }
+
+  const result = hueGood.map((_, i) => (hueGood[i] - hueBad[i]) * (value / 100) + hueBad[i]);
+
   return {
-    [property]: `hsla(${color},65%,50%, 1)`,
+    [property]: `oklch(${Math.min(result[0], 100)}% ${result[1]} ${result[2]})`,
   };
 }

--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -16,19 +16,20 @@ export function percentWithSingleDecimal(val: number): string {
  * Given a value on (or outside) a 0-100 scale, returns a css color key and value for a react `style` attribute
  */
 export function getColor(value: number, property = 'background-color') {
-  const hueGood = [75.48, 0.2381, 142.76];
-  const hueBad = [56.45, 0.2009, 26.56];
+  let color = '';
   if (value < 0) {
-    return { [property]: 'white' };
+    color = '#e0e0e0';
+  } else if (value < 50) {
+    color = 'hsl(0, 45.20%, 50.60%)';
+  } else if (value < 80) {
+    color = 'hsl(49, 58.60%, 56.50%)';
+  } else if (value < 100) {
+    color = 'hsl(120, 54.70%, 60.20%)';
   } else if (value >= 100) {
-    return {
-      [property]: `hsl(190,65%,50%)`,
-    };
+    color = 'oklch(82.08% 0.1561 215.44)';
   }
 
-  const result = hueGood.map((_, i) => (hueGood[i] - hueBad[i]) * (value / 100) + hueBad[i]);
-
   return {
-    [property]: `oklch(${Math.min(result[0], 100)}% ${result[1]} ${result[2]})`,
+    [property]: color,
   };
 }


### PR DESCRIPTION
This changes the color scale for Compare with the goal of making it easier to identify stats that are on the better side of the scale. I tried to maintain the same visual impact of the colors, with a few changes - the red is less saturated, while the blue "best stat" color is more saturated. This ends up with fewer overall color steps, but more distributed. The old one was 85%, 95%, 99%, 100%, while the new one is 50%, 80%, 99%, 100%. I also knocked down the "white" to match the normal DIM text color.

I also tweaked the display for recoil - it now compares the range of recoil deviation values, instead of the raw recoil stat, which should make it easier to visually compare them from "good" to "bad".

Before:
<img width="990" alt="Screenshot 2025-02-17 at 3 02 32 PM" src="https://github.com/user-attachments/assets/c0fc5b5b-90f1-4db2-8b79-34f883eb0145" />
After:
<img width="981" alt="Screenshot 2025-02-17 at 3 02 16 PM" src="https://github.com/user-attachments/assets/9a110017-de7a-4ea4-8663-c875cb5cee70" />
Before:
<img width="1463" alt="Screenshot 2025-02-17 at 3 03 26 PM" src="https://github.com/user-attachments/assets/73a8b23b-0fd8-4b15-a07f-ff06843a051b" />
After:
<img width="1459" alt="Screenshot 2025-02-17 at 3 03 20 PM" src="https://github.com/user-attachments/assets/c4c00474-9dc3-404d-b474-c814add6d8c3" />
