### PR TITLE
Align equipped items with the rest of their siblings

### DIFF
--- a/src/app/inventory-page/Stores.scss
+++ b/src/app/inventory-page/Stores.scss
@@ -25,6 +25,7 @@
     border: $equipped-item-border solid #ddd;
     height: fit-content;
     padding: $equipped-item-padding;
+    margin-top: -1 * ($equipped-item-border + $equipped-item-padding);
   }
 
   .store-cell {


### PR DESCRIPTION
This is a change I've been meaning to try for a while - it nudges the equipped item to align correctly with the rest of the item grid. What do you think?

Before:
<img width="267" height="123" alt="Screenshot 2025-08-04 at 2 42 22 PM" src="https://github.com/user-attachments/assets/7bbfab49-107b-4296-a4d7-733ab230d0c6" />

After:
<img width="251" height="107" alt="Screenshot 2025-08-04 at 2 42 51 PM" src="https://github.com/user-attachments/assets/ce0fbb3e-be83-456a-9c94-f4c6a23f22b7" />
