### PR TITLE
Items that don't have the stat being searched will never match a stat range

### DIFF
--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -175,7 +175,11 @@ function statFilterFromString(
     const statHash = statHashByName[statNames];
     return (item) => {
       const statValuesByHash = getStatValuesByHash(item, byWhichValue);
-      return compare(statValuesByHash[statHash] || 0);
+      const statValue = statValuesByHash[statHash];
+      if (statValue === undefined) {
+        return false;
+      }
+      return compare(statValue);
     };
   }
   const statCombiner = createStatCombiner(statNames, byWhichValue, customStats);


### PR DESCRIPTION
This is the issue from Discord where `stat:rpm:<100` matches a ton of random junk because none of them have an RPM stat.

Changelog: Stat range searches (e.g. `stat:rpm:<100`) will no longer match items that don't have that stat.