### PR TITLE
WIP: Reward Multiplier MINIMUM VP in BETA

### DIFF
--- a/src/app/inventory/rewards.ts
+++ b/src/app/inventory/rewards.ts
@@ -11,6 +11,8 @@ import type { DimStore } from './store-types';
 // These bonuses are hard to programatically identify, they're just dummies.
 const activityScoreBoosts = new Set([3858293505, 3858293504, 3858293507, 3858293506, 3858293509]);
 
+const maxPowerLevel = 550; // Not expected to change, but should be moved to the constants file or pulled from d2ai.
+
 // Per https://redd.it/1m5obsu, thanks u/Testifye, Reward Multiplier is based on your Gear's Power,
 // multiplied by a combination of its Newness/Featuredness and Season Pass bonuses.
 // 10,000 * C * ( ( G + A + 1 ) * ( ( P - 90 ) * ( 9 / 460 ) + 1 ) )
@@ -52,7 +54,7 @@ export function getRewardMultiplier(
     season,
   );
   const activityUnlocks = seasonProgressionDef.rewardItems.filter(
-    (i) => i.rewardedAtProgressionLevel >= seasonPassLevel && activityScoreBoosts.has(i.itemHash),
+    (i) => i.rewardedAtProgressionLevel <= seasonPassLevel && activityScoreBoosts.has(i.itemHash),
   ).length;
   // There are 5 collectible bonuses, each contributing 3%
   gearMultiplier += activityUnlocks * 3;
@@ -61,10 +63,10 @@ export function getRewardMultiplier(
   gearMultiplier = 1 + 0.01 * gearMultiplier;
 
   // The power multiplier, starting at 0, can reach 9x, leading to the 9 numerator here.
-  // Power level gains, from PL90 to PL550, affect the bonus linearly, so there are 460 increments (460 denominator).
+  // Power level gains, from PL90 to PL550, affect the bonus linearly, so there are 460 increments (460 (550-90) denominator).
   const equippedPowerLevel = Math.floor(sumBy(equippedGear, (i) => i.power) / 8);
   const powerBeyond90 = Math.max(equippedPowerLevel - 90, 0);
-  const powerMultiplier = 1 + powerBeyond90 * (9 / 460);
+  const powerMultiplier = 1 + powerBeyond90 * (9 / (maxPowerLevel - 90));
 
   return powerMultiplier * gearMultiplier;
 }

