### PR TITLE
Always show the loading spinner spinning for at least 1 second

### DIFF
--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -79,7 +79,7 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
       icon={item.crafted === 'enhanced' ? enhancedIcon : shapedIcon}
     />
   ) : (
-    wishlistRollIcon && <RatingIcon uiWishListRoll={wishlistRollIcon} />
+    wishlistRollIcon !== undefined && <RatingIcon uiWishListRoll={wishlistRollIcon} />
   );
 
   return (

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -130,7 +130,9 @@ function PlugTooltip({
   const statsArray = stats || [];
   const plugDescriptions = usePlugDescriptions(def, statsArray);
   const sourceString =
-    defs && def.collectibleHash && defs.Collectible.get(def.collectibleHash).sourceString;
+    defs && def.collectibleHash
+      ? defs.Collectible.get(def.collectibleHash).sourceString
+      : undefined;
 
   // filter out hidden objectives
   const filteredPlugObjectives = plugObjectives?.filter(


### PR DESCRIPTION
Even if loading took less time. This makes it feel like people have really clicked the button even if things are loading quickly.