### PR TITLE
Masterwork fixes

### DIFF
--- a/src/app/inventory/store/masterwork.ts
+++ b/src/app/inventory/store/masterwork.ts
@@ -4,7 +4,12 @@ import { isArmor3MasterworkSocket } from 'app/utils/item-utils';
 import { getFirstSocketByCategoryHash, isWeaponMasterworkSocket } from 'app/utils/socket-utils';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
-import { ItemCategoryHashes, SocketCategoryHashes, StatHashes } from 'data/d2/generated-enums';
+import {
+  ItemCategoryHashes,
+  PlugCategoryHashes,
+  SocketCategoryHashes,
+  StatHashes,
+} from 'data/d2/generated-enums';
 import masterworksWithCondStats from 'data/d2/masterworks-with-cond-stats.json';
 import { DimItem, DimMasterwork, DimSockets } from '../item-types';
 
@@ -89,8 +94,17 @@ function buildMasterworkInfo(
     });
   }
 
+  const isArmor3 =
+    masterworkPlug.plugDef.plug.plugCategoryHash === PlugCategoryHashes.V460PlugsArmorMasterworks;
+  const tier = exoticWeapon
+    ? maxTier
+    : isArmor3
+      ? // Pick any stat that's not the energy stat
+        masterworkPlug.plugDef.investmentStats.find((s) => s.isConditionallyActive)?.value || 0
+      : Math.abs(masterworkPlug.plugDef.investmentStats[0].value);
+
   return {
-    tier: exoticWeapon ? maxTier : Math.abs(masterworkPlug.plugDef.investmentStats[0].value),
+    tier,
     stats,
   };
 }

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -600,10 +600,11 @@ export function getGeneralSockets(
     // never include the "pay for artifice upgrade" slot on exotic armor
     socketInfo.plugged?.plugDef.plug.plugCategoryHash !==
       PlugCategoryHashes.EnhancementsArtificeExotic &&
-    // Hide armor masterwork payment socket. We display masterworked status other ways.
-    !socketInfo.plugged?.plugDef.plug.plugCategoryIdentifier.startsWith(
-      'v460.plugs.armor.masterworks',
-    ) &&
+    // Hide armor masterwork payment socket for armor 2.0 since it's the same as the energy bar for them.
+    (item.tier > 0 ||
+      !socketInfo.plugged?.plugDef.plug.plugCategoryIdentifier.startsWith(
+        'v460.plugs.armor.masterworks',
+      )) &&
     !(
       !socketInfo.visibleInGame &&
       trustBungieVisibility.has(socketInfo.plugged?.plugDef.plug.plugCategoryHash)


### PR DESCRIPTION
Changelog: Fixed Assume Masterwork for tiered weapons in Compare
Changelog: Show the armor masterwork socket for tiered armor
Changelog: Correctly calculate the masterwork level for tiered armor

~That last one might not be complete. I wasn't able to find any armor 3.0 in the profile dumps I have collected that had any of the masterwork levels from 1-4.~ I verified this does work.

Fixes #11316
Fixes #11325