### PR TITLE
Add sorting inventory by tier

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1241,6 +1241,7 @@
     "SortByRating": "Armor Quality (D1)",
     "SortByRecent": "Recently Acquired (D2)",
     "SortByTag": "Tag ({{taglist}})",
+    "SortByTier": "Tier (D2)",
     "SortByType": "Type",
     "SortBySeason": "Season (D2)",
     "SortByWeaponElement": "Damage Type",

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -179,6 +179,7 @@ export default function SettingsPage() {
     crafted: t('Settings.SortByCrafted'),
     deepsight: t('Settings.SortByDeepsight'),
     featured: t('Settings.SortByFeatured'),
+    tier: t('Settings.SortByTier'),
   };
 
   const vaultWeaponGroupingOptions = mapToOptions({

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -284,6 +284,8 @@ const ITEM_COMPARATORS: {
   deepsight: compareBy((item) => (item.deepsightInfo ? 1 : 2)),
   // featured -> not featured
   featured: compareBy((item) => (item.featured ? 0 : 1)),
+  // high -> low
+  tier: reverseComparator(compareBy((item) => item.tier)),
   default: () => 0,
 };
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1224,6 +1224,7 @@
     "SortByRecent": "Recently Acquired (D2)",
     "SortBySeason": "Season (D2)",
     "SortByTag": "Tag ({{taglist}})",
+    "SortByTier": "Tier (D2)",
     "SortByType": "Type",
     "SortByWeaponElement": "Damage Type",
     "SortCustom": "Custom Sort",


### PR DESCRIPTION
Now that we show pips on the tiles we can have an inventory sort for tier too.