### PR TITLE
Use the same grouping mechanism for hashtags in loadouts we use in search

### DIFF
--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -4,7 +4,7 @@ import FilterPills, { Option } from 'app/dim-ui/FilterPills';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { DimLanguage } from 'app/i18n';
 import { t, tl } from 'app/i18next-t';
-import { getHashtagsFromString } from 'app/inventory/note-hashtags';
+import { getHashtagsFromString, groupHashtagsByCanonicalForm } from 'app/inventory/note-hashtags';
 import { DimStore } from 'app/inventory/store-types';
 import { findingDisplays } from 'app/loadout-analyzer/finding-display';
 import { useSummaryLoadoutsAnalysis } from 'app/loadout-analyzer/hooks';
@@ -72,16 +72,7 @@ export function useLoadoutFilterPills(
     setSelectedFilters(emptyArray());
   }, [store.id]);
 
-  const loadoutsByHashtag = useMemo(() => {
-    const loadoutsByHashtag: { [hashtag: string]: Loadout[] } = {};
-    for (const loadout of savedLoadouts) {
-      const hashtags = getHashtagsFromString(loadout.name, loadout.notes);
-      for (const hashtag of hashtags) {
-        (loadoutsByHashtag[hashtag.replace('#', '').replace(/_/g, ' ')] ??= []).push(loadout);
-      }
-    }
-    return loadoutsByHashtag;
-  }, [savedLoadouts]);
+  const loadoutsByHashtag = useMemo(() => groupLoadoutsByHashtag(savedLoadouts), [savedLoadouts]);
 
   const filterOptions = Object.entries(loadoutsByHashtag)
     .map(
@@ -211,6 +202,42 @@ export function useLoadoutFilterPills(
     </>,
     selectedFilters.length > 0,
   ];
+}
+
+/**
+ * Groups loadouts by hashtag, using case-insensitive grouping with uppercase preference.
+ */
+function groupLoadoutsByHashtag(loadouts: Loadout[]): { [hashtag: string]: Loadout[] } {
+  const allHashtags: string[] = [];
+  const loadoutsByRawHashtag = new Map<string, Loadout[]>();
+
+  for (const loadout of loadouts) {
+    const hashtags = getHashtagsFromString(loadout.name, loadout.notes);
+    for (const hashtag of hashtags) {
+      allHashtags.push(hashtag);
+      if (!loadoutsByRawHashtag.has(hashtag)) {
+        loadoutsByRawHashtag.set(hashtag, []);
+      }
+      loadoutsByRawHashtag.get(hashtag)!.push(loadout);
+    }
+  }
+
+  const canonicalHashtags = groupHashtagsByCanonicalForm(allHashtags);
+  const result: { [hashtag: string]: Loadout[] } = {};
+
+  for (const [lowerKey, canonicalHashtag] of canonicalHashtags.entries()) {
+    const cleanedHashtag = canonicalHashtag.replace('#', '').replace(/_/g, ' ');
+    result[cleanedHashtag] = [];
+
+    // Collect all loadouts for all variants of this hashtag
+    for (const [rawHashtag, loadouts] of loadoutsByRawHashtag.entries()) {
+      if (rawHashtag.toLowerCase() === lowerKey) {
+        result[cleanedHashtag].push(...loadouts);
+      }
+    }
+  }
+
+  return result;
 }
 
 function AnalysisProgress({


### PR DESCRIPTION
I asked Claude Code to fix this issue and it discovered that we already had a good solution to the problem in our search code. I asked it to refactor that code to let me use it in the loadouts stuff.

Edit: I ended up rewriting it a fair bit myself. I don't think this saved me any time at all.

Fixes #11130