### PR TITLE
More progress on masterwork stats and assumptions

### DIFF
--- a/src/app/dim-ui/EnergyIncrements.tsx
+++ b/src/app/dim-ui/EnergyIncrements.tsx
@@ -3,7 +3,6 @@ import { DimItem } from 'app/inventory/item-types';
 import { getEnergyUpgradeHashes, sumModCosts } from 'app/inventory/store/energy';
 import { EnergySwap } from 'app/loadout-builder/generated-sets/GeneratedSetItem';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 import { compareBy } from 'app/utils/comparators';
 import Cost from 'app/vendors/Cost';
 import clsx from 'clsx';
@@ -48,12 +47,10 @@ export function EnergyMeterIncrements({
   previewUpgrade?: (i: number) => void;
   variant: 'medium' | 'small';
 }) {
+  // This works because Tier 5 armor with 11 energy drops with all energy unlocked.
+  const maxEnergyCapacity = Math.max(10, energyCapacity);
   // layer in possible total slots, then earned slots, then currently used slots
-  // TODO: Maybe in the future, items will say how much energy they *can* have -
-  // or we can just decide this based on if it's Tier 5 armor.
-  const meterIncrements = Array<string | undefined>(
-    Math.max(MAX_ARMOR_ENERGY_CAPACITY, energyCapacity),
-  )
+  const meterIncrements = Array<string | undefined>(maxEnergyCapacity)
     .fill(styles.unavailable)
     .fill(undefined, 0, energyCapacity)
     .fill(styles.used, 0, energyUsed);
@@ -112,13 +109,17 @@ export function EnergyIncrementsWithPresstip({
               {t('EnergyMeter.UpgradeNeeded', energy)}
             </>
           )}
-          <hr />
-          <div className={styles.costs}>
-            <span>{t('Loadouts.ModPlacement.UpgradeCosts')}</span>
-            {costs.map((cost) => (
-              <Cost key={cost.itemHash} cost={cost} className={styles.cost} />
-            ))}
-          </div>
+          {costs.length > 0 && (
+            <>
+              <hr />
+              <div className={styles.costs}>
+                <span>{t('Loadouts.ModPlacement.UpgradeCosts')}</span>
+                {costs.map((cost) => (
+                  <Cost key={cost.itemHash} cost={cost} className={styles.cost} />
+                ))}
+              </div>
+            </>
+          )}
         </>
       }
       className={wrapperClass}

--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -1,5 +1,6 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { isEmpty } from 'app/utils/collections';
+import { isEdgeOfFateArmorMasterworkSocket } from 'app/utils/item-utils';
 import { getFirstSocketByCategoryHash, isWeaponMasterworkSocket } from 'app/utils/socket-utils';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
