### PR TITLE
Fix: Select unenhanced perk versions in Armory

### DIFF
--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -2,6 +2,7 @@ import { UNSET_PLUG_HASH } from 'app/loadout/known-values';
 import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { isEmpty } from 'app/utils/collections';
 import { errorLog } from 'app/utils/log';
+import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { produce } from 'immer';
 import { useCallback, useState } from 'react';
 import { DimItem, DimPlug, DimSocket } from '../item-types';
@@ -46,7 +47,9 @@ export function applySocketOverrides(
       let newPlug, actuallyPlugged;
 
       if (s.isPerk) {
-        newPlug = plugOptions.find((p) => p.plugDef.hash === override);
+        newPlug = plugOptions.find(
+          (p) => p.plugDef.hash === override || perkToEnhanced[p.plugDef.hash] === override,
+        );
         actuallyPlugged = plugOptions.find((p) => p.plugDef.hash === s.plugged?.plugDef.hash);
       } else {
         // This is likely a mod selection!


### PR DESCRIPTION
Fixes #10910

DIM doesn't show enhanced perks at all in the Armory for Enhanceable weapons, but they are there in the PlugSet, marked currentlyCanRoll=false (see [https://data.destinysets.com/i/InventoryItem:1762785663/PlugSet:3559076750](https://data.destinysets.com/i/InventoryItem:1762785663/PlugSet:3559076750))

This causes plug overrides to fail, causing the fake item in Armory to have no perks highlighted, causing no perks to be highlighted in visualized Sishlist entries below.

Simple fix here converts selected perks to un-enhanced, so they will match Wishlists and generate a more normal looking Armory entry. Several followup issues should be addressed here: https://github.com/DestinyItemManager/DIM/issues/11040