### PR TITLE
Optimize useProcess / polish stat constraints editor

### DIFF
--- a/src/app/loadout-analyzer/analysis.test.ts
+++ b/src/app/loadout-analyzer/analysis.test.ts
@@ -3,6 +3,7 @@ import { getBuckets } from 'app/destiny2/d2-buckets';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
+import { ProcessInputs } from 'app/loadout-builder/process-worker/process';
 import { ProcessResult } from 'app/loadout-builder/process-worker/types';
 import { getAutoMods } from 'app/loadout-builder/process/mappers';
 import type { runProcess } from 'app/loadout-builder/process/process-wrapper';
@@ -47,6 +48,7 @@ const analyze = async (
 function noopProcessWorkerMock(..._args: Parameters<typeof runProcess>): {
   cleanup: () => void;
   resultPromise: Promise<Omit<ProcessResult, 'sets'> & { sets: ArmorSet[]; processTime: number }>;
+  input: ProcessInputs;
 } {
   return {
     cleanup: noop,
@@ -65,6 +67,7 @@ function noopProcessWorkerMock(..._args: Parameters<typeof runProcess>): {
         ]),
       ) as StatRanges,
     }),
+    input: undefined as unknown as ProcessInputs, // TODO: this should be the input that was passed to the worker
   };
 }
 

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -324,7 +324,8 @@ export async function analyzeLoadout(
               desiredStatRanges: mergedDesiredStatRanges,
               stopOnFirstSet: true,
               strictUpgrades: !mergedConstraintsImplyStrictUpgrade,
-            });
+              lastInput: undefined, // TODO: it would be nice to memoize these inputs too
+            })!;
 
             hasStrictUpgrade = Boolean((await resultPromise).sets.length);
             if (hasStrictUpgrade) {

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -319,13 +319,11 @@ function StatEditBar({
         aria-label={t('LoadoutBuilder.StatMax')}
         onChange={(e) => {
           setMaxText(e.target.value);
-          try {
-            const value = parseInt(e.target.value, 10);
-            if (isNaN(value) || value < 0 || value > MAX_STAT) {
-              return;
-            }
-            setMax(value);
-          } catch {}
+          const value = parseInt(e.target.value, 10);
+          if (isNaN(value) || value < 0 || value > MAX_STAT) {
+            return;
+          }
+          setMax(value);
         }}
         onBlur={() => onChange()}
         onKeyUp={handleKeyUp}

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -289,20 +289,26 @@ function StatEditBar({
     }
   };
 
+  const [minText, setMinText] = useState(min.toString());
+  const [maxText, setMaxText] = useState(max.toString());
+
   return (
     <div className={styles.statBar}>
       <input
         type="number"
         min={0}
         max={MAX_STAT}
-        value={min}
+        value={minText}
         aria-label={t('LoadoutBuilder.StatMin')}
         onChange={(e) => {
-          const value = parseInt(e.target.value, 10);
-          if (isNaN(value) || value < 0 || value > MAX_STAT) {
-            return;
-          }
-          setMin(value);
+          setMinText(e.target.value);
+          try {
+            const value = parseInt(e.target.value, 10);
+            if (isNaN(value) || value < 0 || value > MAX_STAT) {
+              return;
+            }
+            setMin(value);
+          } catch {}
         }}
         onBlur={() => onChange()}
         onKeyUp={handleKeyUp}
@@ -312,14 +318,17 @@ function StatEditBar({
         type="number"
         min={0}
         max={MAX_STAT}
-        value={max}
+        value={maxText}
         aria-label={t('LoadoutBuilder.StatMax')}
         onChange={(e) => {
-          const value = parseInt(e.target.value, 10);
-          if (isNaN(value) || value < 0 || value > MAX_STAT) {
-            return;
-          }
-          setMax(value);
+          setMaxText(e.target.value);
+          try {
+            const value = parseInt(e.target.value, 10);
+            if (isNaN(value) || value < 0 || value > MAX_STAT) {
+              return;
+            }
+            setMax(value);
+          } catch {}
         }}
         onBlur={() => onChange()}
         onKeyUp={handleKeyUp}

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -249,7 +249,6 @@ function StatRow({
               setMax={setMax}
               onChange={commitStatChanges}
             >
-              {statConstraint.minStat} - {statConstraint.maxStat}
               <StatBar
                 range={statRange}
                 equippedHashes={equippedHashes}

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -301,13 +301,11 @@ function StatEditBar({
         aria-label={t('LoadoutBuilder.StatMin')}
         onChange={(e) => {
           setMinText(e.target.value);
-          try {
-            const value = parseInt(e.target.value, 10);
-            if (isNaN(value) || value < 0 || value > MAX_STAT) {
-              return;
-            }
-            setMin(value);
-          } catch {}
+          const value = parseInt(e.target.value, 10);
+          if (isNaN(value) || value < 0 || value > MAX_STAT) {
+            return;
+          }
+          setMin(value);
         }}
         onBlur={() => onChange()}
         onKeyUp={handleKeyUp}

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -33,30 +33,42 @@ import {
 /** Caps the maximum number of total armor sets that'll be returned */
 const RETURNED_ARMOR_SETS = 200;
 
+export interface ProcessInputs {
+  filteredItems: ProcessItemsByBucket;
+  /** Selected mods' total contribution to each stat */
+  modStatTotals: ArmorStats;
+  /** Mods to add onto the sets */
+  lockedMods: LockedProcessMods;
+  /** The user's chosen stat ranges, in priority order. */
+  desiredStatRanges: DesiredStatRange[];
+  /** Ensure every set includes one exotic */
+  anyExotic: boolean;
+  /** Which artifice mods, large, and small stat mods are available */
+  autoModOptions: AutoModData;
+  /** Use stat mods to hit stat minimums */
+  autoStatMods: boolean;
+  /** If set, only sets where at least one stat **exceeds** `desiredStatRanges` minimums will be returned */
+  strictUpgrades: boolean;
+  /** If set, LO will exit after finding at least one set that fits all constraints (and is a strict upgrade if `strictUpgrades` is set) */
+  stopOnFirstSet: boolean;
+}
+
 /**
  * This processes all permutations of armor to build sets
  * @param filteredItems pared down list of items to process sets from
  * @param modStatTotals Stats that are applied to final stat totals, think general and other mod stats
  */
-export function process(
-  filteredItems: ProcessItemsByBucket,
-  /** Selected mods' total contribution to each stat */
-  modStatTotals: ArmorStats,
-  /** Mods to add onto the sets */
-  lockedMods: LockedProcessMods,
-  /** The user's chosen stat ranges, in priority order. */
-  desiredStatRanges: DesiredStatRange[],
-  /** Ensure every set includes one exotic */
-  anyExotic: boolean,
-  /** Which artifice mods, large, and small stat mods are available */
-  autoModOptions: AutoModData,
-  /** Use stat mods to hit stat minimums */
-  autoStatMods: boolean,
-  /** If set, only sets where at least one stat **exceeds** `desiredStatRanges` minimums will be returned */
-  strictUpgrades: boolean,
-  /** If set, LO will exit after finding at least one set that fits all constraints (and is a strict upgrade if `strictUpgrades` is set) */
-  stopOnFirstSet: boolean,
-): ProcessResult {
+export function process({
+  filteredItems,
+  modStatTotals,
+  lockedMods,
+  desiredStatRanges,
+  anyExotic,
+  autoModOptions,
+  autoStatMods,
+  strictUpgrades,
+  stopOnFirstSet,
+}: ProcessInputs): ProcessResult {
   const pstart = performance.now();
 
   // For efficiency, we'll handle most stats as flat arrays in the order the user prioritized their stats.

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -80,11 +80,14 @@ export function useProcess({
   // want to be able to short circuit updates without killing in-progress
   // processes.
   const cleanupRef = useRef<() => void>(undefined);
-  useEffect(() => {
-    // Cleanup the previous process if it exists
-    cleanupRef.current?.();
-    cleanupRef.current = undefined;
-  }, []);
+  useEffect(
+    () => () => {
+      // Cleanup the previous process if it exists
+      cleanupRef.current?.();
+      cleanupRef.current = undefined;
+    },
+    [],
+  );
   // This allows for some memoization of the inputs to the worker
   const inputsRef = useRef<ProcessInputs>(undefined);
 

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -17,6 +17,7 @@ import { HashLookup } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { StatHashes } from 'data/d2/generated-enums';
 import { mapKeys, once } from 'es-toolkit';
+import { edgeOfFateReleased } from './known-values';
 
 /**
  * Font of X mods conditionally boost a single stat. This maps from
@@ -38,8 +39,10 @@ const fontModHashToStatHash = once(() => {
   };
 });
 
-/** The boost for 0, 1, 2, 3 mods equipped. From Clarity data */
-const boostForNumFontStacks = [0, 30, 50, 60];
+/** The boost for 0, 1, 2, 3 mods equipped. From Clarity data (old) and from
+ * https://www.bungie.net/7/en/News/Article/twid_07_10_2025 for Edge of Fate
+ * version. */
+const boostForNumFontStacks = edgeOfFateReleased ? [0, 20, 40, 50] : [0, 30, 50, 60];
 
 type FontModStatBoosts = {
   [statHash in ArmorStatHashes]?: {


### PR DESCRIPTION
* Debounce the useProcess starter so it doesn't kick off until 500ms after the last change. Fixes #8809 
* Manually memoize useProcess based on deep comparison of its inputs (after processing items into `ProcessItem`s) so changes like moving items or reloading the stores won't generally cause recalculation. 
* Fix a bunch of issues around input to the StatConstraintEditor. Fixes #11129