### PR TITLE
Use the correct bucket hash for D1 emotes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Next
 
 * Removed the "Refresh Wishlist" button and the suggested remote wishlists when using a local wishlist.
+y
+* D1 inventory now shows emotes, and you can add emotes to D1 loadouts.
 
 ## 8.73.0 <span class="changelog-date">(2025-05-25)</span>
 
@@ -13,7 +15,7 @@
 
 * Postmaster items now have a warning indicator if DIM is not allowed to pull them.
 * Added an "ammo" column, a "perks grid" column, and a "mods" column to the Organizer.
-* Slimmed down column labels for some Organizer columns.
+* Slimmed down column labels for some Organizer columns.as
 
 ## 8.71.1 <span class="changelog-date">(2025-05-12)</span>
 

--- a/src/app/destiny1/d1-bucket-categories.ts
+++ b/src/app/destiny1/d1-bucket-categories.ts
@@ -23,7 +23,7 @@ export const D1Categories: {
     BucketHashes.Modifications,
     BucketHashes.Emblems,
     D1BucketHashes.Shader,
-    BucketHashes.Emotes,
+    D1BucketHashes.D1Emotes,
     BucketHashes.Ships,
     BucketHashes.Vehicle,
     D1BucketHashes.Horn,

--- a/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
+++ b/src/app/destiny1/loadout-drawer/LoadoutDrawerContents.tsx
@@ -41,7 +41,7 @@ const loadoutTypes: (BucketHashes | D1BucketHashes)[] = [
   BucketHashes.Materials,
   BucketHashes.Emblems,
   D1BucketHashes.Shader,
-  BucketHashes.Emotes,
+  D1BucketHashes.D1Emotes,
   BucketHashes.Ships,
   BucketHashes.Vehicle,
   D1BucketHashes.Horn,

--- a/src/app/search/d1-known-values.ts
+++ b/src/app/search/d1-known-values.ts
@@ -49,6 +49,7 @@ export const enum D1BucketHashes {
   Bounties = 2197472680,
   Shader = 2973005342,
   Horn = 3796357825,
+  D1Emotes = 3054419239,
 }
 
 //

--- a/src/app/search/items/search-filters/known-values.ts
+++ b/src/app/search/items/search-filters/known-values.ts
@@ -172,6 +172,7 @@ const d1BucketToType: LookupTable<BucketHashes | D1BucketHashes, string> = {
   [D1BucketHashes.Bounties]: 'bounties',
   [D1BucketHashes.Quests]: 'quests',
   [D1BucketHashes.Missions]: 'missions',
+  [D1BucketHashes.D1Emotes]: 'emotes',
 };
 
 export const itemTypeFilter = {


### PR DESCRIPTION
Not sure if I broke this at some point (replacing hashes with enum names) or if it never worked.

Fixes #11084 