### PR TITLE
update sentry workflow

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -96,5 +96,5 @@ jobs:
           SENTRY_PROJECT: dim
         with:
           environment: beta
-          version: ${{ env.VERSION }}
+          release: ${{ env.VERSION }}
           ignore_missing: true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -81,5 +81,5 @@ jobs:
           SENTRY_PROJECT: dim
         with:
           environment: release
-          version: ${{ steps.package-version.outputs.current-version }}
+          release: ${{ steps.package-version.outputs.current-version }}
           ignore_missing: true


### PR DESCRIPTION
update sentry to use "release" instead of "version"

<img width="2144" height="361" alt="image" src="https://github.com/user-attachments/assets/51e32ec9-4ae5-4690-bc2e-37c1dd230644" />
