### PR TITLE
Swap tier number for pips, move banner to the left

### DIFF
--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -1,6 +1,8 @@
 @use '../variables.scss' as *;
 @use 'sass:math';
 
+$iconOverlayScale: math.div(65, 92);
+
 .header {
   composes: resetButton from 'app/dim-ui/common.m.scss';
   display: block;
@@ -15,7 +17,7 @@
   color: #eee;
 
   &:has(.iconOverlay) {
-    padding-right: 20px;
+    padding-left: 10px + 24px * $iconOverlayScale;
   }
 }
 
@@ -134,19 +136,27 @@
 }
 
 .iconOverlay {
-  $scale: math.div(65, 92);
   composes: flexColumn from '../dim-ui/common.m.scss';
   position: absolute;
   box-sizing: border-box;
   align-items: center;
+  gap: 7%;
   top: 0;
-  right: 0;
-  width: 24px * $scale;
-  height: 96px * $scale;
+  left: 0;
+  width: 24px * $iconOverlayScale;
+  height: 96px * $iconOverlayScale;
   background-size: cover;
-  background-position: -2px * $scale -2px * $scale;
+  background-position: -2px * $iconOverlayScale -2px * $iconOverlayScale;
   background-repeat: no-repeat;
   pointer-events: none;
-  padding-top: 28px * $scale;
+  padding-top: 30px * $iconOverlayScale;
   font-size: 12px;
+}
+
+.tierPip {
+  display: block;
+  height: 4px;
+  aspect-ratio: 1;
+  background: #fffd;
+  rotate: 45deg;
 }

--- a/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
+++ b/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
@@ -15,6 +15,7 @@ interface CssExports {
   'pursuit': string;
   'rare': string;
   'subtitle': string;
+  'tierPip': string;
   'title': string;
   'type': string;
   'uncommon': string;

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -86,7 +86,15 @@ export default function ItemPopupHeader({
       </div>
       {item.iconOverlay && (
         <div className={styles.iconOverlay} style={bungieBackgroundStyle(item.iconOverlay)}>
-          {item.tier !== 0 ? item.tier : null}
+          {item.tier !== 0 ? (
+            <>
+              {Array(item.tier)
+                .fill(0)
+                .map((_, i) => (
+                  <div key={i} className={styles.tierPip} />
+                ))}
+            </>
+          ) : null}
         </div>
       )}
       {showArmory && linkToArmory && (


### PR DESCRIPTION
<img width="320" height="63" alt="Screenshot 2025-07-23 at 10 48 31 PM" src="https://github.com/user-attachments/assets/dfbc7270-f1c4-4a9f-aec8-50dcdddb98ec" />

I still think this looks pretty stupid, but moving it to the left makes room for the mobile close button, and the pips do look better than the number.

Fixes #11223
Fixes #11222