### PR TITLE
Correctly log about initial load

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -165,6 +165,12 @@ export function loadStores({
                 infoLog(TAG, 'Fast-follow load live stores from Bungie.net');
               }
             }
+            // The account can be mutated by the first load (lastPlayedDate)
+            account = currentAccountSelector(getState());
+            if (!account) {
+              errorLog(TAG, 'No account after loading stores');
+              return;
+            }
             stores = await dispatch(loadStoresData(account, { firstTime: false, fromOtherTab }));
           } finally {
             loading = false;

--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -158,6 +158,12 @@ export function loadStores({
               infoLog(TAG, 'First time loading stores, only loading from IDB (if available)');
               await dispatch(loadStoresData(account, { firstTime, fromOtherTab }));
               firstTime = false;
+              if (getState().inventory.live) {
+                infoLog(TAG, 'Initial load got live data, skipping fast-follow load');
+                return;
+              } else {
+                infoLog(TAG, 'Fast-follow load live stores from Bungie.net');
+              }
             }
             stores = await dispatch(loadStoresData(account, { firstTime: false, fromOtherTab }));
           } finally {


### PR DESCRIPTION
I already fixed my bug in https://github.com/DestinyItemManager/DIM/commit/33f5cd4624a0c39a10f0fc7f2267cb7bcd800d15, but I still wanted to have this logging around the first load. This does that correctly (I hope).