### PR TITLE
Save stat ranges with defaults

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -179,11 +179,16 @@ export default memo(function LoadoutBuilder({
     [armorItems, modsToAssign],
   );
 
-  const hasPreloadedLoadout = Boolean(preloadedLoadout);
+  // If the user is playing with an existing loadout (potentially one they
+  // received from a loadout share) or a direct /optimizer link, do not
+  // overwrite the global saved loadout parameters. If they decide to save that
+  // loadout, these will still be saved with the loadout. For these purposes we
+  // won't consider the equipped loadout to be a preloaded loadout.
+  const saveParamsAsDefaults = !(preloadedLoadout && preloadedLoadout.id !== 'equipped');
   // Save a subset of the loadout parameters to settings in order to remember them between sessions
-  useSaveLoadoutParameters(hasPreloadedLoadout, loadoutParameters);
+  useSaveLoadoutParameters(saveParamsAsDefaults, loadoutParameters);
   useSaveStatConstraints(
-    hasPreloadedLoadout,
+    saveParamsAsDefaults,
     statConstraints,
     savedStatConstraintsByClass,
     classType,
@@ -589,17 +594,13 @@ function useArmorItems(classType: DestinyClass, vendorItems: DimItem[]): DimItem
  * Save a subset of the loadout parameters to settings in order to remember them between sessions
  */
 function useSaveLoadoutParameters(
-  hasPreloadedLoadout: boolean,
+  saveParamsAsDefaults: boolean,
   loadoutParameters: LoadoutParameters,
 ) {
   const setSetting = useSetSetting();
   const firstRun = useRef(true);
   useEffect(() => {
-    // If the user is playing with an existing loadout (potentially one they
-    // received from a loadout share) or a direct /optimizer link, do not
-    // overwrite the global saved loadout parameters. If they decide to save
-    // that loadout, these will still be saved with the loadout.
-    if (hasPreloadedLoadout) {
+    if (!saveParamsAsDefaults) {
       return;
     }
 
@@ -618,7 +619,7 @@ function useSaveLoadoutParameters(
     setSetting,
     loadoutParameters.assumeArmorMasterwork,
     loadoutParameters.autoStatMods,
-    hasPreloadedLoadout,
+    saveParamsAsDefaults,
     loadoutParameters.includeRuntimeStatBenefits,
   ]);
 }
@@ -627,7 +628,7 @@ function useSaveLoadoutParameters(
  * Save stat constraints (stat order / enablement) per class when it changes
  */
 function useSaveStatConstraints(
-  hasPreloadedLoadout: boolean,
+  saveParamsAsDefaults: boolean,
   statConstraints: StatConstraint[],
   savedStatConstraintsByClass: {
     [key: number]: StatConstraint[];
@@ -638,11 +639,7 @@ function useSaveStatConstraints(
   const firstRun = useRef(true);
 
   useEffect(() => {
-    // If the user is playing with an existing loadout (potentially one they
-    // received from a loadout share) or a direct /optimizer link, do not
-    // overwrite the global saved loadout parameters. If they decide to save
-    // that loadout, these will still be saved with the loadout.
-    if (hasPreloadedLoadout) {
+    if (!saveParamsAsDefaults) {
       return;
     }
 
@@ -658,7 +655,7 @@ function useSaveStatConstraints(
         [classType]: statConstraints,
       });
     }
-  }, [setSetting, statConstraints, savedStatConstraintsByClass, classType, hasPreloadedLoadout]);
+  }, [setSetting, statConstraints, savedStatConstraintsByClass, classType, saveParamsAsDefaults]);
 }
 
 function UndoRedoControls({

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -652,12 +652,10 @@ function useSaveStatConstraints(
       return;
     }
 
-    // Strip out min/max tiers and just save the order
-    const newStatConstraints = statConstraints.map(({ statHash }) => ({ statHash }));
-    if (!deepEqual(newStatConstraints, savedStatConstraintsByClass[classType])) {
+    if (!deepEqual(statConstraints, savedStatConstraintsByClass[classType])) {
       setSetting('loStatConstraintsByClass', {
         ...savedStatConstraintsByClass,
-        [classType]: newStatConstraints,
+        [classType]: statConstraints,
       });
     }
   }, [setSetting, statConstraints, savedStatConstraintsByClass, classType, hasPreloadedLoadout]);

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -408,20 +408,8 @@ function StatBar({
           }}
         />
       )}
-      {(!range || range.minStat !== max) && (
-        <div
-          key="min"
-          className={styles.statBarMin}
-          style={{ left: percent(effectiveMin / MAX_STAT) }}
-        />
-      )}
-      {(!range || range.maxStat !== max) && (
-        <div
-          key="max"
-          className={styles.statBarMax}
-          style={{ left: percent(effectiveMax / MAX_STAT) }}
-        />
-      )}
+      <div className={styles.statBarMin} style={{ left: percent(effectiveMin / MAX_STAT) }} />
+      <div className={styles.statBarMax} style={{ left: percent(effectiveMax / MAX_STAT) }} />
     </div>
   );
 }


### PR DESCRIPTION
1. Don't consider the "Equipped" loadout as an existing loadout for the purposes of deciding whether to save default LO params.
2. Fix the min/max brackets disappearing sometimes.
3. Save min/max range in the defaults instead of just stat order and enabled. We used to do this, then removed it, but now I think it's useful again?

Changelog: When you open Loadout Optimizer with the "Equipped" loadout, the loadout parameters you select will now be saved as the default for that class. This was already true if you entered Loadout Optimizer by clicking the "Loadout Optimizer" button. Editing an existing loadout does not save the parameters as a default.

Changelog: When we save Loadout Optimizer defaults, we'll save the min/max setting for each stat now, not just whether it's enabled and what order.