### PR TITLE
Rudimentary Tier pips on item icon

### DIFF
--- a/src/app/inventory/ItemIcon.m.scss
+++ b/src/app/inventory/ItemIcon.m.scss
@@ -273,3 +273,22 @@ $rgb-masterworked: dim-hex-to-rgb-values($stat-masterworked);
 .strandColorFix {
   filter: hue-rotate(265deg) brightness(1.3);
 }
+
+.tierPipContainer {
+  position: absolute;
+  top: calc(var(--item-size) * 0.29);
+  left: calc(var(--item-size) * 0.11);
+  height: calc(var(--item-size) * 0.42);
+  display: flex;
+  flex-direction: column;
+  gap: 7%;
+}
+
+.tierPip {
+  display: block;
+  height: 14%;
+  aspect-ratio: 1;
+  background: #fffd;
+  rotate: 45deg;
+  outline: black solid 0.1px;
+}

--- a/src/app/inventory/ItemIcon.m.scss.d.ts
+++ b/src/app/inventory/ItemIcon.m.scss.d.ts
@@ -21,6 +21,8 @@ interface CssExports {
   'rare': string;
   'shinyMasterwork': string;
   'strandColorFix': string;
+  'tierPip': string;
+  'tierPipContainer': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -86,6 +86,15 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
           })}
         />
       )}
+      {item.tier > 1 ? (
+        <div className={styles.tierPipContainer}>
+          {Array(item.tier)
+            .fill(0)
+            .map((_, i) => (
+              <div key={i} className={styles.tierPip} />
+            ))}
+        </div>
+      ) : null}
       {item.plug?.energyCost !== undefined && item.plug.energyCost > 0 && (
         <>
           <div className={styles.energyCostOverlay} />


### PR DESCRIPTION
This does not have to be its final form, but it seems important to identify these tiles visually, to help make sure nothing's overlooked while triaging items in DIM. For now it's a hacky duplicate of the game display.

Pips start to appear on Tier 2 or higher.

GAME
<- Tier 2     Tier 1 ->
<img width="275" height="137" alt="image" src="https://github.com/user-attachments/assets/df98595a-0242-48a9-a200-79cfdeea3300" />

DIM:
<img width="290" height="182" alt="image" src="https://github.com/user-attachments/assets/e7b3851c-f5d6-483d-9501-995ab2f41c08" />
