### PR TITLE
Fix tuning stat icon and apply balanced tuning stats

### DIFF
--- a/src/app/inventory/store/stats-conditional.ts
+++ b/src/app/inventory/store/stats-conditional.ts
@@ -59,12 +59,17 @@ function getPlugInvestmentStatActivationRule(
     return { rule: 'never' };
   }
 
+  const defHash = itemDef.hash;
+
   // New Armor 3.0 archetypes grant stats only to secondary stats when masterworked.
-  if (itemDef.plug.plugCategoryHash === PlugCategoryHashes.V460PlugsArmorMasterworks) {
+  if (
+    itemDef.plug.plugCategoryHash === PlugCategoryHashes.V460PlugsArmorMasterworks ||
+    // The Balanced Tuning mod works the same way - it grants its bonus only to the three lowest stats.
+    defHash === ModsWithConditionalStats.BalancedTuning
+  ) {
     return { rule: 'archetypeArmorMasterwork' };
   }
 
-  const defHash = itemDef.hash;
   if (
     defHash === ModsWithConditionalStats.ElementalCapacitor ||
     defHash === ModsWithConditionalStats.EnhancedElementalCapacitor

--- a/src/app/item-popup/ItemStat.m.scss
+++ b/src/app/item-popup/ItemStat.m.scss
@@ -16,22 +16,6 @@
 
 .tunableSymbol {
   position: relative;
-  bottom: 0.2em;
-  span {
-    position: absolute;
-    transform-origin: right;
-
-    &:nth-child(1) {
-      left: 0;
-      bottom: 0.3em;
-      scale: 0.75 1;
-    }
-    &:nth-child(2) {
-      right: 0;
-      bottom: 0.55em;
-      scale: 0.5 1;
-    }
-  }
 }
 
 // The numeric value of the stat

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -14,7 +14,7 @@ import {
   weaponParts,
 } from 'app/search/d2-known-values';
 import { getD1QualityColor, percent } from 'app/shell/formatters';
-import { AppIcon, helpIcon } from 'app/shell/icons';
+import { AppIcon, helpIcon, tuningStatIcon } from 'app/shell/icons';
 import { userGuideUrl } from 'app/shell/links';
 import { sumBy } from 'app/utils/collections';
 import { compareBy, reverseComparator } from 'app/utils/comparators';
@@ -162,10 +162,7 @@ export default function ItemStat({
         title={stat.displayProperties.description}
       >
         {stat.statHash === itemStatInfo?.tunedStatHash && (
-          <span className={styles.tunableSymbol}>
-            ▁<span>▁</span>
-            <span>▁</span>
-          </span>
+          <AppIcon icon={tuningStatIcon} className={styles.tunableSymbol} />
         )}{' '}
         {stat.statHash in statLabels
           ? t(statLabels[stat.statHash as StatHashes]!)

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -405,6 +405,7 @@ export const enum ModsWithConditionalStats {
   EnhancedElementalCapacitor = 711234314, // InventoryItem "Elemental Capacitor"
   EchoOfPersistence = 2272984671, // InventoryItem "Echo of Persistence"
   SparkOfFocus = 1727069360, // InventoryItem "Spark of Focus"
+  BalancedTuning = 3122197216, // InventoryItem "Balanced Tuning"
 }
 
 export const ARTIFICE_PERK_HASH = 3727270518; // InventoryItem "Artifice Armor"

--- a/src/app/shell/icons/custom/TuningStat.ts
+++ b/src/app/shell/icons/custom/TuningStat.ts
@@ -1,0 +1,8 @@
+import { makeCustomIcon } from './utils';
+
+export const dimTuningStatIcon = makeCustomIcon(
+  'TuningStat',
+  20,
+  32,
+  'M10 6.5h10v4h-10zM5 14.5h15v4h-15zM0 22.5h20v4h-20z',
+);

--- a/src/app/shell/icons/index.ts
+++ b/src/app/shell/icons/index.ts
@@ -10,5 +10,6 @@ export { dimPowerIcon as powerIndicatorIcon } from './custom/Power';
 export { dimPowerAltIcon as powerActionIcon } from './custom/PowerAlt';
 export { dimShapedIcon as shapedIcon } from './custom/Shaped';
 export { dimTitanIcon as titanIcon } from './custom/Titan';
+export { dimTuningStatIcon as tuningStatIcon } from './custom/TuningStat';
 export { dimWarlockIcon as warlockIcon } from './custom/Warlock';
 export * from './Library.js';


### PR DESCRIPTION
The styled underscores was fun but didn't work on my machine for whatever reason.

Changelog: The Balanced Tuning mod now correctly applies +1 only to the three lowest armor stats