### PR TITLE
Feature/fix: Include Perk-provided stats in stat bar math

### DIFF
--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -96,6 +96,17 @@
     }
   }
 
+  &.trait {
+    order: 3;
+    background-color: #4887ba;
+    & + &.trait {
+      opacity: 0.8;
+      & + &.trait {
+        opacity: 0.6;
+      }
+    }
+  }
+
   // Colors for the stat bars
   &.masterwork {
     order: 4;
@@ -114,6 +125,9 @@
 
   .mod {
     color: $stat-modded;
+  }
+  .trait {
+    color: #4887ba;
   }
   .masterwork {
     color: $stat-masterworked;

--- a/src/app/item-popup/ItemStat.m.scss.d.ts
+++ b/src/app/item-popup/ItemStat.m.scss.d.ts
@@ -26,6 +26,7 @@ interface CssExports {
   'totalStatMasterwork': string;
   'totalStatModded': string;
   'totalStatNegativeModded': string;
+  'trait': string;
   'value': string;
 }
 export const cssExports: CssExports;


### PR DESCRIPTION
<img width="649" height="374" alt="image" src="https://github.com/user-attachments/assets/ec76c7f2-6f76-472f-aa99-0b3b1418341e" />

Highlights stat contributions from weapon perks, instead of lumping them in with "base stats".