### PR TITLE
Improve contrast of red numbers on black background

### DIFF
--- a/src/app/shell/formatters.ts
+++ b/src/app/shell/formatters.ts
@@ -21,7 +21,7 @@ export function getCompareColor(value: number) {
   if (value < 0) {
     color = '#e0e0e0';
   } else if (value < 50) {
-    color = 'hsl(0, 45.20%, 50.60%)';
+    color = 'rgb(253 98 98)';
   } else if (value < 80) {
     color = 'hsl(49, 58.60%, 56.50%)';
   } else if (value < 100) {


### PR DESCRIPTION
![](https://cdn.discordapp.com/attachments/1397223938546995221/1397805405643608094/Screenshot_2025-07-23_at_9.59.29_PM.png?ex=6885b23a&is=688460ba&hm=027794e8152c9727da4e8151480235d5931276773653c24a37d4ef301b4faa8a&)

I never got a response about whether this is better for colorblind users but it *is* meeting the WCAG AAA contrast requirement now.

Changelog: Increased the contrast of red numbers against a black background.