### PR TITLE
Fix: Bigger Enhanced item icon

### DIFF
--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -38,6 +38,10 @@
   height: calc((8 / 50) * var(--item-size));
   margin-right: auto;
   color: var(--theme-item-shaped-icon);
+  &.enhancedIcon {
+    width: calc((10 / 50) * var(--item-size));
+    height: calc((10 / 50) * var(--item-size));
+  }
 }
 
 .quality {

--- a/src/app/inventory/BadgeInfo.m.scss.d.ts
+++ b/src/app/inventory/BadgeInfo.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'deepsight': string;
   'energyCapacity': string;
   'engram': string;
+  'enhancedIcon': string;
   'fixContrast': string;
   'fullstack': string;
   'masterwork': string;

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -75,7 +75,7 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
   const wishlistRollIcon = toUiWishListRoll(wishlistRoll);
   const summaryIcon = item.crafted ? (
     <AppIcon
-      className={styles.shapedIcon}
+      className={clsx(styles.shapedIcon, item.crafted === 'enhanced' && styles.enhancedIcon)}
       icon={item.crafted === 'enhanced' ? enhancedIcon : shapedIcon}
     />
   ) : (


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/35cbf388-d41d-4af9-82bc-aeeb276d66a3)

The "Enhanced" icon is really small. This brings the enhanced:crafted ratio closer to the game.