### PR TITLE
Restore conditional stat handling for Echo of Persistence and Spark of Focus

### DIFF
--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -354,6 +354,8 @@ export const breakerTypeNames = Object.entries(breakerTypes)
 export const enum ModsWithConditionalStats {
   ElementalCapacitor = 3511092054, // InventoryItem "Elemental Capacitor"
   EnhancedElementalCapacitor = 711234314, // InventoryItem "Elemental Capacitor"
+  EchoOfPersistence = 2272984671, // InventoryItem "Echo of Persistence"
+  SparkOfFocus = 1727069360, // InventoryItem "Spark of Focus"
 }
 
 export const ARTIFICE_PERK_HASH = 3727270518; // InventoryItem "Artifice Armor"


### PR DESCRIPTION
I had removed conditional stat handling from these fragments, because they claim to affect class energy regeneration, and now there's a stat dedicated to that, so to do what they say they do, you'd just affect the Class stat, right? You wouldn't need to be conditional.

But no, they actually didn't modify these fragments at all, and they continue to affect different stats on different classes.

Fixes #11180