### PR TITLE
Update changelog updater

### DIFF
--- a/.github/workflows/changelog-updater.yml
+++ b/.github/workflows/changelog-updater.yml
@@ -30,7 +30,19 @@ jobs:
         run: |
           # Extract commit SHAs from the push event
           COMMIT_SHAS=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[].id' | tr '\n' ' ')
-          node build/update-changelog.js $COMMIT_SHAS > docs/CHANGELOG.md.new
+
+          # Check if any commit is a merge commit (indicates a merged PR)
+          MERGE_COMMIT_SHA=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[] | select(.message | startswith("Merge pull request #")) | .id' | head -1)
+
+          # If there's a merge commit, extract the PR number
+          if [ -n "$MERGE_COMMIT_SHA" ]; then
+            PR_NUMBER=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[] | select(.message | startswith("Merge pull request #")) | .message' | head -1 | sed -n 's/Merge pull request #\([0-9]*\).*/\1/p')
+            echo "Found merged PR #$PR_NUMBER"
+            node build/update-changelog.js --pr-number="$PR_NUMBER" $COMMIT_SHAS > docs/CHANGELOG.md.new
+          else
+            node build/update-changelog.js $COMMIT_SHAS > docs/CHANGELOG.md.new
+          fi
+
           mv docs/CHANGELOG.md.new docs/CHANGELOG.md
 
       - name: Commit files


### PR DESCRIPTION
Claude neglected to mention that the GitHub event data only gives the first line of commits, so our changelog bot wasn't working. Let's try loading the full commit data and PR description from the API.

Changelog: Testing changelog bot.