@@ -40,10 +41,18 @@ function buildMasterworkInfo(
   defs: D2ManifestDefinitions,
 ): DimMasterwork | null {
   // For crafted weapons, the enhanced intrinsic provides masterwork-like stats
-  const masterworkPlug =
+  let masterworkPlug =
     (createdItem.crafted &&
       getFirstSocketByCategoryHash(sockets, SocketCategoryHashes.IntrinsicTraits)?.plugged) ||
     sockets.allSockets.find(isWeaponMasterworkSocket)?.plugged;
+
+  // Look for the Edge of Fate masterwork socket
+  if (!masterworkPlug && createdItem.bucket.inArmor) {
+    masterworkPlug = createdItem.sockets?.allSockets.find(
+      isEdgeOfFateArmorMasterworkSocket,
+    )?.plugged;
+  }
+
   if (!masterworkPlug) {
     return null;
   }

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -28,7 +28,6 @@ import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout/loadout-types';
 import { ModMap, categorizeArmorMods, fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import { count } from 'app/utils/collections';
 import { stubTrue } from 'app/utils/functions';
@@ -146,7 +145,7 @@ export async function analyzeLoadout(
     let allLegendariesMasterworked = true;
     let exoticNotMasterworked = false;
     for (const armorItem of loadoutArmor) {
-      if (armorItem.energy && armorItem.energy.energyCapacity < MAX_ARMOR_ENERGY_CAPACITY) {
+      if (armorItem.energy && armorItem.energy.energyCapacity < 10) {
         if (armorItem.isExotic) {
           exoticNotMasterworked = true;
         } else {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss
@@ -34,10 +34,6 @@
   align-items: center;
 }
 
-.masterworked {
-  color: $masterwork-border-color;
-}
-
 .swapButton {
   composes: dim-button from global;
   justify-self: center;

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.m.scss.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'energySwapContainer': string;
   'energyValue': string;
   'item': string;
-  'masterworked': string;
   'swapButton': string;
   'swapButtonContainer': string;
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -2,7 +2,6 @@ import { EnergyIncrementsWithPresstip } from 'app/dim-ui/EnergyIncrements';
 import { t } from 'app/i18next-t';
 import { useItemPicker } from 'app/item-picker/item-picker';
 import Sockets from 'app/loadout/loadout-ui/Sockets';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
@@ -23,25 +22,9 @@ export function EnergySwap({ energy }: { energy: { energyCapacity: number; energ
 
   return (
     <div className={clsx(styles.energySwapContainer, { [styles.energyHidden]: noEnergyChange })}>
-      <div className={styles.energyValue}>
-        <div
-          className={clsx({
-            [styles.masterworked]: armorEnergyCapacity >= MAX_ARMOR_ENERGY_CAPACITY,
-          })}
-        >
-          {armorEnergyCapacity}
-        </div>
-      </div>
+      <div className={styles.energyValue}>{armorEnergyCapacity}</div>
       <div className={styles.arrow}>➜</div>
-      <div className={styles.energyValue}>
-        <div
-          className={clsx({
-            [styles.masterworked]: resultingEnergyCapacity >= MAX_ARMOR_ENERGY_CAPACITY,
-          })}
-        >
-          {resultingEnergyCapacity}
-        </div>
-      </div>
+      <div className={styles.energyValue}>{resultingEnergyCapacity}</div>
     </div>
   );
 }

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -274,22 +274,27 @@ function mapItemsToGroups(
     ].toString()}`;
   };
 
-  const energyGroups = Object.groupBy(mappedItems, ({ processItem }) =>
+  const firstPassGroups = Object.groupBy(mappedItems, ({ processItem }) =>
     firstPassGroupingFn(processItem),
   );
 
   // Final grouping by everything relevant
   const groups: ItemGroup[] = [];
 
+  // Checks if test is a superset of existing, i.e. every value of existing is contained in test
+  const isSuperset = <T>(test: Set<T>, existing: Set<T>) =>
+    [...existing.values()].every((v) => test.has(v));
+
   // Go through each grouping-by-energy-type, throw out any items with strictly worse properties than
   // another item in that group, then use what's left to build groups by their properties.
-  for (const group of Object.values(energyGroups)) {
+  for (const group of Object.values(firstPassGroups)) {
     const keepSet: MappedItem[] = [];
 
-    // Checks if test is a superset of existing, i.e. every value of existing is contained in test
-    const isSuperset = <T>(test: Set<T>, existing: Set<T>) =>
-      [...existing.values()].every((v) => test.has(v));
-
+    // TODO: Converge this is-better-stats logic with the one in
+    // search-filter/dupes.ts and the one in triage-utils.ts to create a single
+    // utility for figuring out if an item is strictly better than another. This
+    // will be important when considering Tuning mods and would involve
+    // correctly accounting for artifice mods in this function.
     const isStrictlyBetter = (testItem: MappedItem, existingItem: MappedItem) => {
       const testInfo = cache.get(testItem.dimItem)!;
       const existingInfo = cache.get(existingItem.dimItem)!;

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -315,6 +315,7 @@ export function getLoadoutStats(
       armorPiecesStats[hash] += itemStats[hash]?.[0].base ?? 0;
       // TODO: Edge of Fate: Tier 5 armor can have 11 energy - would be great if
       // we could read this from the item's energy info.
+      // TODO: See mappers.ts - we need a utility that figures out the correct masterwork level and then conditionally applies its stats
       armorPiecesStats[hash] +=
         itemEnergy !== undefined && itemEnergy >= MAX_ARMOR_ENERGY_CAPACITY && item.energy
           ? MASTERWORK_ARMOR_STAT_BONUS

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -8,7 +8,6 @@ import {
 import { ResolvedLoadoutMod } from 'app/loadout/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
 import { count, sumBy, uniqBy } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
@@ -363,7 +362,7 @@ function isModSelectable(
 
     // TODO: Edge of Fate: Tier 5 armor can have 11 energy. We'd need to pass
     // that in here somehow.
-    return lockedModCost + modCost <= MAX_ARMOR_ENERGY_CAPACITY;
+    return lockedModCost + modCost <= 10;
   }
 
   return true;

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -1,7 +1,7 @@
 import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ArmorEnergyRules } from 'app/loadout-builder/types';
-import { MAX_ARMOR_ENERGY_CAPACITY } from 'app/search/d2-known-values';
+import { maxEnergyCapacity } from 'app/search/d2-known-values';
 import { isArtifice } from 'app/utils/item-utils';
 
 /**
@@ -21,9 +21,7 @@ export function calculateAssumedItemEnergy(
     assumeArmorMasterwork === AssumeArmorMasterwork.All ||
     assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic ||
     (assumeArmorMasterwork === AssumeArmorMasterwork.Legendary && !item.isExotic)
-      ? // TODO: Edge of Fate: Tier 5 armor can have 11 energy - would be great if
-        // we could read this from the item's energy info.
-        MAX_ARMOR_ENERGY_CAPACITY
+      ? maxEnergyCapacity(item)
       : minItemEnergy;
   return Math.max(itemEnergy, assumedEnergy);
 }

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -16,6 +16,7 @@ export function calculateAssumedItemEnergy(
   if (!item.energy) {
     return 0;
   }
+  // Note: Since Edge of Fate, all new armor drops at max energy.
   const itemEnergy = item.energy.energyCapacity;
   const assumedEnergy =
     assumeArmorMasterwork === AssumeArmorMasterwork.All ||

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -6,8 +6,8 @@ import { ArmorEnergyRules } from 'app/loadout-builder/types';
 import { Assignment, PluggingAction } from 'app/loadout/loadout-types';
 import {
   ItemRarityName,
-  MAX_ARMOR_ENERGY_CAPACITY,
   armor2PlugCategoryHashesByName,
+  maxEnergyCapacity,
 } from 'app/search/d2-known-values';
 import { ModSocketMetadata } from 'app/search/specialty-modslots';
 import { count, mapValues, sumBy } from 'app/utils/collections';
@@ -160,14 +160,11 @@ function getUpgradeCost(
   newEnergy: number,
   needsArtifice: boolean,
 ) {
-  const maxEnergyCapacity = Math.max(
-    dimItem.energy?.energyCapacity ?? 0,
-    MAX_ARMOR_ENERGY_CAPACITY,
-  );
+  const maxEnergy = maxEnergyCapacity(dimItem);
   if (!model.byRarity[item.rarity]) {
     const plugs = getEnergyUpgradePlugs(dimItem);
-    const costsPerTier = Array<number[]>(maxEnergyCapacity);
-    for (let i = 0; i <= maxEnergyCapacity; i++) {
+    const costsPerTier = Array<number[]>(maxEnergy);
+    for (let i = 0; i <= maxEnergy; i++) {
       const previousTierCosts = costsPerTier[i - 1];
       costsPerTier[i] = previousTierCosts
         ? [...previousTierCosts]
@@ -189,7 +186,7 @@ function getUpgradeCost(
     model.byRarity[dimItem.rarity] = costsPerTier;
   }
   const needsEnhancing = item.rarity === 'Exotic' && needsArtifice && !isArtifice(dimItem);
-  const targetEnergy = needsEnhancing ? maxEnergyCapacity : newEnergy;
+  const targetEnergy = needsEnhancing ? maxEnergy : newEnergy;
   const rarityModel = model.byRarity[dimItem.rarity]!;
   const alreadyPaidCosts = rarityModel[item.originalCapacity];
 
@@ -494,7 +491,7 @@ export function fitMostMods({
       resultingItemEnergies[item.id] = {
         energyCapacity: itemEnergies[item.id].originalCapacity,
         energyUsed: requiresArtificeEnhancement
-          ? Math.max(item.energy.energyCapacity, MAX_ARMOR_ENERGY_CAPACITY)
+          ? maxEnergyCapacity(item)
           : sumBy(modsForItem, (mod) => mod.plug.energyCost?.energyCost ?? 0),
       };
     }

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -1,4 +1,5 @@
 import { CustomStatWeights } from '@destinyitemmanager/dim-api-types';
+import { DimItem } from 'app/inventory/item-types';
 import { ArmorStatHashes } from 'app/loadout-builder/types';
 import { HashLookup } from 'app/utils/util-types';
 import { TierType } from 'bungie-api-ts/destiny2';
@@ -21,6 +22,11 @@ export const d2MissingIcon = '/img/misc/missing_icon_d2.png';
 // GAME MECHANICS KNOWN VALUES
 //
 
+// In Edge of Fate, Tier 5 armor was introduced that has 11 energy instead of 10.
+export const maxEnergyCapacity = (item: DimItem): number => (item.tier === 5 ? 11 : 10);
+/**
+ * @deprecated: use `maxEnergyCapacity` instead
+ */
 export const MAX_ARMOR_ENERGY_CAPACITY = 10;
 export const MASTERWORK_ARMOR_STAT_BONUS = 2;
 

--- a/src/app/search/items/search-filters/stats-set.ts
+++ b/src/app/search/items/search-filters/stats-set.ts
@@ -63,17 +63,19 @@ export class StatsSet<T> {
    * stat be better or equal to the input, without being equal to the input stats. For example,
    * if the stat set contains:
    *
+   * ```
    * {
    *   [1, 2, 3],
    *   [1, 1, 2],
    *   [1, 1, 1]
    * }
+   * ```
    *
    * Then:
    *
-   * doBetterStatsExist([1, 2, 3]) === false
-   * doBetterStatsExist([1, 2, 2]) === true
-   * doBetterStatsExist([2, 1, 1]) === false
+   *   * `doBetterStatsExist([1, 2, 3]) === false`
+   *   * `doBetterStatsExist([1, 2, 2]) === true`
+   *   * `doBetterStatsExist([2, 1, 1]) === false`
    *
    * See tests for more examples.
    */

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -317,6 +317,20 @@ export function isArtificeSocket(socket: DimSocket) {
 }
 
 /**
+ * Is this the new-style armor masterwork in Edge of Fate that grants +1 to the three lower stats per tier?
+ */
+// TODO: May want to switch this to isLegacyArmorMasterwork eventually
+export function isEdgeOfFateArmorMasterwork(item: DimItem) {
+  return Boolean(item.sockets?.allSockets.some(isEdgeOfFateArmorMasterworkSocket));
+}
+
+export function isEdgeOfFateArmorMasterworkSocket(socket: DimSocket) {
+  return (
+    socket.plugged?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.V460PlugsArmorMasterworks
+  );
+}
+
+/**
  * Are two Destiny classes compatible? e.g. can an item (firstClass) be equipped
  * by a character (secondClass)? True if they're the same class or one is the
  * wildcard class.


### PR DESCRIPTION
1. I found more assumptions about max energy.
2. I found some places where we assume max energy == masterworked. I didn't fix them to add the new masterwork rules, but I at least stopped them adding +2 unconditionally for anything with 10 energy.
3. Fixed the construction of masterworkInfo for the new masterworks, which fixes the item popup bars
4. Added a bunch of TODO documentation

<img width="361" height="436" alt="Screenshot 2025-07-16 at 1 08 03 AM" src="https://github.com/user-attachments/assets/f81d5628-42b0-459d-841d-f38b02a4736e" />

Fixes #11179
Fixes #11184