### PR TITLE
LO Set bonus tweaks

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -673,7 +673,9 @@
       "ModAssignmentFailed": "Many sets could not accommodate all requested mods",
       "MaybeDecreaseLowerBounds": "Consider reducing minimum stat requirements",
       "MaybeIncreaseUpperBounds": "Consider increasing maximum stat requirements",
-      "AllowAutoStatMods": "Allow DIM to automatically include additional stat mods"
+      "AllowAutoStatMods": "Allow DIM to automatically include additional stat mods",
+      "SetBonuses": "You have chosen some set bonuses, maybe you don't have the right items to use them.",
+      "RemoveSetBonuses": "Consider removing some set bonuses"
     },
     "NoExotic": "No Exotic",
     "NoExoticDescription": "Equivalent to searching \"not:exotic\" in the search bar - sets will not use any exotic armor.",

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -279,6 +279,7 @@ export async function analyzeLoadout(
             lockedExoticHash: loadoutParameters.exoticArmorHash,
             armorEnergyRules,
             searchFilter: itemFilter,
+            setBonuses: loadoutParameters.setBonuses,
           });
           // If the item filter loadout armor that was previously included,
           // this is due to the search filter since we've previously established

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -1,4 +1,8 @@
-import { LoadoutParameters, StatConstraint } from '@destinyitemmanager/dim-api-types';
+import {
+  LoadoutParameters,
+  SetBonusCounts,
+  StatConstraint,
+} from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { savedLoStatConstraintsByClassSelector } from 'app/dim-api/selectors';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
@@ -130,7 +134,7 @@ export default memo(function LoadoutBuilder({
   const autoStatMods = Boolean(loadoutParameters.autoStatMods);
   const includeRuntimeStatBenefits = loadoutParameters.includeRuntimeStatBenefits ?? true;
   const assumeArmorMasterwork = loadoutParameters.assumeArmorMasterwork;
-  const setBonuses = loadoutParameters.setBonuses ?? {};
+  const setBonuses = loadoutParameters.setBonuses ?? emptyObject<SetBonusCounts>();
   const classType = loadout.classType;
 
   const selectedStore = stores.find((store) => store.id === selectedStoreId)!;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -232,6 +232,7 @@ export default memo(function LoadoutBuilder({
       lockedExoticHash,
       armorEnergyRules,
       searchFilter,
+      setBonuses,
     });
     return [armorEnergyRules, items, filterInfo];
   }, [
@@ -244,6 +245,7 @@ export default memo(function LoadoutBuilder({
     unassignedMods,
     lockedExoticHash,
     searchFilter,
+    setBonuses,
   ]);
 
   const modStatChanges = useMemo(

--- a/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
+++ b/src/app/loadout-builder/NoBuildsFoundExplainer.tsx
@@ -459,6 +459,29 @@ export default function NoBuildsFoundExplainer({
     }
   }
 
+  // TODO: Do a better job detecting when this was the problem, and offer a way
+  // to clear set bonuses inline.
+  if (params.setBonuses) {
+    const suggestions: ActionableSuggestion[] = [
+      {
+        id: 'removeSetBonuses',
+        contents: t('LoadoutBuilder.NoBuildsFoundExplainer.RemoveSetBonuses'),
+      },
+    ];
+
+    if (filterInfo?.searchQueryEffective) {
+      suggestions.push({
+        id: 'clearQuery',
+        contents: t('LoadoutBuilder.NoBuildsFoundExplainer.MaybeRemoveSearchQuery'),
+      });
+    }
+
+    problems.push({
+      id: 'setBonuses',
+      description: t('LoadoutBuilder.NoBuildsFoundExplainer.SetBonuses'),
+      suggestions,
+    });
+  }
   return (
     <div className={styles.noBuildsExplainerContainer}>
       <h3 className={styles.noBuildsFoundMsg}>

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -115,6 +115,7 @@ export function runProcess({
       armorEnergyRules,
       activityMods,
       bucketSpecificMods[bucketHash] || [],
+      Object.keys(setBonuses).map(Number),
       getUserItemTag,
     );
 
@@ -205,6 +206,7 @@ const groupComparator = (getTag?: (item: DimItem) => TagValue | undefined) =>
  * - Masterwork status
  * - Exoticness (every exotic must be distinguished from other exotics and all legendaries)
  * - Energy capacity
+ * - Set bonus
  * - If there are mods with tags (activity/combat style) it will create groups split by compatible tags
  */
 function mapItemsToGroups(
@@ -213,9 +215,10 @@ function mapItemsToGroups(
   armorEnergyRules: ArmorEnergyRules,
   activityMods: PluggableInventoryItemDefinition[],
   modsForSlot: PluggableInventoryItemDefinition[],
+  setBonusHashes: number[],
   getUserItemTag?: (item: DimItem) => TagValue | undefined,
 ): ItemGroup[] {
-  // Figure out all the interesting mod slots required by mods are.
+  // Figure out all the interesting mod slots required by mods.
   // This includes combat mod tags because blue-quality items don't have them
   // and there may be legacy items that can slot CWL/Warmind Cell mods but not
   // Elemental Well mods?
@@ -273,7 +276,11 @@ function mapItemsToGroups(
   // Group items by everything relevant.
   const finalGroupingFn = (item: DimItem) => {
     const info = cache.get(item)!;
-    return `${info.stats.toString()}-${info.energyCapacity}-${[
+    const itemSetBonusHash = item.setBonus?.hash ?? 0;
+    // Only group by set bonus if set bonuses are being filtered
+    const setBonusHash = setBonusHashes.includes(itemSetBonusHash) ? itemSetBonusHash : 0;
+
+    return `${info.stats.toString()}-${info.energyCapacity}-${setBonusHash}-${[
       ...info.relevantModSeasons.values(),
     ].toString()}`;
   };

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -712,6 +712,8 @@
       "MaybeRemoveSearchQuery": "Consider clearing or changing the filter in the search bar",
       "ModAssignmentFailed": "Many sets could not accommodate all requested mods",
       "RemoveMods": "Remove these mods",
+      "RemoveSetBonuses": "Consider removing some set bonuses",
+      "SetBonuses": "You have chosen some set bonuses, maybe you don't have the right items to use them.",
       "UpperBoundsFailed": "Many sets did not meet maximum stat requirements"
     },
     "NoExotic": "No Exotic",


### PR DESCRIPTION
1. Add a minimal NoBuildsFoundExplainer for set bonuses
2. If the user has locked an exotic AND their set bonuses require 4 pieces, we can pre-filter down to only items that have those set bonuses.
