### PR TITLE
Store absolute stat values in StatConstraints instead of stat tiers

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -566,7 +566,7 @@ export default (env: Env) => {
         open: false,
         sources: true,
         gzip: false,
-        brotli: true,
+        brotli: false,
       }),
 
       new CopyWebpackPlugin({

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.6",
     "@beyond-js/md5": "^0.0.1",
-    "@destinyitemmanager/dim-api-types": "^1.35.0",
+    "@destinyitemmanager/dim-api-types": "^1.36.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "@types/prop-types": "^15.7.15",
     "@types/react": "19.1.8",
     "@types/react-beautiful-dnd": "^13.1.8",
-    "@types/react-dnd-multi-backend": "^6.0.6",
     "@types/react-dom": "^19.1.6",
     "@types/ua-parser-js": "^0.7.39",
     "@types/use-subscription": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,9 +241,6 @@ devDependencies:
   '@types/react-beautiful-dnd':
     specifier: ^13.1.8
     version: 13.1.8
-  '@types/react-dnd-multi-backend':
-    specifier: ^6.0.6
-    version: 6.0.6(react-dom@19.1.0)(react@19.1.0)
   '@types/react-dom':
     specifier: ^19.1.6
     version: 19.1.6(@types/react@19.1.8)
@@ -3934,25 +3931,13 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
-  /@react-dnd/asap@4.0.1:
-    resolution: {integrity: sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==}
-    dev: true
-
   /@react-dnd/asap@5.0.2:
     resolution: {integrity: sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==}
     dev: false
 
-  /@react-dnd/invariant@2.0.0:
-    resolution: {integrity: sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==}
-    dev: true
-
   /@react-dnd/invariant@4.0.2:
     resolution: {integrity: sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==}
     dev: false
-
-  /@react-dnd/shallowequal@2.0.0:
-    resolution: {integrity: sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==}
-    dev: true
 
   /@react-dnd/shallowequal@4.0.2:
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
@@ -4963,13 +4948,6 @@ packages:
       '@types/node': 22.0.2
     dev: true
 
-  /@types/hoist-non-react-statics@3.3.6:
-    resolution: {integrity: sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==}
-    dependencies:
-      '@types/react': 19.1.8
-      hoist-non-react-statics: 3.3.2
-    dev: true
-
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
     dev: true
@@ -5064,18 +5042,6 @@ packages:
     resolution: {integrity: sha512-E3TyFsro9pQuK4r8S/OL6G99eq7p8v29sX0PM7oT8Z+PJfZvSQTx4zTQbUJ+QZXioAF0e7TGBEcA1XhYhCweyQ==}
     dependencies:
       '@types/react': 19.1.8
-    dev: true
-
-  /@types/react-dnd-multi-backend@6.0.6(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-rM+AUaejK5I2jUh+q3dE9/B8b5Oae2iMoirgdOAnsEseuBo/89HT8UeNXxwSJVxWndc9quBZYEW7Hcu+JlM0jA==}
-    dependencies:
-      '@types/react': 19.1.8
-      dnd-core: 10.0.2
-      react-dnd: 10.0.2(react-dom@19.1.0)(react@19.1.0)
-      react-dnd-touch-backend: 10.0.2
-    transitivePeerDependencies:
-      - react
-      - react-dom
     dev: true
 
   /@types/react-dom@19.1.6(@types/react@19.1.8):
@@ -7409,14 +7375,6 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /dnd-core@10.0.2:
-    resolution: {integrity: sha512-PrxEjxF0+6Y1n1n1Z9hSWZ1tvnDXv9syL+BccV1r1RC08uWNsyetf8AnWmUF3NgYPwy0HKQJwTqGkZK+1NlaFA==}
-    dependencies:
-      '@react-dnd/asap': 4.0.1
-      '@react-dnd/invariant': 2.0.0
-      redux: 5.0.1
-    dev: true
-
   /dnd-core@16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
     dependencies:
@@ -9252,6 +9210,7 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 18.3.1
+    dev: false
 
   /hookified@1.9.1:
     resolution: {integrity: sha512-u3pxtGhKjcSXnGm1CX6aXS9xew535j3lkOCegbA6jdyh0BaAjTbXI4aslKstCr6zUNtoCxFGFKwjbSHdGrMB8g==}
@@ -12566,33 +12525,12 @@ packages:
       react-dnd: 16.0.1(@types/node@22.0.2)(@types/react@19.1.8)(react@19.1.0)
     dev: false
 
-  /react-dnd-touch-backend@10.0.2:
-    resolution: {integrity: sha512-+lW/Ern0dKyHToD0oP+Wc/ZD6l7qJazosLqbjzL7OnPlig6WxdlrHkJylOLkeAdZj41fIJJ551Lb57pIL0CcPw==}
-    dependencies:
-      '@react-dnd/invariant': 2.0.0
-      dnd-core: 10.0.2
-    dev: true
-
   /react-dnd-touch-backend@16.0.1:
     resolution: {integrity: sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==}
     dependencies:
       '@react-dnd/invariant': 4.0.2
       dnd-core: 16.0.1
     dev: false
-
-  /react-dnd@10.0.2(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-SC2Ymvntynhoqtf5zaFhZscm9xenCoMofilxPdlwUlaelAzmbl9fw82C4ZJ//+lNm3kWAKXjGDZg2/aWjKEAtg==}
-    peerDependencies:
-      react: '>= 16.8'
-      react-dom: '>= 16.8'
-    dependencies:
-      '@react-dnd/shallowequal': 2.0.0
-      '@types/hoist-non-react-statics': 3.3.6
-      dnd-core: 10.0.2
-      hoist-non-react-statics: 3.3.2
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    dev: true
 
   /react-dnd@16.0.1(@types/node@22.0.2)(@types/react@19.1.8)(react@19.1.0):
     resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
@@ -12750,6 +12688,7 @@ packages:
 
   /redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+    dev: false
 
   /refa@0.12.1:
     resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^0.0.1
     version: 0.0.1
   '@destinyitemmanager/dim-api-types':
-    specifier: ^1.35.0
-    version: 1.35.0
+    specifier: ^1.36.0
+    version: 1.36.0
   '@fortawesome/fontawesome-free':
     specifier: ^5.15.4
     version: 5.15.4
@@ -2032,8 +2032,8 @@ packages:
       postcss-selector-parser: 7.1.0
     dev: true
 
-  /@destinyitemmanager/dim-api-types@1.35.0:
-    resolution: {integrity: sha512-0RQcOrzdQa6vHNHDPFzcFF7n6VXDN4ToqASZ42nxu9HTNjbUowdG87LWrO1wZrS4Rro5bYCa5cVXfoIiO7xBKw==}
+  /@destinyitemmanager/dim-api-types@1.36.0:
+    resolution: {integrity: sha512-KFf0Mbbb6G+8SwZm4LiMrt4prQspWLu0d/bSbD+e7/pkoQUZeErhhAwxjb2rgTmunYLDQeRKq8k74z0BzLbB5Q==}
     dev: false
 
   /@discoveryjs/json-ext@0.6.3:

--- a/src/app/loadout-analyzer/analysis.test.ts
+++ b/src/app/loadout-analyzer/analysis.test.ts
@@ -316,12 +316,14 @@ describe('basic loadout analysis finding tests', () => {
     for (const c of args) {
       if (c.statHash === StatHashes.Recovery) {
         // The loadout has no constraint for recovery, so it gets the existing loadout stats as the minimum
-        expect(c.minTier).toBe(
-          baseArmorStatConstraints.find((base) => base.statHash === c.statHash)!.minTier,
+        expect(c.minStat).toBe(
+          baseArmorStatConstraints.find((base) => base.statHash === c.statHash)!.minTier! * 10,
         );
       } else if (c.statHash !== StatHashes.Mobility) {
         // The loadout does not satisfy stat constraints, but LO gets called with the constraints as minimum
-        expect(c.minTier).toBe(newConstraints.find((n) => n.statHash === c.statHash)!.minTier);
+        expect(c.minStat).toBe(
+          newConstraints.find((n) => n.statHash === c.statHash)!.minTier! * 10,
+        );
       }
     }
 

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -24,6 +24,7 @@ import {
   resolveLoadoutModHashes,
 } from 'app/loadout-drawer/loadout-utils';
 import { fullyResolveLoadout } from 'app/loadout/ingame/selectors';
+import { MAX_STAT, edgeOfFateReleased } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout/loadout-types';
 import { ModMap, categorizeArmorMods, fitMostMods } from 'app/loadout/mod-assignment-utils';
@@ -298,8 +299,10 @@ export async function analyzeLoadout(
           existingLoadoutStatsAsStatConstraints = statConstraints.map((c) => ({
             statHash: c.statHash,
             ignored: c.ignored,
-            maxTier: 10,
-            minTier: statTier(assumedLoadoutStats[c.statHash]!.value),
+            maxStat: MAX_STAT,
+            minStat: edgeOfFateReleased
+              ? assumedLoadoutStats[c.statHash]!.value
+              : statTier(assumedLoadoutStats[c.statHash]!.value) * 10,
           }));
           const { mergedDesiredStatRanges, mergedConstraintsImplyStrictUpgrade } =
             mergeStrictUpgradeStatConstraints(
@@ -478,7 +481,7 @@ function getStatProblems(
     return {
       stats,
       canHitStats: resolvedStatConstraints.every(
-        (c) => c.ignored || statTier(stats[c.statHash].value ?? 0) >= c.minTier,
+        (c) => c.ignored || (stats[c.statHash].value ?? 0) >= c.minStat,
       ),
     };
   };

--- a/src/app/loadout-analyzer/utils.ts
+++ b/src/app/loadout-analyzer/utils.ts
@@ -2,7 +2,7 @@ import { DesiredStatRange, ResolvedStatConstraint } from 'app/loadout-builder/ty
 
 /**
  * Loadout Analysis (and the corresponding LO mode) sometimes are interested in
- * strictly better tiers. This takes (assumed) loadout stats and the
+ * strictly better stats/tiers. This takes (assumed) loadout stats and the
  * user-selected stat constraints and merges them so that a set satisfying the
  * merged constraints always satisfies both the input constraint sets.
  *
@@ -26,23 +26,25 @@ export function mergeStrictUpgradeStatConstraints(
   // the existing tier, satisfying the definition of "strict upgrade").
   let mergedConstraintsImplyStrictUpgrade = false;
   const mergedDesiredStatRanges = parameterStatConstraints.map((constraint) => {
-    const existingLoadoutTier = existingLoadoutStatsAsStatConstraints?.find(
+    const existingStatConstraint = existingLoadoutStatsAsStatConstraints?.find(
       (c) => c.statHash === constraint.statHash,
     );
-    if (existingLoadoutTier && !constraint.ignored) {
-      const existingTierValue = existingLoadoutTier.ignored ? 0 : existingLoadoutTier.minTier;
-      const effectiveLoadoutTier = Math.min(constraint.maxTier, existingTierValue);
-      mergedConstraintsImplyStrictUpgrade ||= constraint.minTier > effectiveLoadoutTier;
+    const minStat = constraint.ignored ? 0 : constraint.minStat;
+    const maxStat = constraint.ignored ? 0 : constraint.maxStat;
+    if (existingStatConstraint && !constraint.ignored) {
+      const existingMinStat = existingStatConstraint.ignored ? 0 : existingStatConstraint.minStat;
+      const effectiveMinStat = Math.min(maxStat, existingMinStat);
+      mergedConstraintsImplyStrictUpgrade ||= minStat > effectiveMinStat;
       return {
         statHash: constraint.statHash,
-        minTier: Math.max(constraint.minTier, effectiveLoadoutTier),
-        maxTier: constraint.ignored ? 0 : constraint.maxTier,
+        minStat: Math.max(minStat, effectiveMinStat),
+        maxStat,
       };
     }
     return {
       statHash: constraint.statHash,
-      minTier: constraint.minTier,
-      maxTier: constraint.ignored ? 0 : constraint.maxTier,
+      minStat,
+      maxStat,
     };
   });
   return { mergedDesiredStatRanges, mergedConstraintsImplyStrictUpgrade };

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -203,7 +203,7 @@ export default function NoBuildsFoundExplainer({
   // two non-solar combat mods, mod assignment is trivially infeasible and we
   // can point that out directly?
 
-  const anyStatMinimums = params.statConstraints!.some((f) => Boolean(f.minTier));
+  const anyStatMinimums = params.statConstraints!.some((f) => Boolean(f.minTier || f.minStat));
 
   const bucketIndependentMods = [...lockedModMap.generalMods, ...lockedModMap.activityMods];
 

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -12,7 +12,10 @@ function getComparatorsForMatchedSetSorting(desiredStatRanges: DesiredStatRange[
     comparators.push(
       compareBy(
         (s) =>
-          -Math.min(statTier(s.stats[constraint.statHash as ArmorStatHashes]), constraint.maxTier),
+          -Math.min(
+            statTier(s.stats[constraint.statHash as ArmorStatHashes]),
+            statTier(constraint.maxStat),
+          ),
       ),
     );
   }
@@ -41,6 +44,6 @@ export function calculateTotalTier(stats: ArmorStats) {
 
 export function sumEnabledStats(stats: ArmorStats, desiredStatRanges: DesiredStatRange[]) {
   return sumBy(desiredStatRanges, (constraint) =>
-    Math.min(statTier(stats[constraint.statHash as ArmorStatHashes]), constraint.maxTier),
+    Math.min(statTier(stats[constraint.statHash as ArmorStatHashes]), statTier(constraint.maxStat)),
   );
 }

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -23,6 +23,7 @@ import {
   updateMods,
 } from 'app/loadout-drawer/loadout-drawer-reducer';
 import { findItemForLoadout, newLoadout, pickBackingStore } from 'app/loadout-drawer/loadout-utils';
+import { EFFECTIVE_MAX_STAT, MAX_STAT } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
 import { showNotification } from 'app/notifications/notifications';
@@ -364,7 +365,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
       case 'statConstraintReset': {
         return updateStatConstraints(
           state,
-          armorStats.map((s) => ({ statHash: s, minTier: 0, maxTier: 10, ignored: false })),
+          armorStats.map((s) => ({ statHash: s, minStat: 0, maxStat: MAX_STAT, ignored: false })),
         );
       }
       case 'statConstraintRandomize': {
@@ -373,8 +374,8 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
           shuffle(
             armorStats.map((s) => ({
               statHash: s,
-              minTier: Math.floor(Math.random() * 10),
-              maxTier: 10,
+              minStat: Math.floor(Math.random() * EFFECTIVE_MAX_STAT),
+              maxStat: MAX_STAT,
               ignored: false,
             })),
           ),

--- a/src/app/loadout-builder/loadout-params.test.ts
+++ b/src/app/loadout-builder/loadout-params.test.ts
@@ -1,0 +1,72 @@
+import { MAX_STAT } from 'app/loadout/known-values';
+import { armorStats } from 'app/search/d2-known-values';
+import { resolveStatConstraints, unresolveStatConstraints } from './loadout-params';
+
+describe('resolveStatConstraints', () => {
+  const cases = [
+    {
+      name: 'fills in ignored stats',
+      before: [
+        { statHash: armorStats[0], minStat: 20, maxStat: 60 },
+        { statHash: armorStats[2], minStat: 10 },
+      ],
+      after: [
+        { statHash: armorStats[0], minStat: 20, maxStat: 60, ignored: false },
+        // Order is preserved
+        { statHash: armorStats[2], minStat: 10, maxStat: MAX_STAT, ignored: false },
+        { statHash: armorStats[1], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[3], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[4], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[5], minStat: 0, maxStat: MAX_STAT, ignored: true },
+      ],
+    },
+    {
+      name: 'uses minTier/maxTier if minStat/maxStat are not provided',
+      before: [{ statHash: armorStats[1], minTier: 3, maxTier: 5 }],
+      after: [
+        { statHash: armorStats[1], minStat: 30, maxStat: 50, ignored: false },
+        { statHash: armorStats[0], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[2], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[3], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[4], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[5], minStat: 0, maxStat: MAX_STAT, ignored: true },
+      ],
+    },
+  ];
+
+  for (const { name, before, after } of cases) {
+    it(name, () => {
+      const result = resolveStatConstraints(before);
+      expect(result).toEqual(after);
+    });
+  }
+});
+
+describe('unresolveStatConstraints', () => {
+  const cases = [
+    {
+      name: 'converts resolved constraints back to StatConstraint[]',
+      before: [
+        { statHash: armorStats[2], minStat: 10, maxStat: MAX_STAT, ignored: false },
+        { statHash: armorStats[0], minStat: 20, maxStat: 60, ignored: false },
+        { statHash: armorStats[1], minStat: 0, maxStat: MAX_STAT, ignored: true },
+      ],
+      after: [
+        { statHash: armorStats[2], minStat: 10 },
+        { statHash: armorStats[0], minStat: 20, maxStat: 60 },
+      ],
+    },
+    {
+      name: 'omits minStat if 0 and maxStat if MAX_STAT',
+      before: [{ statHash: armorStats[0], minStat: 0, maxStat: MAX_STAT, ignored: false }],
+      after: [{ statHash: armorStats[0] }],
+    },
+  ];
+
+  for (const { name, before, after } of cases) {
+    it(name, () => {
+      const result = unresolveStatConstraints(before);
+      expect(result).toEqual(after);
+    });
+  }
+});

--- a/src/app/loadout-builder/loadout-params.ts
+++ b/src/app/loadout-builder/loadout-params.ts
@@ -1,6 +1,7 @@
 /* Functions for dealing with the LoadoutParameters structure we save with loadouts and use to save and share LO settings. */
 
 import { StatConstraint, defaultLoadoutParameters } from '@destinyitemmanager/dim-api-types';
+import { MAX_STAT } from 'app/loadout/known-values';
 import { armorStats } from 'app/search/d2-known-values';
 import { compareBy } from 'app/utils/comparators';
 import { keyBy } from 'es-toolkit';
@@ -16,7 +17,9 @@ export function resolveStatConstraints(
   const statConstraintsByStatHash = keyBy(statConstraints, (c) => c.statHash);
   const resolvedStatConstraints: ResolvedStatConstraint[] = armorStats.map((statHash) => {
     const c = statConstraintsByStatHash[statHash];
-    return { statHash, minTier: c?.minTier ?? 0, maxTier: c ? (c.maxTier ?? 10) : 0, ignored: !c };
+    const minStat = c?.minStat ?? (c?.minTier ?? 0) * 10;
+    const maxStat = c?.maxStat ?? (c?.maxTier !== undefined ? c.maxTier * 10 : MAX_STAT);
+    return { statHash, minStat, maxStat, ignored: !c };
   });
 
   return resolvedStatConstraints.sort(
@@ -37,13 +40,13 @@ export function unresolveStatConstraints(
   return resolvedStatConstraints
     .filter((c) => !c.ignored)
     .map((c) => {
-      const { statHash, minTier, maxTier } = c;
+      const { statHash, minStat, maxStat } = c;
       const constraint: StatConstraint = { statHash };
-      if (minTier > 0) {
-        constraint.minTier = minTier;
+      if (minStat > 0) {
+        constraint.minStat = minStat;
       }
-      if (maxTier < 10) {
-        constraint.maxTier = maxTier;
+      if (maxStat < MAX_STAT) {
+        constraint.maxStat = maxStat;
       }
       return constraint;
     });

--- a/src/app/loadout-builder/process-utils.test.ts
+++ b/src/app/loadout-builder/process-utils.test.ts
@@ -1,5 +1,6 @@
 import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { MAX_STAT } from 'app/loadout/known-values';
 import { armorStats } from 'app/search/d2-known-values';
 import { emptySet } from 'app/utils/empty';
 import { StatHashes } from 'data/d2/generated-enums';
@@ -495,8 +496,8 @@ describe('process-utils optimal mods', () => {
     resolvedStatConstraints = armorStats.map((statHash) => ({
       statHash,
       ignored: false,
-      maxTier: 8,
-      minTier: 3,
+      maxStat: 80,
+      minStat: 30,
     }));
   });
 
@@ -637,12 +638,14 @@ test('process-utils activity mods', async () => {
     statOrder,
   );
 
-  const resolvedStatConstraints = statOrder.map((statHash) => ({
-    statHash,
-    ignored: false,
-    maxTier: 10,
-    minTier: 0,
-  }));
+  const resolvedStatConstraints = statOrder.map(
+    (statHash): ResolvedStatConstraint => ({
+      statHash,
+      ignored: false,
+      maxStat: MAX_STAT,
+      minStat: 0,
+    }),
+  );
 
   const setStats = [55, 55, 55, 50, 50, 50];
 

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -12,11 +12,12 @@ export interface MinMaxTier {
 /**
  * Resolved stat constraints take the compact form of the API stat constraints
  * and expand them so that each stat has a corresponding constraint, the min and
- * max are defined, and the ignored flag is set. In the API version, stat
- * constraints are simply missing if ignored, and min-0/max-10 is omitted as
- * implied.
+ * max are defined, and the ignored flag is set. Tiers are replaces with exact
+ * stat values. In the API version, stat constraints are simply missing if
+ * ignored, and min-0/max-10 is omitted as implied.
  */
-export interface ResolvedStatConstraint extends Required<StatConstraint> {
+export interface ResolvedStatConstraint
+  extends Required<Omit<StatConstraint, 'minTier' | 'maxTier'>> {
   /**
    * An ignored stat has an effective maximum tier of 0, so that any
    * stat tiers in excess of T0 are deemed worthless.
@@ -26,11 +27,10 @@ export interface ResolvedStatConstraint extends Required<StatConstraint> {
 
 /**
  * When a stat is ignored, we treat it as if it were effectively a constraint
- * with a max desired tier of 0. ResolvedStatContraintRange is the same as
- * DesiredStatRange, but with the ignored flag removed, and maxTier set to
- * 0 for ignored sets.
+ * with a max desired tier of 0. DesiredStatRange is the same as StatConstraint,
+ * but with the ignored flag removed, and maxStat set to 0 for ignored sets.
  */
-export type DesiredStatRange = Required<StatConstraint>;
+export type DesiredStatRange = Required<Omit<StatConstraint, 'minTier' | 'maxTier'>>;
 
 /** A map from bucketHash to the pinned item if there is one. */
 export interface PinnedItems {

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -2,6 +2,7 @@ import {
   armor2PlugCategoryHashes,
   armor2PlugCategoryHashesByName,
 } from 'app/search/d2-known-values';
+import { D2CalculatedSeason } from 'data/d2/d2-season-info';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import raidModPlugCategoryHashes from 'data/d2/raid-mod-plug-category-hashes.json';
 
@@ -32,3 +33,15 @@ export const knownModPlugCategoryHashes = [
  * This hash is set for plugs that aren't included in an ingame loadout.
  */
 export const UNSET_PLUG_HASH = 2166136261;
+
+export const MAX_TIER = 10;
+export const MAX_STAT = 200;
+
+// Once Edge of Fate is released, we should show loadouts that can
+// have any higher stats, not just higher tiers.
+// TODO: Also make sure analysis ignores tiers
+export const edgeOfFateReleased = D2CalculatedSeason >= 27;
+// The current reasonable maximum stat value. We have this separate from
+// MAX_STAT (which is the Edge of Fate value) to allow folks to theorycraft a
+// bit before it releases. Afterwards they will be the same.
+export const EFFECTIVE_MAX_STAT = edgeOfFateReleased ? MAX_STAT : 10 * MAX_TIER;

--- a/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
@@ -82,9 +82,7 @@ export default function LoadoutShareSheet({
     loadout.parameters &&
       (loadout.parameters.query ||
         loadout.parameters.exoticArmorHash ||
-        loadout.parameters.statConstraints?.some(
-          (s) => s.maxTier !== undefined || s.minTier !== undefined,
-        )),
+        loadout.parameters.statConstraints?.length),
   );
 
   return (

--- a/src/app/settings/initial-settings.ts
+++ b/src/app/settings/initial-settings.ts
@@ -1,8 +1,4 @@
-import {
-  defaultSettings,
-  Settings as DimApiSettings,
-  VaultWeaponGroupingStyle,
-} from '@destinyitemmanager/dim-api-types';
+import { defaultSettings, Settings as DimApiSettings } from '@destinyitemmanager/dim-api-types';
 import { defaultLanguage, DimLanguage } from 'app/i18n';
 
 /**
@@ -10,13 +6,11 @@ import { defaultLanguage, DimLanguage } from 'app/i18n';
  */
 export interface Settings extends DimApiSettings {
   language: DimLanguage;
-  vaultArmorGroupingStyle: VaultWeaponGroupingStyle;
 }
 
 export const initialSettingsState: Settings = {
   ...defaultSettings,
   language: defaultLanguage(),
-  vaultArmorGroupingStyle: VaultWeaponGroupingStyle.Inline,
   organizerColumnsWeapons: [
     'icon',
     'name',

--- a/src/app/store-stats/StatTooltip.tsx
+++ b/src/app/store-stats/StatTooltip.tsx
@@ -3,6 +3,7 @@ import { Tooltip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { DimCharacterStat } from 'app/inventory/store-types';
 import { statTier } from 'app/loadout-builder/utils';
+import { edgeOfFateReleased, EFFECTIVE_MAX_STAT } from 'app/loadout/known-values';
 import clsx from 'clsx';
 import { useSelector } from 'react-redux';
 import ClarityCharacterStat from './ClarityCharacterStat';
@@ -24,14 +25,14 @@ export default function StatTooltip({
 }) {
   const tier = statTier(stat.value);
   const descriptionsToDisplay = useSelector(settingSelector('descriptionsToDisplay'));
-  const useClarityInfo = descriptionsToDisplay !== 'bungie';
+  const useClarityInfo = descriptionsToDisplay !== 'bungie' && !edgeOfFateReleased;
 
   return (
     <div>
       <Tooltip.Header text={stat.displayProperties.name} />
       <div className={styles.values}>
         <div className={styles.label}>{t('Stats.Tier', { tier })}</div>
-        <div>{`${stat.value}/100`}</div>
+        <div>{`${stat.value}/${EFFECTIVE_MAX_STAT}`}</div>
       </div>
       <hr />
       <div>{stat.displayProperties.description}</div>


### PR DESCRIPTION
In preparation for Edge of Fate making every stat point count, I've swapped over from using stat tiers in StatConstraints to storing exact stat min/max. Both can go up to 200.

- This should still work with loadouts that have the old stat tiers saved. They should really only be updated if you change the stat constraints.
- All the existing functionality should still work exactly the same (Loadout Optimizer / Analyzer, stat tier displays, stat tier editor)
- I'm beginning to put in some places where once Edge of Fate releases, we can automatically swap out of a tiered world. But that's not complete - we'll need to rewire a bunch of stuff, see https://github.com/DestinyItemManager/DIM/issues/11066