### PR TITLE
Consider exotics the same if they have the same name

### DIFF
--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -36,12 +36,12 @@ export function findLockableExotics(
   classType: DestinyClass,
   defs: D2ManifestDefinitions,
 ) {
-  // Find all the armor 2 exotics.
+  // Find all the armor 2/3 exotics.
   const exotics = uniqBy(
     [...allItems, ...vendorItems]
       .filter((item) => item.isExotic && item.classType === classType && isLoadoutBuilderItem(item))
       .sort(compareByIndex(ArmorBucketHashes, (item) => item.bucket.hash)),
-    (item) => item.hash,
+    (item) => item.name,
   );
 
   // Add in armor 1 exotics that don't have an armor 2 version


### PR DESCRIPTION
Fixes #11193.

Changelog: Fixed an issue where the Loadout Optimizer would consider Armor 3.0 and Armor 2.0 versions of exotics separately. Now, if you select an exotic, all your copies of that exotic will be considered.