### PR TITLE
Fix Chrome Android not resetting --viewport-bottom-offset when the keyboard is hidden

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Fix a bug in Chrome for Android 134 and newer where the space reserved for the virtual keyboard would not be reclaimed after the keyboard is dismissed.
+
 ## 8.63.0 <span class="changelog-date">(2025-03-16)</span>
 
 * Fixed a bug where the Organizer wouldn't show all the items if your screen was very tall or zoomed out.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,3 +108,16 @@ Check out the [docs]() folder for more tips.
 * We use [i18next](https://github.com/i18next/i18next) for all our translated strings, so if you want to translate something that's currently English-only, take a look at that. Usually it's as simple as replacing some text with `<span>{t('KEY')}</span>` and then defining KEY in the `config\i18n.json` file.
 
 * `pnpm i18n` will add, sort, and prune `src/locale/en.json`. You should never manually edit `src/locale/en.json`. Some keys are obfuscated by code and will need to be added as comments into the code such as `// t('LoadoutBuilder.ObfuscatedKey1')`. If you have any questions, ping @delphiactual via GitHub, Slack, or Discord.
+
+### Android Debugging
+
+Assuming you have an Android phone:
+
+1. Enable Developer Mode
+2. Enable USB debugging
+3. In Chrome, visit chrome://inspect/#devices and connect to the device.
+4. Enable port forwarding for port 8080.
+5. Visit https://localhost:8080/developer on your laptop and copy the "Open this link in another browser" link address.
+6. Back in the inspect devices screen, paste that URL into the "Open tab with URL" box to open it on your Android device.
+7. Save the API keys on the Android device and log in as normal.
+8. Back in the inspect devices screen, click "inspect" under the tab you want to debug.

--- a/src/app/css-variables.ts
+++ b/src/app/css-variables.ts
@@ -76,7 +76,10 @@ export function setCssVariableEventListeners() {
        * viewport to change. As a result, we only apply the following CSS Variable if the
        * viewport size change is large enough (such as when the keyboard opens).
        */
-      const bottomOffset = window.innerHeight - (viewportHeight + Math.round(viewport.offsetTop));
+      const bottomOffset = Math.max(
+        0,
+        window.innerHeight - (viewportHeight + Math.round(viewport.offsetTop)),
+      );
 
       // bottomOffset === 0 means the visual viewport has been reset to its initial size
       if (bottomOffset === 0 || bottomOffset >= KEYBOARD_THRESHOLD) {


### PR DESCRIPTION
Turns out some of the screen sizes are now non-whole-pixel amounts and that caused a rounding error that resulted in a negative number.