### PR TITLE
Fix: harmonizable only if pattern incomplete

### DIFF
--- a/src/app/search/items/search-filters/known-values.ts
+++ b/src/app/search/items/search-filters/known-values.ts
@@ -375,9 +375,7 @@ const knownValuesFilters: ItemFilterDefinition[] = [
     keywords: ['patternunlocked'],
     description: tl('Filter.PatternUnlocked'),
     destinyVersion: 2,
-    filter: () => (item) =>
-      item.patternUnlockRecord &&
-      !(item.patternUnlockRecord.state & DestinyRecordState.ObjectiveNotCompleted),
+    filter: () => patternIsUnlocked,
   },
   {
     keywords: 'source',
@@ -405,9 +403,16 @@ const knownValuesFilters: ItemFilterDefinition[] = [
     destinyVersion: 2,
     filter: () => {
       const outputValues = Object.values(focusingOutputs);
-      return (item) => outputValues.includes(item.hash);
+      return (item: DimItem) => outputValues.includes(item.hash);
     },
   },
 ];
+
+export function patternIsUnlocked(item: DimItem) {
+  return (
+    item.patternUnlockRecord &&
+    !(item.patternUnlockRecord.state & DestinyRecordState.ObjectiveNotCompleted)
+  );
+}
 
 export default knownValuesFilters;

--- a/src/app/search/items/search-filters/known-values.ts
+++ b/src/app/search/items/search-filters/known-values.ts
@@ -403,7 +403,7 @@ const knownValuesFilters: ItemFilterDefinition[] = [
     destinyVersion: 2,
     filter: () => {
       const outputValues = Object.values(focusingOutputs);
-      return (item: DimItem) => outputValues.includes(item.hash);
+      return (item) => outputValues.includes(item.hash);
     },
   },
 ];

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -241,14 +241,16 @@ const socketFilters: ItemFilterDefinition[] = [
       (item) =>
         !patternIsUnlocked(item) &&
         (filterValue === 'harmonizable'
-          ? Boolean(
+          ? // is:harmonizable checks for an "insert harmonizer" socket
+            Boolean(
               item.sockets?.allSockets.some(
                 (s) =>
                   s.plugged?.plugDef.plug.plugCategoryHash ===
                     PlugCategoryHashes.CraftingPlugsWeaponsModsExtractors && s.visibleInGame,
               ),
             )
-          : Boolean(
+          : // is:extractable checks for red-borderness
+            Boolean(
               item.deepsightInfo &&
                 item.patternUnlockRecord &&
                 item.patternUnlockRecord.state & DestinyRecordState.ObjectiveNotCompleted,

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -31,6 +31,7 @@ import {
 } from 'data/d2/generated-enums';
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { ItemFilterDefinition } from '../item-filter-types';
+import { patternIsUnlocked } from './known-values';
 
 export const modslotFilter = {
   keywords: 'modslot',
@@ -238,7 +239,8 @@ const socketFilters: ItemFilterDefinition[] = [
     filter:
       ({ filterValue }) =>
       (item) =>
-        filterValue === 'harmonizable'
+        !patternIsUnlocked(item) &&
+        (filterValue === 'harmonizable'
           ? Boolean(
               item.sockets?.allSockets.some(
                 (s) =>
@@ -250,7 +252,7 @@ const socketFilters: ItemFilterDefinition[] = [
               item.deepsightInfo &&
                 item.patternUnlockRecord &&
                 item.patternUnlockRecord.state & DestinyRecordState.ObjectiveNotCompleted,
-            ),
+            )),
   },
   {
     keywords: 'memento',


### PR DESCRIPTION
A Bungie bug is showing a harmonizer socket on items with completed patterns.