### PR TITLE
Add an ErrorBoundary at the LO set level

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -619,9 +619,9 @@
     "Artifice": "Artifice",
     "AssumeMasterwork": "Assume Masterwork",
     "AssumeMasterworkOptions": {
-      "All": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
-      "AllWithArtificeExotic": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
-      "ArtificeExotic": "Armor 2.0 exotics enhanced to accept Artifice stat mods.",
+      "All": "Armor 2.0: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
+      "AllWithArtificeExotic": "Armor 2.0: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nArmor 2.0 Exotics: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
+      "ArtificeExotic": "Enhanced to accept Artifice stat mods.",
       "Legendary": "Legendary: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "None": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "Current": "Current stats, assumed energy level at least {{minLoItemEnergy}}.",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -621,7 +621,7 @@
     "AssumeMasterworkOptions": {
       "All": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
       "AllWithArtificeExotic": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
-      "ArtificeExotic": "Enhanced to accept Artifice stat mods.",
+      "ArtificeExotic": "Armor 2.0 exotics enhanced to accept Artifice stat mods.",
       "Legendary": "Legendary: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "None": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "Current": "Current stats, assumed energy level at least {{minLoItemEnergy}}.",

--- a/src/app/loadout-builder/filter/EnergyOptions.m.scss
+++ b/src/app/loadout-builder/filter/EnergyOptions.m.scss
@@ -7,4 +7,5 @@
 .tooltip {
   text-wrap: pretty;
   margin-top: 4px;
+  white-space: pre-wrap;
 }

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -107,8 +107,7 @@ export default memo(function GeneratedSet({
       errorLog(
         'loadout optimizer',
         'internal error: set rendering was unable to fit some mods that the worker thought were possible',
-        unassignedMods,
-        invalidMods,
+        { unassignedMods, invalidMods },
       );
     }
 

--- a/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSets.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from 'app/dim-ui/ErrorBoundary';
 import { WindowVirtualList } from 'app/dim-ui/VirtualList';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
@@ -52,20 +53,22 @@ export default function GeneratedSets({
       getItemKey={identity}
     >
       {(index) => (
-        <GeneratedSet
-          set={sets[index]}
-          selectedStore={selectedStore}
-          lockedMods={lockedMods}
-          pinnedItems={pinnedItems}
-          lbDispatch={lbDispatch}
-          desiredStatRanges={desiredStatRanges}
-          modStatChanges={modStatChanges}
-          loadouts={loadouts}
-          armorEnergyRules={armorEnergyRules}
-          originalLoadout={loadout}
-          equippedHashes={equippedHashes}
-          autoStatMods={autoStatMods}
-        />
+        <ErrorBoundary key={index} name="GeneratedSet">
+          <GeneratedSet
+            set={sets[index]}
+            selectedStore={selectedStore}
+            lockedMods={lockedMods}
+            pinnedItems={pinnedItems}
+            lbDispatch={lbDispatch}
+            desiredStatRanges={desiredStatRanges}
+            modStatChanges={modStatChanges}
+            loadouts={loadouts}
+            armorEnergyRules={armorEnergyRules}
+            originalLoadout={loadout}
+            equippedHashes={equippedHashes}
+            autoStatMods={autoStatMods}
+          />
+        </ErrorBoundary>
       )}
     </WindowVirtualList>
   );

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -2,7 +2,7 @@ import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ArmorEnergyRules } from 'app/loadout-builder/types';
 import { maxEnergyCapacity } from 'app/search/d2-known-values';
-import { isArtifice } from 'app/utils/item-utils';
+import { isArtifice, isEdgeOfFateArmorMasterwork } from 'app/utils/item-utils';
 
 /**
  * Gets the max energy we can use on this item, based on its current energy
@@ -28,13 +28,17 @@ export function calculateAssumedItemEnergy(
 }
 
 /**
- * as of TFS, [relevant, modern] exotics can use artifice stat mods, if the user pays to enhance the armor
+ * As of TFS, [relevant, modern] exotics could be upgraded to have an artifice
+ * mod slot. As of Edge of Fate / Armor 3.0, all new drops of exotics *cannot*
+ * be enhanced to have artifice stats, and exotic class items have been stripped
+ * of their artifice stat slot.
  */
 export function isAssumedArtifice(item: DimItem, { assumeArmorMasterwork }: ArmorEnergyRules) {
   return (
     (item.isExotic &&
       item.energy &&
-      assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic) ||
+      assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic &&
+      !isEdgeOfFateArmorMasterwork(item)) ||
     isArtifice(item)
   );
 }

--- a/src/app/shell/ErrorPanel.m.scss
+++ b/src/app/shell/ErrorPanel.m.scss
@@ -7,6 +7,7 @@
   padding: 0.85em;
   background: color.scale($red, $lightness: -90%);
   border-top: 4px solid $red;
+  user-select: text;
 
   h2 {
     margin: 0 0 8px 0 !important;

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -320,6 +320,7 @@ export function isArtificeSocket(socket: DimSocket) {
  * Is this the new-style armor masterwork in Edge of Fate that grants +1 to the three lower stats per tier?
  */
 // TODO: May want to switch this to isLegacyArmorMasterwork eventually
+// TODO: Maybe replace this with "isArmor3"?
 export function isEdgeOfFateArmorMasterwork(item: DimItem) {
   return Boolean(item.sockets?.allSockets.some(isEdgeOfFateArmorMasterworkSocket));
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -653,7 +653,7 @@
     "AssumeMasterworkOptions": {
       "All": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
       "AllWithArtificeExotic": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
-      "ArtificeExotic": "Enhanced to accept Artifice stat mods.",
+      "ArtificeExotic": "Armor 2.0 exotics enhanced to accept Artifice stat mods.",
       "Current": "Current stats, assumed energy level at least {{minLoItemEnergy}}.",
       "Legendary": "Legendary: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "Masterworked": "+2 in each stat, assumed energy level 10.",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -651,9 +651,9 @@
     "Artifice": "Artifice",
     "AssumeMasterwork": "Assume Masterwork",
     "AssumeMasterworkOptions": {
-      "All": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
-      "AllWithArtificeExotic": "All armor: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
-      "ArtificeExotic": "Armor 2.0 exotics enhanced to accept Artifice stat mods.",
+      "All": "Armor 2.0: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)",
+      "AllWithArtificeExotic": "Armor 2.0: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nArmor 2.0 Exotics: $t(LoadoutBuilder.AssumeMasterworkOptions.ArtificeExotic)",
+      "ArtificeExotic": "Enhanced to accept Artifice stat mods.",
       "Current": "Current stats, assumed energy level at least {{minLoItemEnergy}}.",
       "Legendary": "Legendary: $t(LoadoutBuilder.AssumeMasterworkOptions.Masterworked)\nExotic: $t(LoadoutBuilder.AssumeMasterworkOptions.Current)",
       "Masterworked": "+2 in each stat, assumed energy level 10.",


### PR DESCRIPTION
Corrects our can-assume-artifice logic to account for the fact that Armor 3.0 exotics cannot be given an artifice mod.

Fixes #11189.