### PR TITLE
Correctly calculate masterwork bonuses in loadouts

### DIFF
--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -1,18 +1,18 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { isPluggableItem } from 'app/inventory/store/sockets';
+import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
 import { calculateAssumedItemEnergy, isAssumedArtifice } from 'app/loadout/armor-upgrade-utils';
 import {
   activityModPlugCategoryHashes,
   knownModPlugCategoryHashes,
 } from 'app/loadout/known-values';
-import { MASTERWORK_ARMOR_STAT_BONUS, armorStats } from 'app/search/d2-known-values';
+import { armorStats } from 'app/search/d2-known-values';
 import { filterMap, mapValues, sumBy } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-types';
 import {
   getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadatas,
-  isEdgeOfFateArmorMasterwork,
 } from '../../utils/item-utils';
 import { AutoModData, ProcessArmorSet, ProcessItem, ProcessMod } from '../process-worker/types';
 import {
@@ -57,33 +57,10 @@ export function mapDimItemToProcessItem({
   armorEnergyRules: ArmorEnergyRules;
   modsForSlot?: PluggableInventoryItemDefinition[];
 }): ProcessItem {
-  const { id, hash, name, isExotic, power, stats: dimItemStats } = dimItem;
+  const { id, hash, name, isExotic, power } = dimItem;
 
-  const newMasterworkType = isEdgeOfFateArmorMasterwork(dimItem);
-
-  const statMap: { [statHash: number]: number } = {};
+  const stats = calculateAssumedMasterworkStats(dimItem, armorEnergyRules);
   const capacity = calculateAssumedItemEnergy(dimItem, armorEnergyRules);
-
-  if (dimItemStats) {
-    // TODO: Rather than patch this directly, figure out what mod we'd insert
-    // for the given assume-masterwork level, and apply its stats
-    //   1. Find the correct masterwork socket on the item
-    //   2. Look through the plugset attached to that socket for the correct masterwork level
-    //   3. Evaluate conditional stats
-    //   4. Apply the stats to the item
-    // Alternatively, once we pick the right masterwork mod, we could use socketOverrides to get a resolved item with stats
-    for (const { statHash, base } of dimItemStats) {
-      let value = base;
-      if (!newMasterworkType && capacity >= 10) {
-        // Legacy masterwork armor gives +2 in each stat once you hit max energy
-        value += MASTERWORK_ARMOR_STAT_BONUS;
-      } else {
-        // TODO: Apply the new masterwork bonus to the three lower stats
-      }
-      statMap[statHash] = value;
-    }
-  }
-
   const modMetadatas = getSpecialtySocketMetadatas(dimItem);
   const modsCost = modsForSlot
     ? sumBy(modsForSlot, (mod) => mod.plug.energyCost?.energyCost ?? 0)
@@ -98,7 +75,7 @@ export function mapDimItemToProcessItem({
     isExotic,
     isArtifice: assumeArtifice,
     power,
-    stats: statMap,
+    stats,
     remainingEnergyCapacity: capacity - modsCost,
     compatibleModSeasons: modMetadatas?.map((m) => m.slotTag),
   };

--- a/src/app/loadout/armor-upgrade-utils.ts
+++ b/src/app/loadout/armor-upgrade-utils.ts
@@ -9,21 +9,15 @@ import { isArtifice, isEdgeOfFateArmorMasterwork } from 'app/utils/item-utils';
  * level and the passed in ArmorEnergyRules that allow us to pretend the item
  * has more energy.
  */
-export function calculateAssumedItemEnergy(
-  item: DimItem,
-  { assumeArmorMasterwork, minItemEnergy }: ArmorEnergyRules,
-) {
+export function calculateAssumedItemEnergy(item: DimItem, armorEnergyRules: ArmorEnergyRules) {
   if (!item.energy) {
     return 0;
   }
   // Note: Since Edge of Fate, all new armor drops at max energy.
   const itemEnergy = item.energy.energyCapacity;
-  const assumedEnergy =
-    assumeArmorMasterwork === AssumeArmorMasterwork.All ||
-    assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic ||
-    (assumeArmorMasterwork === AssumeArmorMasterwork.Legendary && !item.isExotic)
-      ? maxEnergyCapacity(item)
-      : minItemEnergy;
+  const assumedEnergy = isAssumedMasterworked(item, armorEnergyRules)
+    ? maxEnergyCapacity(item)
+    : armorEnergyRules.minItemEnergy;
   return Math.max(itemEnergy, assumedEnergy);
 }
 
@@ -40,5 +34,16 @@ export function isAssumedArtifice(item: DimItem, { assumeArmorMasterwork }: Armo
       assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic &&
       !isEdgeOfFateArmorMasterwork(item)) ||
     isArtifice(item)
+  );
+}
+
+/**
+ * Does the armor energy rules mean that this item is assumed to be masterworked?
+ */
+export function isAssumedMasterworked(item: DimItem, { assumeArmorMasterwork }: ArmorEnergyRules) {
+  return (
+    assumeArmorMasterwork === AssumeArmorMasterwork.All ||
+    assumeArmorMasterwork === AssumeArmorMasterwork.ArtificeExotic ||
+    (assumeArmorMasterwork === AssumeArmorMasterwork.Legendary && !item.isExotic)
   );
 }


### PR DESCRIPTION
This manually calculates the correct masterwork bonuses based on the new Armor 3.0 rules.

This can be a bit hard to see, but here's an example. This Exotic Class Item is MW level 2, and I have Assume Masterwork set to "+Exotic".

Class Item:
<img width="389" height="331" alt="Screenshot 2025-07-16 at 10 51 03 PM" src="https://github.com/user-attachments/assets/b001db52-88ac-4054-887d-bd3eb29b7e1e" />

Before, the +2 contribution from the exotic wasn't counted at all (e.g. Health 72):
<img width="690" height="149" alt="Screenshot 2025-07-16 at 10 50 01 PM" src="https://github.com/user-attachments/assets/8bae8755-0d72-41ea-a4ae-4966a6d65757" />
And in the Loadout stats, it's 64 - doesn't even include the +2 each from the other masterworked items:
<img width="307" height="215" alt="Screenshot 2025-07-16 at 10 50 06 PM" src="https://github.com/user-attachments/assets/19474f82-276f-449a-ba11-931c2c1b9595" />

After, Health is 77, meaning it includes the +5 from the exotic:
<img width="667" height="144" alt="Screenshot 2025-07-16 at 10 48 48 PM" src="https://github.com/user-attachments/assets/38ff7760-957c-407b-9beb-05d28daa314c" />
And in the Loadout stats, it's 70, which includes +2 from the exotic and two masterworks.
<img width="302" height="214" alt="Screenshot 2025-07-16 at 10 48 56 PM" src="https://github.com/user-attachments/assets/c7163f4b-42c8-4ad7-ba8b-efa07b60055c" />