### PR TITLE
Fix/Feature: Details/Search Triage buttons for ingame loadouts

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -33,7 +33,7 @@ import { usePageTitle } from 'app/utils/hooks';
 import { DestinySeasonDefinition } from 'bungie-api-ts/destiny2';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import styles from './Loadouts.m.scss';
 import LoadoutRow from './LoadoutsRow';
 import { updateLoadoutStore } from './actions';
@@ -128,7 +128,14 @@ function Loadouts({ account }: { account: DestinyAccount }) {
   const [editingInGameLoadout, setEditingInGameLoadout] = useState<InGameLoadout>();
   const handleEditSheetClose = useCallback(() => setEditingInGameLoadout(undefined), []);
 
-  const [viewingInGameLoadout, setViewingInGameLoadout] = useState<InGameLoadout>();
+  const location = useLocation();
+  const locationState = location.state as
+    | {
+        inGameLoadout: InGameLoadout;
+      }
+    | undefined;
+
+  const [viewingInGameLoadout, setViewingInGameLoadout] = useState(locationState?.inGameLoadout);
   const handleViewingSheetClose = useCallback(() => setViewingInGameLoadout(undefined), []);
 
   const [filteredLoadouts, filterPills, hasSelectedFilters] = useLoadoutFilterPills(

--- a/src/app/search/items/search-filters/loadouts.ts
+++ b/src/app/search/items/search-filters/loadouts.ts
@@ -43,6 +43,7 @@ const loadoutFilters: ItemFilterDefinition[] = [
       return (item) =>
         loadoutsByItem[item.id]?.some(
           ({ loadout }) =>
+            loadout.id === filterValue ||
             loadout.name.toLowerCase().includes(filterValue) ||
             (filterValue.startsWith('#') && // short circuit for less load
               !isInGameLoadout(loadout) &&


### PR DESCRIPTION
Fixes https://github.com/DestinyItemManager/DIM/issues/11007

In Triage tab:
- Fixes search filter button for In-Game Loadouts (previously initiated a filter by loadout name, but In-Game Loadouts have dupe/generic names)
  - Now searches by Loadout ID.
  - inloadout filter changed to support Loadout IDs.
- Adds an "edit" button to In-Game Loadouts, like that for DIM Loadouts.
  - This technically leads to Details, not Edit, but Details gives the most options and the Identifier Editor is right there.
  - Adds capability to push selected loadout Details state to Loadouts page. (since In-Game Loadouts are only examinable on Loadouts page)