### PR TITLE
Don't show refresh wishlists button or wishlist suggestions when using local wishlist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Removed the "Refresh Wishlist" button and the suggested remote wishlists when using a local wishlist.
+
 ## 8.73.0 <span class="changelog-date">(2025-05-25)</span>
 
 ## 8.72.1 <span class="changelog-date">(2025-05-19)</span>

--- a/src/app/settings/WishListSettings.tsx
+++ b/src/app/settings/WishListSettings.tsx
@@ -117,6 +117,9 @@ export default function WishListSettings() {
     (list) => !activeWishlistUrls.includes(list.url),
   );
 
+  const hasRemoteWishList = activeWishlistUrls.length > 0;
+  const hasLocalWishList = !hasRemoteWishList && wishList.infos.length > 0;
+
   return (
     <section id="wishlist">
       <h2>
@@ -134,9 +137,11 @@ export default function WishListSettings() {
             <button type="button" className="dim-button" onClick={clearWishListEvent}>
               <AppIcon icon={banIcon} /> {t('WishListRoll.Clear')}
             </button>
-            <button type="button" className="dim-button" onClick={handleReloadWishlists}>
-              <AppIcon icon={refreshIcon} /> {t('WishListRoll.Refresh')}
-            </button>
+            {hasRemoteWishList && (
+              <button type="button" className="dim-button" onClick={handleReloadWishlists}>
+                <AppIcon icon={refreshIcon} /> {t('WishListRoll.Refresh')}
+              </button>
+            )}
           </div>
           {wishListLastUpdated && (
             <div className={fineprintClass}>
@@ -149,56 +154,60 @@ export default function WishListSettings() {
         </div>
       )}
 
-      {activeWishlistUrls.map((url) => {
-        const loadedData = wishList.infos.find((info) => info.url === url);
-        const builtinEntry = builtInWishlists.find((list) => list.url === url);
-        if (builtinEntry) {
-          return (
-            <BuiltinWishlist
-              key={url}
-              url={url}
-              name={builtinEntry.name}
-              title={loadedData?.title}
-              description={loadedData?.description}
-              rollsCount={loadedData?.numRolls}
-              dupeRollsCount={loadedData?.dupeRolls}
-              checked={true}
-              onChange={(checked) => changeUrl(url, checked)}
-            />
-          );
-        } else {
-          return (
-            <UrlWishlist
-              key={url}
-              url={url}
-              title={loadedData?.title}
-              description={loadedData?.description}
-              rollsCount={loadedData?.numRolls}
-              dupeRollsCount={loadedData?.dupeRolls}
-              onRemove={() => changeUrl(url, false)}
-            />
-          );
-        }
-      })}
+      {!hasLocalWishList &&
+        activeWishlistUrls.map((url) => {
+          const loadedData = wishList.infos.find((info) => info.url === url);
+          const builtinEntry = builtInWishlists.find((list) => list.url === url);
+          if (builtinEntry) {
+            return (
+              <BuiltinWishlist
+                key={url}
+                url={url}
+                name={builtinEntry.name}
+                title={loadedData?.title}
+                description={loadedData?.description}
+                rollsCount={loadedData?.numRolls}
+                dupeRollsCount={loadedData?.dupeRolls}
+                checked={true}
+                onChange={(checked) => changeUrl(url, checked)}
+              />
+            );
+          } else {
+            return (
+              <UrlWishlist
+                key={url}
+                url={url}
+                title={loadedData?.title}
+                description={loadedData?.description}
+                rollsCount={loadedData?.numRolls}
+                dupeRollsCount={loadedData?.dupeRolls}
+                onRemove={() => changeUrl(url, false)}
+              />
+            );
+          }
+        })}
 
-      {disabledBuiltinLists.map((list) => (
-        <BuiltinWishlist
-          key={list.url}
-          url={list.url}
-          name={list.name}
-          title={undefined}
-          description={undefined}
-          checked={false}
-          rollsCount={undefined}
-          dupeRollsCount={undefined}
-          onChange={(checked) => changeUrl(list.url, checked)}
+      {!hasLocalWishList &&
+        disabledBuiltinLists.map((list) => (
+          <BuiltinWishlist
+            key={list.url}
+            url={list.url}
+            name={list.name}
+            title={undefined}
+            description={undefined}
+            checked={false}
+            rollsCount={undefined}
+            dupeRollsCount={undefined}
+            onChange={(checked) => changeUrl(list.url, checked)}
+          />
+        ))}
+
+      {!hasLocalWishList && (
+        <NewUrlWishlist
+          addWishlistDisabled={addUrlDisabled}
+          onAddWishlist={(url) => changeUrl(url, true)}
         />
-      ))}
-
-      <NewUrlWishlist
-        addWishlistDisabled={addUrlDisabled}
-        onAddWishlist={(url) => changeUrl(url, true)}
-      />
+      )}
 
       <div className={settingClass}>
         <FileUpload onDrop={loadWishList} title={t('WishListRoll.Import')} />


### PR DESCRIPTION
Fixes #10977 by removing controls that either wouldn't do anything (refresh) or would wipe out the local wishlist (load from URL, load suggested). Users can clear their local wishlist to get those back.