### PR TITLE
Load associated PRs' info in changelog bot

### DIFF
--- a/.github/workflows/changelog-updater.yml
+++ b/.github/workflows/changelog-updater.yml
@@ -30,19 +30,9 @@ jobs:
         run: |
           # Extract commit SHAs from the push event
           COMMIT_SHAS=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[].id' | tr '\n' ' ')
-
-          # Check if any commit is a merge commit (indicates a merged PR)
-          MERGE_COMMIT_SHA=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[] | select(.message | startswith("Merge pull request #")) | .id' | head -1)
-
-          # If there's a merge commit, extract the PR number
-          if [ -n "$MERGE_COMMIT_SHA" ]; then
-            PR_NUMBER=$(echo '${{ toJson(github.event.commits) }}' | jq -r '.[] | select(.message | startswith("Merge pull request #")) | .message' | head -1 | sed -n 's/Merge pull request #\([0-9]*\).*/\1/p')
-            echo "Found merged PR #$PR_NUMBER"
-            node build/update-changelog.js --pr-number="$PR_NUMBER" $COMMIT_SHAS > docs/CHANGELOG.md.new
-          else
-            node build/update-changelog.js $COMMIT_SHAS > docs/CHANGELOG.md.new
-          fi
-
+          
+          # Process all commits and automatically detect associated PRs using GitHub API
+          node build/update-changelog.js $COMMIT_SHAS > docs/CHANGELOG.md.new
           mv docs/CHANGELOG.md.new docs/CHANGELOG.md
 
       - name: Commit files


### PR DESCRIPTION
Give Claude another chance to redeem itself. Now it's loading associated PRs' info from the GraphQL API to try and really get the right answer.

Changelog: Testing changelog.