### PR TITLE
Compare tweaks/follow-ups

### DIFF
--- a/src/app/compare/CompareColumns.m.scss
+++ b/src/app/compare/CompareColumns.m.scss
@@ -7,11 +7,6 @@
   white-space: nowrap;
   overflow: hidden;
 
-  &.initialItem {
-    color: var(--theme-accent-primary);
-    font-weight: bold;
-  }
-
   // Add the magnifying glass icons to items that can be clicked to find them
   &:global(.compare-findable) {
     cursor: pointer;
@@ -34,6 +29,11 @@
       vertical-align: initial;
     }
   }
+}
+
+.initialItem {
+  color: var(--theme-accent-primary);
+  font-weight: bold;
 }
 
 .energy {

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -4,7 +4,7 @@ import { ColumnSort, SortDirection } from 'app/dim-ui/table-columns';
 import { t } from 'app/i18next-t';
 import ItemPopupTrigger from 'app/inventory/ItemPopupTrigger';
 import { moveItemTo } from 'app/inventory/move-item';
-import { currentStoreSelector, notesSelector } from 'app/inventory/selectors';
+import { currentStoreSelector } from 'app/inventory/selectors';
 import ActionButton from 'app/item-actions/ActionButton';
 import { LockActionButton, TagActionButton } from 'app/item-actions/ActionButtons';
 import { useD2Definitions } from 'app/manifest/selectors';
@@ -47,7 +47,6 @@ export default memo(function CompareItem({
 }) {
   const headerRef = useRef<HTMLDivElement>(null);
   useSetCSSVarToHeight(headerRef, '--compare-item-height');
-  const itemNotes = useSelector(notesSelector(item));
   const dispatch = useThunkDispatch();
   const currentStore = useSelector(currentStoreSelector)!;
   const pullItem = useCallback(() => {
@@ -75,15 +74,13 @@ export default memo(function CompareItem({
         <ItemPopupTrigger item={item} noCompare={true}>
           {(ref, onClick) => (
             <div className={styles.itemAside} ref={ref} onClick={onClick}>
-              <PressTip minimal tooltip={itemNotes}>
-                <ConnectedInventoryItem item={item} />
-              </PressTip>
+              <ConnectedInventoryItem item={item} />
             </div>
           )}
         </ItemPopupTrigger>
       </div>
     ),
-    [item, pullItem, remove, itemNotes],
+    [item, pullItem, remove],
   );
 
   const handleRowClick = (row: Row, column: ColumnDefinition) => {

--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -1,13 +1,12 @@
-.recoil svg {
-  margin-left: 5px;
-  vertical-align: middle;
-}
+@use '../variables.scss' as *;
 
 .range {
   font-size: 0.9em;
 }
 
 .stat {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  align-items: center;
   height: 16px;
   margin-right: calc(var(--item-size) + 16px);
   // the goal width is 64px at normal item tile size (50px)
@@ -15,6 +14,16 @@
   // so that this doesn't blow out the overall compare width
   width: calc(50px + 64px + 4px - var(--item-size));
   position: relative;
+  font-variant-numeric: tabular-nums;
+  gap: 5px;
+}
+
+.statValue {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  width: 4ch;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
 }
 
 .bar {
@@ -28,4 +37,13 @@
     background-color: rgba(255, 255, 255, 0.25);
     height: 100%;
   }
+}
+
+.masterwork::before {
+  content: '';
+  display: block;
+  border-radius: 50%;
+  background-color: $stat-masterworked;
+  height: 4px;
+  width: 4px;
 }

--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -20,7 +20,6 @@
 
 .statValue {
   composes: flexRow from '../dim-ui/common.m.scss';
-  width: 4ch;
   align-items: center;
   justify-content: flex-end;
   gap: 3px;
@@ -39,7 +38,7 @@
   }
 }
 
-.masterwork::before {
+.masterwork::after {
   content: '';
   display: block;
   border-radius: 50%;

--- a/src/app/compare/CompareStat.m.scss.d.ts
+++ b/src/app/compare/CompareStat.m.scss.d.ts
@@ -2,9 +2,10 @@
 // Please do not change this file!
 interface CssExports {
   'bar': string;
+  'masterwork': string;
   'range': string;
-  'recoil': string;
   'stat': string;
+  'statValue': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -1,6 +1,7 @@
 import AnimatedNumber from 'app/dim-ui/AnimatedNumber';
 import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { getCompareColor, percent } from 'app/shell/formatters';
+import clsx from 'clsx';
 import { StatHashes } from 'data/d2/generated-enums';
 import { D1Stat, DimItem, DimStat } from '../inventory/item-types';
 import styles from './CompareStat.m.scss';
@@ -18,6 +19,9 @@ export default function CompareStat({
   min: number;
   max: number;
 }) {
+  const isMasterworkStat = Boolean(
+    stat && item.masterworkInfo?.stats?.some((s) => s.isPrimary && s.hash === stat.statHash),
+  );
   const color = getCompareColor(statRange(stat, min, max, value));
 
   return (
@@ -27,14 +31,11 @@ export default function CompareStat({
           <span style={{ width: percent(value / stat.maximumValue) }} />
         </span>
       )}
-      {stat?.statHash === StatHashes.RecoilDirection ? (
-        <span className={styles.recoil}>
-          <span>{value}</span>
-          <RecoilStat value={value} />
-        </span>
-      ) : (
-        <AnimatedNumber value={value} />
-      )}
+      <AnimatedNumber
+        value={value}
+        className={clsx(styles.statValue, { [styles.masterwork]: isMasterworkStat })}
+      />
+      {stat?.statHash === StatHashes.RecoilDirection && <RecoilStat value={value} />}
       {Boolean(value) &&
         stat &&
         'qualityPercentage' in stat &&

--- a/src/app/dim-ui/AnimatedNumber.tsx
+++ b/src/app/dim-ui/AnimatedNumber.tsx
@@ -10,7 +10,13 @@ const spring: Tween = {
 /**
  * A number that animates between values.
  */
-export default function AnimatedNumber({ value }: { value: number }) {
+export default function AnimatedNumber({
+  value,
+  className,
+}: {
+  value: number;
+  className?: string;
+}) {
   const val = useMotionValue(value);
   const transformedVal = useTransform(val, (v) => Math.floor(v));
 
@@ -18,5 +24,5 @@ export default function AnimatedNumber({ value }: { value: number }) {
     animate(val, value, spring);
   }, [val, value]);
 
-  return <motion.span>{transformedVal}</motion.span>;
+  return <motion.span className={className}>{transformedVal}</motion.span>;
 }

--- a/src/app/item-popup/ItemSocketsGeneral.tsx
+++ b/src/app/item-popup/ItemSocketsGeneral.tsx
@@ -44,10 +44,9 @@ export default function ItemSocketsGeneral({
 
   // Only show the first of each style of category when minimal
   const modSocketCategories = (
-    minimal
+    minimal && item.bucket.inArmor
       ? uniqBy(modSocketsByCategory.entries(), ([category]) => category.category.categoryStyle)
-      : // This might not be necessary with iterator-helpers
-        [...modSocketsByCategory.entries()]
+      : [...modSocketsByCategory.entries()]
   )
     .map(
       ([category, sockets]) =>


### PR DESCRIPTION
1. Change to show all sockets for ghosts, ships, etc:
    <img width="1408" alt="Screenshot 2025-04-12 at 7 11 14 PM" src="https://github.com/user-attachments/assets/5d5c8968-8c4a-4d02-a4f3-c03d2fe7ccd0" />
2. Add an orange dot next to the masterwork stat for each item:
	<img width="989" alt="Screenshot 2025-04-12 at 7 06 15 PM" src="https://github.com/user-attachments/assets/89e358ae-9b31-4118-9a05-84da97c75a39" />
3. Fix the initial item losing its orange highlight.
4. Remove the notes poptip that duplicates the Title attribute (fixes #11013)
