### PR TITLE
Fix a bug where the auto-expanding list of items wouldn't expand if the screen is tall

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fixed a bug where the Organizer wouldn't show all the items if your screen was very tall or zoomed out.
+
 ## 8.62.0 <span class="changelog-date">(2025-03-09)</span>
 
 ## 8.61.0 <span class="changelog-date">(2025-03-02)</span>

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -537,7 +537,7 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
           </React.Fragment>
         ))}
       </div>
-      {rows.length > maxItems && <ItemListExpander onExpand={expandItems} />}
+      {rows.length > maxItems && <ItemListExpander numItems={maxItems} onExpand={expandItems} />}
     </>
   );
 }
@@ -630,7 +630,7 @@ function columnSetting(itemType: 'weapon' | 'armor' | 'ghost') {
   }
 }
 
-function ItemListExpander({ onExpand }: { onExpand: () => void }) {
+function ItemListExpander({ onExpand, numItems }: { onExpand: () => void; numItems: number }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -655,8 +655,18 @@ function ItemListExpander({ onExpand }: { onExpand: () => void }) {
     );
 
     observer.observe(elem);
+
     return () => observer.unobserve(elem);
-  }, [onExpand]);
+  }, [
+    onExpand,
+    // This is a hack to fix the case where:
+    // 1. The expander is on screen when the component renders.
+    // 2. After adding more items, it's still on screen. Since the observer only
+    //    runs if the item is initially onscreen, or enters the screen, there
+    //    are no changes. So we'll just reconstruct the observer every time to
+    //    allow it to re-fire if it's still on the screen.
+    numItems,
+  ]);
 
   return <div ref={ref} />;
 }


### PR DESCRIPTION
The comment explains it - basically the element that triggers expanding the list was still on the screen after expanding from 20->40, so it didn't trigger again.

As a reminder, this auto-expanding list strategy allows us to have the "all weapons" and "all armor" views that would otherwise render too many elements for the browser to handle.