### PR TITLE
stream deck cleanup/update for EoF

### DIFF
--- a/src/app/item-actions/ItemAccessoryButtons.tsx
+++ b/src/app/item-actions/ItemAccessoryButtons.tsx
@@ -51,7 +51,7 @@ export default function ItemAccessoryButtons({
       {actionsModel.infusable && (
         <InfuseActionButton item={item} label={showLabel} actionModel={actionsModel} />
       )}
-      {streamDeckEnabled && <OpenOnStreamDeckButton label={showLabel} item={item} />}
+      {streamDeckEnabled && <OpenOnStreamDeckButton type="item" label={showLabel} item={item} />}
     </>
   );
 }

--- a/src/app/item-popup/ItemPopup.tsx
+++ b/src/app/item-popup/ItemPopup.tsx
@@ -11,6 +11,8 @@ import ItemAccessoryButtons from 'app/item-actions/ItemAccessoryButtons';
 import ItemMoveLocations from 'app/item-actions/ItemMoveLocations';
 import type { ItemRarityName } from 'app/search/d2-known-values';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import OpenOnStreamDeckButton from 'app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton';
+import { streamDeckEnabledSelector } from 'app/stream-deck/selectors';
 import { nonPullablePostmasterItem } from 'app/utils/item-utils';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
