### PR TITLE
Reduce padding for item popup header text for items with iconOverlay

### DIFF
--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -17,7 +17,7 @@ $iconOverlayScale: math.div(65, 92);
   color: #eee;
 
   &:has(.iconOverlay) {
-    padding-left: 10px + 24px * $iconOverlayScale;
+    padding-left: 5px + 24px * $iconOverlayScale;
   }
 }
 


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Changelog: Adjust text spacing for item popup headers when tier/season banner are present

<details>
<summary>Comparison:</summary>
Old:
<img width="328" height="76" alt="Screenshot 2025-08-04 at 2 58 03 PM" src="https://github.com/user-attachments/assets/23e7bffa-83ab-4ca6-9e32-daa54fabfc36" />
New:
<img width="328" height="81" alt="Screenshot 2025-08-04 at 2 58 18 PM" src="https://github.com/user-attachments/assets/4bed3153-61ed-462c-8ef2-2fa4e5c99e7f" />


Old:
<img width="326" height="99" alt="Screenshot 2025-08-04 at 2 57 38 PM" src="https://github.com/user-attachments/assets/67d14b25-74ca-4d91-9491-99200a5c29c9" />
New:
<img width="325" height="99" alt="Screenshot 2025-08-04 at 2 57 21 PM" src="https://github.com/user-attachments/assets/41267021-2470-47ae-bbf1-f2009cce1f9e" />
</details>