### PR TITLE
Go to great lengths to get the highlight behind the items

### DIFF
--- a/src/app/compare/Compare.m.scss
+++ b/src/app/compare/Compare.m.scss
@@ -15,14 +15,17 @@
   // each item is a column of cells
   grid-auto-flow: column;
   // the first column is the header
-  grid-template-columns: min-content;
+  grid-template-columns: 0 min-content;
   // the rest are item, then separator, repeated forever
   grid-auto-columns: min-content 1px;
-  gap: 0 4px;
-  // This is necessary - otherwise sticky headers will stop at one screens-width of scrollign
+  // This is necessary - otherwise sticky headers will stop at one screens-width of scrolling
   width: max-content;
   // Always give enough room for the item icon
   min-height: calc(36px + 1lh + var(--item-size) + 8px);
+  > *[role='cell'] {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
 }
 
 // the header and items live in a horizontal scrolling container

--- a/src/app/compare/CompareItem.m.scss
+++ b/src/app/compare/CompareItem.m.scss
@@ -28,20 +28,34 @@
   padding-right: 8px;
   color: var(--theme-accent-secondary);
 }
+.highlighted {
+  background-color: #202020;
+}
+.spacer {
+  composes: header;
+  cursor: default !important;
+}
 
 // The highlight behind each item
 .highlightBar {
-  background-color: rgba(255, 255, 255, 0.125);
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  // Reserve space for always-on scrollbars :-(
-  width: calc(
-    100vw - var(--scrollbar-width) - env(safe-area-inset-left) - env(safe-area-inset-right)
-  );
-  z-index: -1;
-  pointer-events: none;
+  position: relative;
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    // Reserve space for always-on scrollbars :-(
+    width: calc(
+      100vw - var(--scrollbar-width) - env(safe-area-inset-left) - env(safe-area-inset-right)
+    );
+    z-index: -1;
+    pointer-events: none;
+  }
+  &.highlighted::after {
+    background-color: #202020;
+  }
 }
 
 .lastRow {
@@ -57,6 +71,8 @@
   align-items: center;
   justify-content: space-between;
   height: 32px;
+  padding-left: 4px;
+  padding-right: 4px;
   // pull & lock buttons
   > div:nth-child(1),
   > div:nth-child(2) {
@@ -98,7 +114,7 @@
 .itemAside {
   position: absolute;
   padding: 0;
-  right: 4px;
+  right: 8px;
   top: calc(32px + 4px + 1lh);
   cursor: pointer;
 }

--- a/src/app/compare/CompareItem.m.scss.d.ts
+++ b/src/app/compare/CompareItem.m.scss.d.ts
@@ -5,12 +5,14 @@ interface CssExports {
   'header': string;
   'headerContainer': string;
   'highlightBar': string;
+  'highlighted': string;
   'itemActions': string;
   'itemAside': string;
   'lastRow': string;
   'separator': string;
   'sortAsc': string;
   'sortDesc': string;
+  'spacer': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -154,7 +154,16 @@ export function CompareHeaders({
   const isShiftHeld = useShiftHeld();
   return (
     <>
-      <div className={styles.header} />
+      <div key="spacer-1" className={styles.spacer} />
+      {filteredColumns.map((column) => (
+        <div
+          key={`hl-${column.id}`}
+          className={clsx(styles.highlightBar, {
+            [styles.highlighted]: highlight === column.id,
+          })}
+        />
+      ))}
+      <div key="spacer-2" className={styles.spacer} />
       {filteredColumns.map((column, i) => {
         const columnSort = !column.noSort && columnSorts.find((c) => c.columnId === column.id);
         return (
@@ -168,9 +177,13 @@ export function CompareHeaders({
                   ? styles.sortDesc
                   : styles.sortAsc
                 : undefined,
-              i === filteredColumns.length - 1 && styles.lastRow,
+              {
+                [styles.lastRow]: i === filteredColumns.length - 1,
+                [styles.highlighted]: highlight === column.id,
+              },
             )}
             onPointerEnter={() => setHighlight(column.id)}
+            onPointerLeave={() => setHighlight(undefined)}
             onClick={
               column.noSort
                 ? undefined
@@ -189,7 +202,6 @@ export function CompareHeaders({
             {columnSort && (
               <AppIcon icon={columnSort.sort === SortDirection.ASC ? faAngleRight : faAngleLeft} />
             )}
-            {column.id === highlight && <div className={styles.highlightBar} />}
           </div>
         );
       })}


### PR DESCRIPTION
This was really annoying, but in the new grid-based layout my trick for lightweight row highlighting put the highlight over the rows, instead of behind it. I ended up having to make a zero-width column to hold the highlights.