@@ -76,6 +78,11 @@ export default function ItemPopup({
     () => item && buildItemActionsModel(item, stores),
     [item, stores],
   );
+
+  const streamDeckEnabled = $featureFlags.elgatoStreamDeck
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useSelector(streamDeckEnabledSelector)
+    : false;
 
   const failureStrings = Array.from(extraInfo?.failureStrings ?? []);
 
@@ -148,6 +155,9 @@ export default function ItemPopup({
               <div className={clsx(styles.desktopPopupBody, styles.popupBackground)}>
                 {header}
                 {content}
+                {streamDeckEnabled && item.bucket.inInventory && (
+                  <OpenOnStreamDeckButton type="inventory-item" label item={item} />
+                )}
               </div>
               {itemActionsModel.hasControls && (
                 <div className={styles.desktopActions}>

--- a/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
+++ b/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
@@ -1,6 +1,7 @@
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import ActionButton from 'app/item-actions/ActionButton';
+import { BucketHashes } from 'data/d2/generated-enums';
 import streamDeckIcon from 'images/streamDeck.svg';
 import { useMemo } from 'react';
 import { useStreamDeckSelection } from '../stream-deck';
@@ -25,7 +26,7 @@ export default function OpenOnStreamDeckButton({
 
   const deepLink = useStreamDeckSelection({
     options,
-    equippable: type === 'inventory-item' ? undefined : !item.notransfer,
+    equippable: !item.notransfer || item.bucket.hash === BucketHashes.Subclass,
   });
 
   if (!deepLink) {

--- a/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
+++ b/src/app/stream-deck/OpenOnStreamDeckButton/OpenOnStreamDeckButton.tsx
@@ -1,25 +1,31 @@
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
 import ActionButton from 'app/item-actions/ActionButton';
-import { BucketHashes } from 'data/d2/generated-enums';
 import streamDeckIcon from 'images/streamDeck.svg';
 import { useMemo } from 'react';
 import { useStreamDeckSelection } from '../stream-deck';
 import styles from './OpenOnStreamDeckButton.m.scss';
 
-export default function OpenOnStreamDeckButton({ item, label }: { item: DimItem; label: boolean }) {
+export default function OpenOnStreamDeckButton({
+  item,
+  label,
+  type,
+}: {
+  item: DimItem;
+  label: boolean;
+  type: 'inventory-item' | 'item';
+}) {
   const options = useMemo(
     () => ({
-      type: 'item' as const,
+      type,
       item,
-      isSubClass: item.bucket.hash === BucketHashes.Subclass,
     }),
-    [item],
+    [item, type],
   );
 
   const deepLink = useStreamDeckSelection({
     options,
-    equippable: !item.notransfer,
+    equippable: type === 'inventory-item' ? undefined : !item.notransfer,
   });
 
   if (!deepLink) {

--- a/src/app/stream-deck/actions.ts
+++ b/src/app/stream-deck/actions.ts
@@ -1,6 +1,6 @@
 import { createAction } from 'typesafe-actions';
 
-export type SelectionType = 'item' | 'loadout' | 'postmaster' | undefined;
+export type SelectionType = 'item' | 'loadout' | 'inventory-item' | 'postmaster' | undefined;
 
 export interface StreamDeckAuth {
   instance: string;

--- a/src/app/stream-deck/async-module.ts
+++ b/src/app/stream-deck/async-module.ts
@@ -36,6 +36,7 @@ function refreshStreamDeck(state: RootState) {
           postmaster: packager.postmaster(store),
           metrics: packager.metrics(state),
           vault: packager.vault(state),
+          inventory: packager.inventoryCounters(state),
           maxPower: packager.maxPower(store, state),
           equippedItems: packager.equippedItems(store),
         },

--- a/src/app/stream-deck/interfaces.ts
+++ b/src/app/stream-deck/interfaces.ts
@@ -138,7 +138,11 @@ interface SendStateArgs {
     maxPower?: MaxPowerArgs;
     equippedItems?: string[];
     metrics?: MetricsArgs;
+    /**
+     * @deprecated replaced by`inventory`.
+     */
     vault?: VaultArgs;
+    inventory?: Record<string, number>;
   };
 }
 

--- a/src/app/stream-deck/interfaces.ts
+++ b/src/app/stream-deck/interfaces.ts
@@ -10,6 +10,7 @@ export interface SearchAction {
   action: 'search';
   query: string;
   page: string;
+  append?: boolean;
   pullItems?: boolean;
   sendToVault?: boolean;
 }
@@ -99,12 +100,7 @@ interface VaultArgs {
 }
 
 interface MetricsArgs {
-  gambit: number;
-  vanguard: number;
-  crucible: number;
-  trials: number;
   gunsmith: number;
-  ironBanner: number;
   triumphs: number;
   triumphsActive: number;
   battlePass: number;
@@ -166,6 +162,7 @@ interface SendPickerItemsArgs {
     items: {
       item: string;
       icon: string;
+      tier?: number;
       overlay?: string;
       isExotic?: boolean;
       element?: string;

--- a/src/app/stream-deck/msg-handlers.ts
+++ b/src/app/stream-deck/msg-handlers.ts
@@ -71,6 +71,7 @@ function requestPickerItemsHandler({
           label: item.name,
           item: streamDeckClearId(item.index),
           icon: item.icon,
+          tier: item.tier,
           overlay: item.iconOverlay,
           isExotic: item.isExotic,
           isCrafted: Boolean(item.crafted),
@@ -101,8 +102,19 @@ function searchHandler({ msg, state, store }: HandlerArgs<SearchAction>): ThunkR
         // delay a bit to trigger the search
         await delay(250);
       }
+
+      let query = state.shell.searchQuery;
+
+      if (msg.append) {
+        query += ` ${msg.query}`;
+      } else if (query !== msg.query) {
+        query = msg.query;
+      } else {
+        query = '';
+      }
+
       // update the search query
-      dispatch(setSearchQuery(state.shell.searchQuery === msg.query ? '' : msg.query));
+      dispatch(setSearchQuery(query));
     } else if (msg.query) {
       // reset any previous search
       dispatch(setSearchQuery(''));

--- a/src/app/stream-deck/useStreamDeckSelection.ts
+++ b/src/app/stream-deck/useStreamDeckSelection.ts
@@ -11,7 +11,7 @@ import { streamDeckSelectionSelector } from './selectors';
 import { STREAM_DECK_DEEP_LINK } from './util/authorization';
 import { streamDeckClearId } from './util/packager';
 
-export type StreamDeckSelectionOptions = (
+export type StreamDeckSelectionOptions =
   | {
       type: 'in-game-loadout';
       loadout: InGameLoadout;
@@ -28,8 +28,7 @@ export type StreamDeckSelectionOptions = (
   | {
       type: 'inventory-item';
       item: DimItem;
-    }
-) & { isSubClass?: boolean };
+    };
 
 function findSubClassIcon(items: LoadoutItem[], state: RootState) {
   const defs = d2ManifestSelector(state);
@@ -74,10 +73,11 @@ const toSelection = (data: StreamDeckSelectionOptions) => (state: RootState) => 
         label: item.name,
         subtitle: item.typeName,
         item: streamDeckClearId(item.index),
+        tier: item.tier,
         icon: item.icon,
         overlay: item.iconOverlay,
         isExotic: item.isExotic,
-        isSubClass: data.isSubClass,
+        isSubClass: item.bucket.hash === BucketHashes.Subclass,
         isCrafted: Boolean(item.crafted),
         element:
           item.element?.enumValue === DamageType.Kinetic
@@ -129,9 +129,7 @@ const types = {
 function useSelection({ equippable, options }: UseStreamDeckSelectionArgs): string | undefined {
   const type = types[options.type];
   const selection = useSelector(streamDeckSelectionSelector);
-  const canSelect = Boolean(
-    (equippable || options.isSubClass || type === 'inventory-item') && selection === type,
-  );
+  const canSelect = Boolean((equippable || type === 'inventory-item') && selection === type);
   return useSelector(toSelectionHref(canSelect, options));
 }
 

--- a/src/app/stream-deck/useStreamDeckSelection.ts
+++ b/src/app/stream-deck/useStreamDeckSelection.ts
@@ -25,6 +25,10 @@ export type StreamDeckSelectionOptions = (
       type: 'item';
       item: DimItem;
     }
+  | {
+      type: 'inventory-item';
+      item: DimItem;
+    }
 ) & { isSubClass?: boolean };
 
 function findSubClassIcon(items: LoadoutItem[], state: RootState) {
@@ -81,6 +85,17 @@ const toSelection = (data: StreamDeckSelectionOptions) => (state: RootState) => 
             : item.element?.displayProperties?.icon,
       };
     }
+    case 'inventory-item': {
+      const { item } = data;
+      return {
+        type: 'inventory-item',
+        label: item.name,
+        subtitle: item.typeName,
+        item: streamDeckClearId(item.index),
+        icon: item.icon,
+        isExotic: item.isExotic,
+      };
+    }
   }
 };
 
@@ -101,13 +116,22 @@ const toSelectionHref =
 
 export interface UseStreamDeckSelectionArgs {
   options: StreamDeckSelectionOptions;
-  equippable: boolean;
+  equippable: boolean | undefined;
 }
 
+const types = {
+  item: 'item',
+  loadout: 'loadout',
+  'in-game-loadout': 'in-game-loadout',
+  'inventory-item': 'inventory-item',
+};
+
 function useSelection({ equippable, options }: UseStreamDeckSelectionArgs): string | undefined {
-  const type = options.type === 'item' ? 'item' : 'loadout';
+  const type = types[options.type];
   const selection = useSelector(streamDeckSelectionSelector);
-  const canSelect = Boolean((equippable || options.isSubClass) && selection === type);
+  const canSelect = Boolean(
+    (equippable || options.isSubClass || type === 'inventory-item') && selection === type,
+  );
   return useSelector(toSelectionHref(canSelect, options));
 }
 

--- a/src/app/stream-deck/util/packager.ts
+++ b/src/app/stream-deck/util/packager.ts
@@ -102,12 +102,7 @@ function metrics(state: RootState) {
     : seasonProgress?.level;
 
   return {
-    gambit: 0, // progression[3008065600].currentProgress,
-    vanguard: 0, // progression[457612306].currentProgress,
-    crucible: 0, // progression[2083746873].currentProgress,
-    trials: 0, // progression[2755675426].currentProgress,
     gunsmith: progression[1471185389].currentProgress,
-    ironBanner: 0, // progression[599071390].currentProgress,
     triumphs: lifetimeScore ?? 0,
     triumphsActive: activeScore ?? 0,
     battlePass: battlePassHash ? seasonalRank : 0,

--- a/src/app/stream-deck/util/packager.ts
+++ b/src/app/stream-deck/util/packager.ts
@@ -123,6 +123,24 @@ function equippedItems(store?: DimStore) {
   return store?.items.filter((it) => it.equipment).map((it) => streamDeckClearId(it.index)) ?? [];
 }
 
+function inventoryCounters(state?: RootState) {
+  return state?.inventory.stores
+    .flatMap((it) => it.items)
+    .filter((it) => it.bucket.inInventory)
+    .reduce(
+      (acc, it) => {
+        const key = streamDeckClearId(it.index);
+        if (acc[key]) {
+          acc[key] += it.amount;
+        } else {
+          acc[key] = it.amount;
+        }
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+}
+
 function character(store: DimStore) {
   return {
     class: store.classType,
@@ -193,4 +211,5 @@ export default {
   maxPower,
   postmaster,
   equippedItems,
+  inventoryCounters,
 };


### PR DESCRIPTION
Hello there, I've done some updates for the latest stream deck plugin and some cleanup/update for Edge of Fate:

- removed progress metrics (no more available)
- added new "append only" mode to append filters to search query from plugin (search action)
- now the state sent to the plugin includes also the counters of inventory items grouped by element id (vault action)
- restored subclass item pick
- added `tier` to selection/picker action

Bye 😄 