### PR TITLE
Fix: Update shiny filter for Heresy weapons

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -2,7 +2,7 @@ import BungieImage, { bungieBackgroundStyle } from 'app/dim-ui/BungieImage';
 import BucketIcon from 'app/dim-ui/svgs/BucketIcon';
 import { getBucketSvgIcon } from 'app/dim-ui/svgs/itemCategory';
 import { D2ItemTiers, d2MissingIcon, ItemTierName } from 'app/search/d2-known-values';
-import { isShiny } from 'app/utils/item-utils';
+import { braveShiny } from 'app/utils/item-utils';
 import { errorLog } from 'app/utils/log';
 import { isModCostVisible } from 'app/utils/socket-utils';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
@@ -60,7 +60,7 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
   const classifiedPlaceholder =
     item.icon === d2MissingIcon && item.classified && getBucketSvgIcon(item.bucket.hash);
   const itemImageStyles = getItemImageStyles(item, className);
-  const itemIsShiny = isShiny(item);
+  const itemIsShiny = braveShiny(item);
   return (
     <>
       {classifiedPlaceholder ? (

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -19,6 +19,7 @@ import {
   countEnhancedPerks,
   getIntrinsicArmorPerkSocket,
   getSocketsByCategoryHash,
+  getSocketsByType,
   matchesCuratedRoll,
 } from 'app/utils/socket-utils';
 import { StringLookup } from 'app/utils/util-types';
@@ -32,7 +33,6 @@ import {
 } from 'data/d2/generated-enums';
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { ItemFilterDefinition } from '../item-filter-types';
-import D2Sources from './d2-sources';
 
 function hasExtraPerks(item: DimItem) {
   return getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.WeaponPerks_Reusable)
@@ -102,25 +102,24 @@ const socketFilters: ItemFilterDefinition[] = [
     description: tl('Filter.Shiny'),
     destinyVersion: 2,
     filter: () => (i) => {
-      if (braveShiny(i)) {
-        return true;
-      }
-      if (!hasExtraPerks(i)) {
-        return false;
-      }
-
-      for (const src of ['heresy', 'revenant']) {
-        const sourceInfo = D2Sources[src];
-        if (i.name === 'Psychopomp') {
-          console.log(sourceInfo, i.source);
+      if (i.bucket.inWeapons) {
+        // Brave weapons are the original type of shiny
+        if (braveShiny(i)) {
+          return true;
         }
+
+        // There are special Heresy weapons with an extra Origin Trait
+        const plugOptions = getSocketsByType(i, 'origin')[0]?.plugOptions;
         if (
-          (i.source && sourceInfo.sourceHashes?.includes(i.source)) ||
-          sourceInfo.itemHashes?.includes(i.hash)
+          plugOptions &&
+          plugOptions.length === 2 &&
+          plugOptions[0].plugDef.hash === 878237828 && // Willing Vessel
+          plugOptions[1].plugDef.hash === 120721526 // Runneth Over
         ) {
           return true;
         }
       }
+
       return false;
     },
   },

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -1,5 +1,4 @@
 import { tl } from 'app/i18next-t';
-import type { DimItem } from 'app/inventory/item-types';
 import { enhancementSocketHash } from 'app/inventory/store/crafted';
 import {
   DEFAULT_GLOW,
@@ -33,16 +32,6 @@ import {
 } from 'data/d2/generated-enums';
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { ItemFilterDefinition } from '../item-filter-types';
-
-function hasExtraPerks(item: DimItem) {
-  return getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.WeaponPerks_Reusable)
-    .filter(
-      (socket) =>
-        socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames &&
-        socket.hasRandomizedPlugItems,
-    )
-    .some((socket) => socket.plugOptions.length > 1);
-}
 
 export const modslotFilter = {
   keywords: 'modslot',
@@ -132,7 +121,13 @@ const socketFilters: ItemFilterDefinition[] = [
         return false;
       }
 
-      return hasExtraPerks(item);
+      return getSocketsByCategoryHash(item.sockets, SocketCategoryHashes.WeaponPerks_Reusable)
+        .filter(
+          (socket) =>
+            socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames &&
+            socket.hasRandomizedPlugItems,
+        )
+        .some((socket) => socket.plugOptions.length > 1);
     },
   },
   {

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -333,8 +333,8 @@ export function isItemLoadoutCompatible(itemClass: DestinyClass, loadoutClass: D
   return itemClass === DestinyClass.Unknown || itemClass === loadoutClass;
 }
 
-/** "shiny" special-edtion items from Into The Light, with a unique ornament and extra perks */
-export function isShiny(item: DimItem) {
+/** "shiny" items, special-edition items from Into The Light, with a unique ornament and extra perks */
+export function braveShiny(item: DimItem) {
   return item.sockets?.allSockets.some(
     (s) =>
       s.plugOptions.some((s) => s.plugDef.plug.plugCategoryIdentifier === 'holofoil_skins_shared'), //

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -11,6 +11,7 @@ import { isDeepsightResonanceSocket } from 'app/inventory/store/deepsight';
 import {
   GhostActivitySocketTypeHashes,
   armor2PlugCategoryHashes,
+  weaponMasterworkY2SocketTypeHash,
 } from 'app/search/d2-known-values';
 import { DestinySocketCategoryStyle, TierType } from 'bungie-api-ts/destiny2';
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
@@ -320,6 +321,84 @@ export function getDisplayedItemSockets(
   } else {
     return getGeneralSockets(item, excludeEmptySockets);
   }
+}
+
+export function getSocketsByType(
+  item: DimItem,
+  type?: 'all' | 'traits' | 'shaders' | 'origin',
+): DimSocket[] {
+  if (!item.sockets) {
+    return [];
+  }
+
+  let sockets = [];
+  const { modSocketsByCategory, perks } = getDisplayedItemSockets(
+    item,
+    /* excludeEmptySockets */ true,
+  )!;
+
+  if (perks) {
+    sockets.push(...getSocketsByIndexes(item.sockets, perks.socketIndexes));
+  }
+  switch (type) {
+    case 'traits':
+      sockets = sockets.filter(
+        (s) =>
+          s.plugged &&
+          (s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames ||
+            s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics),
+      );
+      break;
+
+    case 'origin':
+      sockets = sockets.filter((s) =>
+        s.plugged?.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.WeaponModsOriginTraits),
+      );
+      break;
+
+    case 'shaders': {
+      sockets.push(...[...modSocketsByCategory.values()].flat());
+      sockets = sockets.filter(
+        (s) =>
+          s.plugged &&
+          (s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Shader ||
+            s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Mementos ||
+            s.plugged.plugDef.plug.plugCategoryIdentifier.includes('skin')),
+      );
+      break;
+    }
+
+    default: {
+      // Improve this when we use iterator-helpers
+      sockets.push(...[...modSocketsByCategory.values()].flat());
+      sockets = sockets.filter(
+        (s) =>
+          !(
+            s.plugged &&
+            (s.plugged?.plugDef.itemCategoryHashes?.includes(
+              ItemCategoryHashes.WeaponModsOriginTraits,
+            ) ||
+              s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Frames ||
+              s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Intrinsics ||
+              s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Shader ||
+              s.plugged.plugDef.plug.plugCategoryHash === PlugCategoryHashes.Mementos ||
+              s.plugged.plugDef.plug.plugCategoryIdentifier.includes('skin'))
+          ),
+      );
+      break;
+    }
+  }
+
+  sockets = sockets.filter(
+    (s) =>
+      // we have a separate column for the kill tracker
+      !isKillTrackerSocket(s) &&
+      // and for the regular weapon masterworks
+      s.socketDefinition.socketTypeHash !== weaponMasterworkY2SocketTypeHash &&
+      // Remove "extra intrinsics" for exotic class items
+      (!item.bucket.inArmor || !(s.isPerk && s.visibleInGame && socketContainsIntrinsicPlug(s))),
+  );
+  return sockets;
 }
 
 export function getWeaponSockets(


### PR DESCRIPTION
Expands is:shiny to find any special Heresy weapons with an additional origin trait, Runneth Over.

This shifts a few functions around. Steals a cool one from organizer and moved it to socket utils.
The main change is just **src/app/search/items/search-filters/sockets.ts L 104**