### PR TITLE
Filter out perk descriptions that repeat the stat bonus.

### DIFF
--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -260,7 +260,7 @@ export default function SocketDetailsSelectedPlug({
 
         {plugDescriptions.perks.map((perkDesc) => (
           <React.Fragment key={perkDesc.perkHash}>
-            {perkDesc.description && (
+            {perkDesc.description && !perkDesc.description.includes('▲') && (
               <div>
                 <RichDestinyText text={perkDesc.description} />
               </div>


### PR DESCRIPTION
Fixes #11287

Changelog: Remove repeated stat info in perk descriptions
