### PR TITLE
Prevent parent sheet from receiving drag events while child sheet is up

### DIFF
--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -266,7 +266,7 @@ export default function Sheet({
       dragListener={false}
       dragConstraints={dragConstraints}
       dragElastic={0}
-      onDragEnd={handleDragEnd}
+      onDragEnd={disabled ? undefined : handleDragEnd}
       // regular props
       style={{ zIndex }}
       className={clsx(styles.sheet, sheetClassName, { [styles.sheetDisabled]: disabled })}
@@ -288,7 +288,7 @@ export default function Sheet({
         <AppIcon icon={disabledIcon} />
       </button>
 
-      <div className={styles.container} onPointerDown={dragHandleDown}>
+      <div className={styles.container} onPointerDown={disabled ? undefined : dragHandleDown}>
         {Boolean(header) && (
           <div className={clsx(styles.header, headerClassName)}>
             {typeof header === 'function' ? header({ onClose: triggerClose }) : header}

--- a/src/app/dim-ui/Sheet.tsx
+++ b/src/app/dim-ui/Sheet.tsx
@@ -46,6 +46,7 @@ export type SheetContent = React.ReactNode | ((args: { onClose: () => void }) =>
 // The sheet is dismissed if it's flicked at a velocity above dismissVelocity,
 // or dragged down more than dismissAmount times the height of the sheet.
 const dismissVelocity = 120; // px/ms
+const dismissByVelocityMinOffset = 16; // px
 const dismissAmount = 0.5;
 
 const spring: Spring = {
@@ -210,9 +211,11 @@ export default function Sheet({
   // drag velocity or if the sheet has been dragged halfway the down from its height.
   const handleDragEnd = useCallback(
     (_event: TouchEvent | MouseEvent | PointerEvent, info: PanInfo) => {
+      const velocity = info.velocity.y / window.devicePixelRatio;
+      const offset = info.offset.y;
       if (
-        info.velocity.y > dismissVelocity ||
-        (sheet.current && info.offset.y > dismissAmount * sheet.current.clientHeight)
+        (velocity > dismissVelocity && offset > dismissByVelocityMinOffset) ||
+        (sheet.current && offset > dismissAmount * sheet.current.clientHeight)
       ) {
         triggerClose();
         return;


### PR DESCRIPTION
Fixes #10417. For some reason the parent sheet was getting drag events even when it was covered by a child sheet, and sometimes it would register really high velocities when you're really going to town on scrolling the sheet contents. 

I also added a minimum offset threshold which should help prevent spurious dismissals, and what I am hoping is not a Chrome-specific bugfix to the velocity calculations (I think they're in device pixels per second, not CSS pixels per secont).

There's a lot of work that still needs to go into the sheet but this should prevent accidentally losing work. 