### PR TITLE
Fix: Distinguish Classic theme settings sections

### DIFF
--- a/src/app/settings/SettingsPage.m.scss
+++ b/src/app/settings/SettingsPage.m.scss
@@ -56,7 +56,7 @@
   composes: flexColumn from '../dim-ui/common.m.scss';
   gap: 8px;
   padding: 8px;
-  background-color: var(--theme-search-bg);
+  background-color: var(--theme-section-bg);
 
   @include phone-portrait {
     margin-left: -10px;

--- a/src/app/themes/_theme-classic.scss
+++ b/src/app/themes/_theme-classic.scss
@@ -2,6 +2,8 @@
 .theme-classic {
   // App
   --theme-app-bg: #313233;
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: #222;
 
   // App background gradient pattern
   --theme-app-bg-gradient: var(--theme-app-bg);
@@ -17,5 +19,6 @@
   --theme-organizer-row-odd-bg: var(--theme-app-bg);
   --theme-organizer-row-even-bg: #252627;
 
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: var(--theme-app-bg);
 }

--- a/src/app/themes/_theme-dimdark.scss
+++ b/src/app/themes/_theme-dimdark.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #1e222a;
 
@@ -54,6 +56,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(0, 0, 0, 0.4);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
 

--- a/src/app/themes/_theme-europa.scss
+++ b/src/app/themes/_theme-europa.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #1d2b5e;
   --theme-mobile-background: #1d2b5e;
@@ -55,6 +57,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(255, 255, 255, 0.15);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);

--- a/src/app/themes/_theme-neomuna.scss
+++ b/src/app/themes/_theme-neomuna.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #0b2432;
   --theme-mobile-background: #0b2432;
@@ -55,6 +57,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(255, 255, 255, 0.15);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);

--- a/src/app/themes/_theme-pyramid.scss
+++ b/src/app/themes/_theme-pyramid.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #000;
 
@@ -54,6 +56,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(255, 255, 255, 0.15);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);

--- a/src/app/themes/_theme-throneworld.scss
+++ b/src/app/themes/_theme-throneworld.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #1b422c;
   --theme-mobile-background: #1b422c;
@@ -55,6 +57,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(0, 0, 0, 0.4);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);

--- a/src/app/themes/_theme-vexnet.scss
+++ b/src/app/themes/_theme-vexnet.scss
@@ -41,6 +41,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #0d2f63;
   --theme-mobile-background: #0d2f63;
@@ -55,6 +57,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(255, 255, 255, 0.15);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: rgba(255, 255, 255, 0.2);

--- a/src/app/themes/_theme.scss
+++ b/src/app/themes/_theme.scss
@@ -43,6 +43,8 @@
 
   // App
   --theme-app-bg: var(--theme-app-bg-gradient);
+  // Background color for (currently only) Settings page sections. Distinguishes them from theme-app-bg.
+  --theme-section-bg: var(--theme-search-bg);
   // The color of PWA elements like the title bar. This cannot be a gradient.
   --theme-pwa-background: #202034;
   --theme-mobile-background: #000;
@@ -57,6 +59,7 @@
   --theme-dropdown-menu-bg: var(--theme-fill-modal);
 
   // Search
+  // Background color for the search bar. Distinguishes it from theme-header-nav-bg.
   --theme-search-bg: rgba(0, 0, 0, 0.4);
   --theme-search-dropdown-bg: var(--theme-fill-modal-actions);
   --theme-search-dropdown-border: transparent;


### PR DESCRIPTION
Classic Settings page lost section styling, maybe in the conversion to themes.

Before
![image](https://github.com/user-attachments/assets/1eadd67d-2c40-4fa4-a35f-652684374c24)


After
![image](https://github.com/user-attachments/assets/1acd04e3-5e4b-4187-beb7-34e0c416852a)
