### PR TITLE
restore seasonPassHash

### DIFF
--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -42,7 +42,7 @@ export default function Milestones({
   const season = profileInfo.profile?.data?.currentSeasonHash
     ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
     : undefined;
-  const seasonPass = season?.seasonPassList[0].seasonPassHash
+  const seasonPass = season?.seasonPassList[0]?.seasonPassHash
     ? defs.SeasonPass.get(season.seasonPassList[0].seasonPassHash)
     : undefined;
 

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -42,8 +42,8 @@ export default function Milestones({
   const season = profileInfo.profile?.data?.currentSeasonHash
     ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
     : undefined;
-  const seasonPass = season?.seasonPassHash
-    ? defs.SeasonPass.get(season.seasonPassHash)
+  const seasonPass = season?.seasonPassList[0].seasonPassHash
+    ? defs.SeasonPass.get(season.seasonPassList[0].seasonPassHash)
     : undefined;
 
   const milestoneItems = uniqBy(

--- a/src/app/stream-deck/util/packager.ts
+++ b/src/app/stream-deck/util/packager.ts
@@ -69,7 +69,7 @@ function getCurrentSeason(
   const season = profile?.profile?.data?.currentSeasonHash
     ? defs?.Season.get(profile.profile.data.currentSeasonHash)
     : undefined;
-  const seasonPass = season?.seasonPassList[0].seasonPassHash
+  const seasonPass = season?.seasonPassList[0]?.seasonPassHash
     ? defs?.SeasonPass.get(season.seasonPassList[0].seasonPassHash)
     : undefined;
   if (!season) {

--- a/src/app/stream-deck/util/packager.ts
+++ b/src/app/stream-deck/util/packager.ts
@@ -69,8 +69,8 @@ function getCurrentSeason(
   const season = profile?.profile?.data?.currentSeasonHash
     ? defs?.Season.get(profile.profile.data.currentSeasonHash)
     : undefined;
-  const seasonPass = season?.seasonPassHash
-    ? defs?.SeasonPass.get(season.seasonPassHash)
+  const seasonPass = season?.seasonPassList[0].seasonPassHash
+    ? defs?.SeasonPass.get(season.seasonPassList[0].seasonPassHash)
     : undefined;
   if (!season) {
     return [];


### PR DESCRIPTION
seasonPassHash is now under a list of hashes...

just hardcoding to [0] for now which restores original functionality, not sure what/where [1] is from/at.