### PR TITLE
Try to prevent cases where we might use the wrong inventory

### DIFF
--- a/src/app/inventory/actions.ts
+++ b/src/app/inventory/actions.ts
@@ -26,6 +26,7 @@ import { ItemCreationContext } from './store/d2-item-factory';
 export const update = createAction('inventory/UPDATE')<{
   stores: DimStore[];
   currencies: AccountCurrency[];
+  responseMintedTimestamp?: string;
 }>();
 
 /**

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -121,6 +121,7 @@ export function loadStores({
     try {
       let stores: DimStore[] | undefined;
       if (loading) {
+        infoLog(TAG, 'Already loading stores, skipping this load');
         return;
       }
       await navigator.locks.request(
@@ -421,7 +422,13 @@ function loadStoresData(
               if (live && Date.now() - profileMintedDate.getTime() < FRESH_ENOUGH_TO_CLEAN_INFOS) {
                 dispatch(cleanInfos(stores));
               }
-              dispatch(update({ stores, currencies }));
+              dispatch(
+                update({
+                  stores,
+                  currencies,
+                  responseMintedTimestamp: profileResponse.responseMintedTimestamp,
+                }),
+              );
               dispatch(inGameLoadoutLoaded(loadouts));
 
               stopStateTimer();

--- a/src/app/inventory/reducer.ts
+++ b/src/app/inventory/reducer.ts
@@ -66,6 +66,18 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
 ): InventoryState => {
   switch (action.type) {
     case getType(actions.profileLoaded):
+      if (
+        action.payload.profile.responseMintedTimestamp <=
+        (state.profileResponse?.responseMintedTimestamp ?? 0)
+      ) {
+        warnLog(
+          'd2-stores',
+          'Not updating profile, it is older than what we already have',
+          action.payload.profile.responseMintedTimestamp,
+          state.profileResponse?.responseMintedTimestamp,
+        );
+        return state;
+      }
       return {
         ...state,
         profileResponse: action.payload.profile,
@@ -76,6 +88,17 @@ export const inventory: Reducer<InventoryState, InventoryAction | AccountsAction
       return { ...state, profileError: action.payload };
 
     case getType(actions.update):
+      if (
+        action.payload.responseMintedTimestamp !== state.profileResponse?.responseMintedTimestamp
+      ) {
+        warnLog(
+          'd2-stores',
+          'Not updating inventory - the profile has changed from under us',
+          action.payload.responseMintedTimestamp,
+          state.profileResponse?.responseMintedTimestamp,
+        );
+        return state;
+      }
       return updateInventory(state, action.payload);
 
     case getType(actions.charactersUpdated):


### PR DESCRIPTION
I still haven't found any evidence that this is happening, but this code should prevent a case where we write an inventory that's computed from not-the-latest profile data. Folks who are more active in the game than me should run with the console open and see if this helps.