### PR TITLE
Add warning icon to postmaster items that cannot be pulled by DIM

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Postmaster items now have warning indicator if DIM is not allowed to pull them
+
 ## 8.71.1 <span class="changelog-date">(2025-05-12)</span>
 
 * Fix misaligned stat numbers in Compare box.

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -66,10 +66,7 @@ export default memo(function CompareItem({
           ) : item.owner !== 'unknown' &&
             !item.canPullFromPostmaster &&
             item.location.inPostmaster ? (
-            <PressTip
-              elementType="span"
-              tooltip={t('MovePopup.CantPullFromPostmaster')}
-            >
+            <PressTip elementType="span" tooltip={t('MovePopup.CantPullFromPostmaster')}>
               <ActionButton onClick={noop} disabled>
                 <AppIcon icon={faExclamationTriangle} />
               </ActionButton>

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -12,6 +12,7 @@ import { ColumnDefinition, Row, TableContext } from 'app/organizer/table-types';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { noop } from 'app/utils/functions';
 import { useSetCSSVarToHeight, useShiftHeld } from 'app/utils/hooks';
+import { nonPullablePostmasterItem } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { memo, useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -63,9 +64,7 @@ export default memo(function CompareItem({
         <div className={styles.itemActions}>
           {item.vendor ? (
             <VendorItemWarning item={item} />
-          ) : item.owner !== 'unknown' &&
-            !item.canPullFromPostmaster &&
-            item.location.inPostmaster ? (
+          ) : nonPullablePostmasterItem(item) ? (
             <PressTip elementType="span" tooltip={t('MovePopup.CantPullFromPostmaster')}>
               <ActionButton onClick={noop} disabled>
                 <AppIcon icon={faExclamationTriangle} />

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -23,6 +23,7 @@ import {
   faAngleLeft,
   faAngleRight,
   faArrowCircleDown,
+  faExclamationTriangle,
   shoppingCart,
 } from '../shell/icons';
 import styles from './CompareItem.m.scss';
@@ -62,6 +63,17 @@ export default memo(function CompareItem({
         <div className={styles.itemActions}>
           {item.vendor ? (
             <VendorItemWarning item={item} />
+          ) : item.owner !== 'unknown' &&
+            !item.canPullFromPostmaster &&
+            item.location.inPostmaster ? (
+            <PressTip
+              elementType="span"
+              tooltip={() => <>{t('MovePopup.CantPullFromPostmaster')}</>}
+            >
+              <ActionButton onClick={noop} disabled>
+                <AppIcon icon={faExclamationTriangle} />
+              </ActionButton>
+            </PressTip>
           ) : (
             <ActionButton title={t('Hotkey.Pull')} onClick={pullItem}>
               <AppIcon icon={faArrowCircleDown} />

--- a/src/app/compare/CompareItem.tsx
+++ b/src/app/compare/CompareItem.tsx
@@ -68,7 +68,7 @@ export default memo(function CompareItem({
             item.location.inPostmaster ? (
             <PressTip
               elementType="span"
-              tooltip={() => <>{t('MovePopup.CantPullFromPostmaster')}</>}
+              tooltip={t('MovePopup.CantPullFromPostmaster')}
             >
               <ActionButton onClick={noop} disabled>
                 <AppIcon icon={faExclamationTriangle} />

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -103,7 +103,7 @@
   height: calc(var(--item-size) / 5);
   font-size: calc(var(--item-size) / 5);
   position: absolute;
-  top: $item-border-width + 3px;
+  top: $item-border-width + 2px;
   right: $item-border-width + 3px;
   pointer-events: none;
   filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));

--- a/src/app/inventory/InventoryItem.m.scss
+++ b/src/app/inventory/InventoryItem.m.scss
@@ -96,3 +96,15 @@
   color: #29f36a; // #5eff92;
   filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
 }
+
+.warningIcon {
+  display: block;
+  width: calc(var(--item-size) / 5);
+  height: calc(var(--item-size) / 5);
+  font-size: calc(var(--item-size) / 5);
+  position: absolute;
+  top: $item-border-width + 3px;
+  right: $item-border-width + 3px;
+  pointer-events: none;
+  filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.8));
+}

--- a/src/app/inventory/InventoryItem.m.scss.d.ts
+++ b/src/app/inventory/InventoryItem.m.scss.d.ts
@@ -8,6 +8,7 @@ interface CssExports {
   'subclass': string;
   'subclassBase': string;
   'subclassSuperIcon': string;
+  'warningIcon': string;
   'xpBar': string;
   'xpBarAmount': string;
 }

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -1,5 +1,6 @@
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { percent } from 'app/shell/formatters';
+import { nonPullablePostmasterItem } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
 import React, { useMemo } from 'react';
@@ -118,9 +119,7 @@ export default function InventoryItem({
           </div>
         )}
         (
-        {(item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster && (
-          <AlertIcon className={styles.warningIcon} />
-        )) ||
+        {(nonPullablePostmasterItem(item) && <AlertIcon className={styles.warningIcon} />) ||
           (isNew && <NewItemIndicator />)}
       </>
     );

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -1,3 +1,4 @@
+import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import { percent } from 'app/shell/formatters';
 import clsx from 'clsx';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -116,7 +117,11 @@ export default function InventoryItem({
             {hasNotes && <AppIcon className={styles.icon} icon={stickyNoteIcon} />}
           </div>
         )}
-        {isNew && <NewItemIndicator />}
+        (
+        {(item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster && (
+          <AlertIcon className={styles.warningIcon} />
+        )) ||
+          (isNew && <NewItemIndicator />)}
       </>
     );
   }, [isNew, item, hasNotes, subclassIconInfo, tag, wishlistRoll, autoLockTagged]);

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -11,6 +11,7 @@ import ItemAccessoryButtons from 'app/item-actions/ItemAccessoryButtons';
 import ItemMoveLocations from 'app/item-actions/ItemMoveLocations';
 import type { ItemTierName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { nonPullablePostmasterItem } from 'app/utils/item-utils';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { useMemo, useRef } from 'react';
@@ -89,7 +90,7 @@ export default function ItemPopup({
             </div>
           ),
       )}
-      {item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster && (
+      {nonPullablePostmasterItem(item) && (
         <div className={styles.failureReason}>
           <AlertIcon />
           <RichDestinyText text={t('MovePopup.CantPullFromPostmaster')} ownerId={item.owner} />

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -1,3 +1,4 @@
+import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClickOutside from 'app/dim-ui/ClickOutside';
 import { PressTipRoot } from 'app/dim-ui/PressTip';
 import Sheet from 'app/dim-ui/Sheet';
@@ -76,9 +77,6 @@ export default function ItemPopup({
   );
 
   const failureStrings = Array.from(extraInfo?.failureStrings ?? []);
-  if (item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster) {
-    failureStrings.push(t('MovePopup.CantPullFromPostmaster'));
-  }
 
   const header = (
     <div className={styles.header}>
@@ -90,6 +88,12 @@ export default function ItemPopup({
               <RichDestinyText text={failureString} ownerId={item.owner} />
             </div>
           ),
+      )}
+      {item.owner !== 'unknown' && !item.canPullFromPostmaster && item.location.inPostmaster && (
+        <div className={styles.failureReason}>
+          <AlertIcon />
+          <RichDestinyText text={t('MovePopup.CantPullFromPostmaster')} ownerId={item.owner} />
+        </div>
       )}
       {isPhonePortrait && itemActionsModel.hasAccessoryControls && (
         <div className={styles.mobileItemActions}>

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -163,6 +163,12 @@ export function itemCanBeEquippedByStoreId(
   );
 }
 
+export function nonPullablePostmasterItem(item: DimItem): boolean {
+  return (
+    item.owner !== 'unknown' && !item.canPullFromPostmaster && Boolean(item.location.inPostmaster)
+  );
+}
+
 /** Could this be added to a loadout? */
 export function itemCanBeInLoadout(item: DimItem): boolean {
   return (


### PR DESCRIPTION
Closes #4715 

Adds a yellow warning icon to top right (taking precedence over `isNew` icon) and adds the same icon to the text on the popup itself.

Replaces the "Pull item to active character" button with a warning icon+PressTip in Compare view as well.

Note: some screenshots use surrogate items as I didn't have any that qualified in my postmaster during testing.
<img width="682" alt="Screenshot 2025-04-24 at 6 43 18 PM" src="https://github.com/user-attachments/assets/d38bd267-dbc1-424d-a104-2fd1cbba3a12" />
<img width="240" alt="Screenshot 2025-04-24 at 6 46 48 PM" src="https://github.com/user-attachments/assets/0522448c-3ad4-4e44-b997-af97ab380765" />
<img width="635" alt="Screenshot 2025-04-28 at 2 04 06 PM" src="https://github.com/user-attachments/assets/2778bfba-d1b1-41cc-b9b1-cda54fe5fed4" />
