### PR TITLE
Remove deprecated pathfinders / show seasonal hub title

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1135,6 +1135,7 @@
     "GambitPathfinder": "Gambit Pathfinder",
     "CruciblePathfinder": "Crucible Pathfinder",
     "VanguardPathfinder": "Vanguard Pathfinder",
+    "SeasonalHub": "Seasonal Hub",
     "SecretTriumph": "Secret Triumph",
     "StatTrackers": "Stat Trackers",
     "TrackedTriumphs": "Tracked Triumphs",

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -96,7 +96,10 @@ export default function Progress({ account }: { account: DestinyAccount }) {
   const menuItems = compact([
     { id: 'ranks', title: t('Progress.CrucibleRank') },
     { id: 'trackedTriumphs', title: t('Progress.TrackedTriumphs') },
-    eventCard && { id: 'event', title: eventCard.displayProperties.name },
+    eventCard && {
+      id: 'event',
+      title: eventCard.displayProperties.name || t('Progress.SeasonalHub'),
+    },
     { id: 'milestones', title: t('Progress.Milestones') },
     paleHeartPathfinderNode && {
       id: 'paleHeartPathfinder',
@@ -153,7 +156,10 @@ export default function Progress({ account }: { account: DestinyAccount }) {
 
           {eventCard && (
             <section id="event">
-              <CollapsibleTitle title={eventCard.displayProperties.name} sectionId="event">
+              <CollapsibleTitle
+                title={eventCard.displayProperties.name || t('Progress.SeasonalHub')}
+                sectionId="event"
+              >
                 <div className="progress-row">
                   <Event card={eventCard} store={selectedStore} buckets={buckets} />
                 </div>

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -92,9 +92,6 @@ export default function Progress({ account }: { account: DestinyAccount }) {
     defs.PresentationNode.get(coreSettings.seasonalChallengesPresentationNodeHash);
 
   const paleHeartPathfinderNode = defs.PresentationNode.get(1062988660);
-  const gambitPathfinderNode = defs.PresentationNode.get(1190294990);
-  const cruciblePathfinderNode = defs.PresentationNode.get(1289679000);
-  const vanguardPathfinderNode = defs.PresentationNode.get(2968370335);
 
   const menuItems = compact([
     { id: 'ranks', title: t('Progress.CrucibleRank') },
@@ -105,9 +102,6 @@ export default function Progress({ account }: { account: DestinyAccount }) {
       id: 'paleHeartPathfinder',
       title: t('Progress.PaleHeartPathfinder'),
     },
-    gambitPathfinderNode && { id: 'gambitPathfinder', title: t('Progress.GambitPathfinder') },
-    cruciblePathfinderNode && { id: 'cruciblePathfinder', title: t('Progress.CruciblePathfinder') },
-    vanguardPathfinderNode && { id: 'vanguardPathfinder', title: t('Progress.VanguardPathfinder') },
     seasonalChallengesPresentationNode && {
       id: 'seasonal-challenges',
       title: seasonalChallengesPresentationNode.displayProperties.name,
@@ -181,38 +175,6 @@ export default function Progress({ account }: { account: DestinyAccount }) {
                 id="paleHeartPathfinder"
                 name={t('Progress.PaleHeartPathfinder')}
                 presentationNode={paleHeartPathfinderNode}
-                store={selectedStore}
-              />
-            </ErrorBoundary>
-          )}
-
-          {gambitPathfinderNode && (
-            <ErrorBoundary name={t('Progress.GambitPathfinder')}>
-              <Pathfinder
-                id="gambitPathfinder"
-                name={t('Progress.GambitPathfinder')}
-                presentationNode={gambitPathfinderNode}
-                store={selectedStore}
-              />
-            </ErrorBoundary>
-          )}
-
-          {cruciblePathfinderNode && (
-            <ErrorBoundary name={t('Progress.CruciblePathfinder')}>
-              <Pathfinder
-                id="cruciblePathfinder"
-                name={t('Progress.CruciblePathfinder')}
-                presentationNode={cruciblePathfinderNode}
-                store={selectedStore}
-              />
-            </ErrorBoundary>
-          )}
-          {vanguardPathfinderNode && (
-            <ErrorBoundary name={t('Progress.VanguardPathfinder')}>
-              <Pathfinder
-                id="vanguardPathfinder"
-                name={t('Progress.VanguardPathfinder')}
-                presentationNode={vanguardPathfinderNode}
                 store={selectedStore}
               />
             </ErrorBoundary>

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1104,9 +1104,7 @@
   },
   "Progress": {
     "Bounties": "Bounties",
-    "CruciblePathfinder": "Crucible Pathfinder",
     "CrucibleRank": "Ranks",
-    "GambitPathfinder": "Gambit Pathfinder",
     "Items": "Quest Items",
     "Milestones": "Milestones & Challenges",
     "NoEventChallenges": "You have completed all event challenges",
@@ -1127,9 +1125,9 @@
     "RecordValue": "{{value}}pts",
     "Resets_one": "1 reset",
     "Resets_other": "{{count}} resets",
+    "SeasonalHub": "Seasonal Hub",
     "StatTrackers": "Stat Trackers",
-    "TrackedTriumphs": "Tracked Triumphs",
-    "VanguardPathfinder": "Vanguard Pathfinder"
+    "TrackedTriumphs": "Tracked Triumphs"
   },
   "RecordBooks": {
     "HideCompleted": "Hide completed records",


### PR DESCRIPTION
Very minor fixes for the Progress page plus a workaround for "Seasonal Hub" not having a name.