--- a/src/app/inventory/rewards.ts
+++ b/src/app/inventory/rewards.ts
@@ -1,0 +1,70 @@
+import type { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { getSeasonPassStatus } from 'app/progress/SeasonalRank';
+import { sumBy } from 'app/utils/collections';
+import { errorLog } from 'app/utils/log';
+import { getCurrentSeasonInfo } from 'app/utils/seasons';
+import type { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import type { DimItem } from './item-types';
+import type { DimStore } from './store-types';
+
+// Temporary solution. Might need to be created with d2ai?
+// These bonuses are hard to programatically identify, they're just dummies.
+const activityScoreBoosts = new Set([3858293505, 3858293504, 3858293507, 3858293506, 3858293509]);
+
+// Per https://redd.it/1m5obsu, thanks u/Testifye, Reward Multiplier is based on your Gear's Power,
+// multiplied by a combination of its Newness/Featuredness and Season Pass bonuses.
+// 10,000 * C * ( ( G + A + 1 ) * ( ( P - 90 ) * ( 9 / 460 ) + 1 ) )
+
+export function getRewardMultiplier(
+  defs: D2ManifestDefinitions,
+  profileInfo: DestinyProfileResponse,
+  gear: DimStore | DimItem[],
+) {
+  const equippedGear =
+    'id' in gear
+      ? gear?.items.filter((i) => i.equipped && (i.bucket.inWeapons || i.bucket.inArmor))
+      : gear;
+
+  if (equippedGear.length !== 8) {
+    errorLog('RewardMultiplier', `getRewardMultiplier called with ${equippedGear.length} items`);
+    return null;
+  }
+
+  // Treat gearMultiplier as a whole number percentage first for math precision. 10 = 10%
+  // 1% for each featured item
+  let gearMultiplier = equippedGear.filter((i) => i.featured).length;
+  // 2% additional bonus for using all featured gear.
+  if (gearMultiplier === 8) {
+    gearMultiplier = 10;
+  }
+
+  //  Activity score boosts come from the season pass
+  const { season, seasonPass } = getCurrentSeasonInfo(defs, profileInfo);
+  if (!season || !seasonPass) {
+    errorLog('RewardMultiplier', `getRewardMultiplier called with no season/pass available?`);
+    return null;
+  }
+
+  const { seasonPassLevel, seasonProgressionDef } = getSeasonPassStatus(
+    defs,
+    profileInfo,
+    seasonPass,
+    season,
+  );
+  const activityUnlocks = seasonProgressionDef.rewardItems.filter(
+    (i) => i.rewardedAtProgressionLevel >= seasonPassLevel && activityScoreBoosts.has(i.itemHash),
+  ).length;
+  // There are 5 collectible bonuses, each contributing 3%
+  gearMultiplier += activityUnlocks * 3;
+
+  // Convert this into a multipliable ratio number. 25% becomes 1.25
+  gearMultiplier = 1 + 0.01 * gearMultiplier;
+
+  // The power multiplier, starting at 0, can reach 9x, leading to the 9 numerator here.
+  // Power level gains, from PL90 to PL550, affect the bonus linearly, so there are 460 increments (460 denominator).
+  const equippedPowerLevel = Math.floor(sumBy(equippedGear, (i) => i.power) / 8);
+  const powerBeyond90 = Math.max(equippedPowerLevel - 90, 0);
+  const powerMultiplier = 1 + powerBeyond90 * (9 / 460);
+
+  return powerMultiplier * gearMultiplier;
+}

--- a/src/app/inventory/store/well-rested.ts
+++ b/src/app/inventory/store/well-rested.ts
@@ -1,9 +1,6 @@
-import {
-  DestinyCharacterProgressionComponent,
-  DestinyProgressionDefinition,
-  DestinySeasonDefinition,
-  DestinySeasonPassDefinition,
-} from 'bungie-api-ts/destiny2';
+import { getSeasonPassStatus } from 'app/progress/SeasonalRank';
+import { getCurrentSeasonInfo } from 'app/utils/seasons';
+import { DestinyProfileResponse, DestinyProgressionDefinition } from 'bungie-api-ts/destiny2';
 import { clamp } from 'es-toolkit';
 import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
 
@@ -14,14 +11,13 @@ import { D2ManifestDefinitions } from '../../destiny2/d2-definitions';
  */
 export function isWellRested(
   defs: D2ManifestDefinitions,
-  season: DestinySeasonDefinition | undefined,
-  seasonPass: DestinySeasonPassDefinition | undefined,
-  characterProgression: DestinyCharacterProgressionComponent,
+  profileInfo: DestinyProfileResponse,
 ): {
   wellRested: boolean;
-  progress?: number;
+  weeklyProgress?: number;
   requiredXP?: number;
 } {
+  const { season, seasonPass } = getCurrentSeasonInfo(defs, profileInfo);
   if (!season?.seasonPassProgressionHash) {
     return {
       wellRested: false,
@@ -38,35 +34,31 @@ export function isWellRested(
     };
   }
 
-  const seasonProgress = characterProgression.progressions[seasonPassProgressionHash];
-  const prestigeProgress = characterProgression.progressions[prestigeProgressionHash];
+  const {
+    seasonPassLevel,
+    seasonProgression,
+    prestigeMode,
+    prestigeProgression,
+    prestigeProgressionDef,
+    seasonProgressionDef,
+    weeklyProgress,
+  } = getSeasonPassStatus(defs, profileInfo, seasonPass, season);
 
-  const prestigeMode = seasonProgress.level === seasonProgress.levelCap;
-
-  const seasonProgressDef = defs.Progression.get(seasonPassProgressionHash);
-  const prestigeProgressDef = defs.Progression.get(prestigeProgressionHash);
-
-  if (seasonProgressDef.steps.length === seasonProgress.levelCap) {
+  if (seasonProgressionDef.steps.length === seasonProgression.levelCap) {
     for (let i = 0; i < WELL_RESTED_LEVELS; i++) {
-      seasonProgressDef.steps.push(prestigeProgressDef.steps[0]);
+      seasonProgressionDef.steps.push(prestigeProgressionDef.steps[0]);
     }
   }
 
-  const totalLevel = prestigeMode
-    ? seasonProgress.level + prestigeProgress.level
-    : seasonProgress.level;
-
-  const progress = prestigeMode ? prestigeProgress.weeklyProgress : seasonProgress.weeklyProgress;
-
   const requiredXP =
-    prestigeMode && prestigeProgress.level >= WELL_RESTED_LEVELS
-      ? xpRequiredForLevel(0, prestigeProgressDef) * WELL_RESTED_LEVELS
-      : xpTotalRequiredForLevel(totalLevel, seasonProgressDef, WELL_RESTED_LEVELS);
+    prestigeMode && prestigeProgression.level >= WELL_RESTED_LEVELS
+      ? xpRequiredForLevel(0, prestigeProgressionDef) * WELL_RESTED_LEVELS
+      : xpTotalRequiredForLevel(seasonPassLevel, seasonProgressionDef, WELL_RESTED_LEVELS);
 
   // Have you gained XP equal to three full levels worth of XP?
   return {
-    wellRested: progress < requiredXP,
-    progress,
+    wellRested: weeklyProgress < requiredXP,
+    weeklyProgress,
     requiredXP,
   };
 }

--- a/src/app/loadout/loadout-menu/LoadoutPopup.tsx
+++ b/src/app/loadout/loadout-menu/LoadoutPopup.tsx
@@ -1,13 +1,16 @@
 import { SearchType } from '@destinyitemmanager/dim-api-types';
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { languageSelector, settingSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import ClassIcon from 'app/dim-ui/ClassIcon';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { startFarming } from 'app/farming/actions';
 import { t } from 'app/i18next-t';
+import { getRewardMultiplier } from 'app/inventory/rewards';
 import {
   allItemsSelector,
   bucketsSelector,
+  profileResponseSelector,
   unlockedPlugSetItemsSelector,
 } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -344,6 +347,14 @@ export default function LoadoutPopup({
             onClick={onClick}
           />
         )}
+
+        {defs.isDestiny2 && $DIM_FLAVOR !== 'release' && (
+          <li className={styles.menuItem}>
+            <span>
+              Reward Multiplier ×<RewardMultiplier defs={defs} store={dimStore} />
+            </span>
+          </li>
+        )}
       </ul>
     </div>
   );
@@ -447,4 +458,10 @@ function doApplyRandomLoadout(store: DimStore, options: RandomLoadoutOptions): T
       showNotification({ type: 'warning', title: t('Loadouts.Random'), body: errorMessage(e) });
     }
   };
+}
+
+function RewardMultiplier({ defs, store }: { defs: D2ManifestDefinitions; store: DimStore }) {
+  const profileInfo = useSelector(profileResponseSelector);
+  const multi = profileInfo && getRewardMultiplier(defs, profileInfo, store);
+  return multi?.toFixed(2);
 }

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -7,7 +7,6 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { uniqBy } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { DestinyMilestone, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
-import { D2SeasonPassActiveList } from 'data/d2/d2-season-info';
 import { useSelector } from 'react-redux';
 import styles from './Milestones.m.scss';
 import { PowerCaps } from './PowerCaps';
@@ -29,7 +28,6 @@ const sortPowerBonus = compareBy((powerBonus: number | undefined) => -(powerBonu
 export default function Milestones({
   profileInfo,
   store,
-
   buckets,
 }: {
   store: DimStore;
@@ -40,12 +38,6 @@ export default function Milestones({
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
   const characterProgressions = getCharacterProgressions(profileInfo, store.id);
   const dropPower = useSelector(dropPowerLevelSelector(store.id));
-  const season = profileInfo.profile?.data?.currentSeasonHash
-    ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
-    : undefined;
-  const seasonPass = season?.seasonPassList[D2SeasonPassActiveList]?.seasonPassHash
-    ? defs.SeasonPass.get(season.seasonPassList[D2SeasonPassActiveList].seasonPassHash)
-    : undefined;
 
   const milestoneItems = uniqBy(
     [...milestonesForCharacter(defs, profileInfo, store), ...profileMilestones],
@@ -65,18 +57,8 @@ export default function Milestones({
     <>
       {characterProgressions && (
         <PursuitGrid>
-          <SeasonalRank
-            store={store}
-            characterProgressions={characterProgressions}
-            season={season}
-            seasonPass={seasonPass}
-            profileInfo={profileInfo}
-          />
-          <WellRestedPerkIcon
-            progressions={characterProgressions}
-            season={season}
-            seasonPass={seasonPass}
-          />
+          <SeasonalRank store={store} profileInfo={profileInfo} />
+          <WellRestedPerkIcon profileInfo={profileInfo} />
           <PowerCaps />
         </PursuitGrid>
       )}

--- a/src/app/progress/WellRestedPerkIcon.tsx
+++ b/src/app/progress/WellRestedPerkIcon.tsx
@@ -1,25 +1,17 @@
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { WELL_RESTED_PERK } from 'app/search/d2-known-values';
-import {
-  DestinyCharacterProgressionComponent,
-  DestinySeasonDefinition,
-  DestinySeasonPassDefinition,
-} from 'bungie-api-ts/destiny2';
+import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import BungieImage from '../dim-ui/BungieImage';
 import { isWellRested } from '../inventory/store/well-rested';
 
 export default function WellRestedPerkIcon({
-  progressions,
-  season,
-  seasonPass,
+  profileInfo,
 }: {
-  progressions: DestinyCharacterProgressionComponent;
-  season: DestinySeasonDefinition | undefined;
-  seasonPass?: DestinySeasonPassDefinition;
+  profileInfo: DestinyProfileResponse;
 }) {
   const defs = useD2Definitions()!;
-  const wellRestedInfo = isWellRested(defs, season, seasonPass, progressions);
+  const wellRestedInfo = isWellRested(defs, profileInfo);
 
   if (!wellRestedInfo.wellRested) {
     return null;
@@ -37,9 +29,9 @@ export default function WellRestedPerkIcon({
           src={perkDisplay.icon}
           title={perkDisplay.description}
         />
-        {wellRestedInfo.progress !== undefined && wellRestedInfo.requiredXP !== undefined && (
+        {wellRestedInfo.weeklyProgress !== undefined && wellRestedInfo.requiredXP !== undefined && (
           <span>
-            {wellRestedInfo.progress.toLocaleString()}
+            {wellRestedInfo.weeklyProgress.toLocaleString()}
             <wbr />/<wbr />
             {wellRestedInfo.requiredXP.toLocaleString()}
           </span>

--- a/src/app/utils/seasons.ts
+++ b/src/app/utils/seasons.ts
@@ -1,0 +1,16 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
+import { D2SeasonPassActiveList } from 'data/d2/d2-season-info';
+
+export function getCurrentSeasonInfo(
+  defs: D2ManifestDefinitions,
+  profileInfo: DestinyProfileResponse,
+) {
+  const season = profileInfo.profile?.data?.currentSeasonHash
+    ? defs.Season.get(profileInfo.profile.data.currentSeasonHash)
+    : undefined;
+  const seasonPass = season?.seasonPassList[D2SeasonPassActiveList]?.seasonPassHash
+    ? defs.SeasonPass.get(season.seasonPassList[D2SeasonPassActiveList].seasonPassHash)
+    : undefined;
+  return { season, seasonPass };
+}


### PR DESCRIPTION
This centralizes and simplifies some logic for season pass related parsing, then uses that and other information to generate Reward Multiplier data.
This information appears at the bottom of the character header dropdown in beta only.
I would like to put it there so I can QA it a bit while using DIM and playing game.