### PR TITLE
Right-align 2-digit numbers in Compare

### DIFF
--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -23,6 +23,11 @@
   align-items: center;
   justify-content: flex-end;
   gap: 3px;
+  min-width: 2ch; // Try to right-align 2-digit numbers
+
+  &.noMinWidth {
+    min-width: none;
+  }
 }
 
 .bar {

--- a/src/app/compare/CompareStat.m.scss.d.ts
+++ b/src/app/compare/CompareStat.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'bar': string;
   'masterwork': string;
+  'noMinWidth': string;
   'range': string;
   'stat': string;
   'statValue': string;

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -35,7 +35,10 @@ export default function CompareStat({
       )}
       <AnimatedNumber
         value={value}
-        className={clsx(styles.statValue, { [styles.masterwork]: isMasterworkStat })}
+        className={clsx(styles.statValue, {
+          [styles.masterwork]: isMasterworkStat,
+          [styles.noMinWidth]: stat?.statHash === StatHashes.AnyEnergyTypeCost,
+        })}
       />
       {stat?.statHash === StatHashes.RecoilDirection && <RecoilStat value={value} />}
       {Boolean(value) &&


### PR DESCRIPTION
A relatively simple change but I think it makes numbers much easier to compare:

Before:
<img width="1315" alt="Screenshot 2025-04-26 at 5 22 36 PM" src="https://github.com/user-attachments/assets/0d30c541-a623-45de-9de2-45fbe42fd44c" />

After:
<img width="1279" alt="Screenshot 2025-04-26 at 5 22 24 PM" src="https://github.com/user-attachments/assets/a1790e33-3f1e-405a-9de1-4f0414799fd5" />