### PR TITLE
Remove masterwork coloring on armor stats

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -97,9 +97,10 @@ export default function ItemStat({
   const masterworkValue =
     item?.masterworkInfo?.stats?.find((s) => s.hash === stat.statHash)?.value ?? 0;
   // This bool controls the stat name being gold
-  const isMasterworkedStat = masterworkValue !== 0;
+  const isMasterworkedStat = !item?.bucket.inArmor && masterworkValue !== 0;
   const masterworkDisplayValue = masterworkValue || armorMasterworkValue;
   let masterworkDisplayWidth = masterworkDisplayValue || 0;
+
   // baseBar here is the leftmost segment of the stat bar.
   // For armor, this is the "roll," the sum of its invisible stat plugs.
   // For weapons, this is the default base stat in its item definition, before barrels/mags/etc.


### PR DESCRIPTION
Given how armor 3.0 works, it seems really inappropriate to put a special gold color on the armor's _non_ main stats, in fact its _worst_ stats.

This led to thinking about how it's weird to gold all 6 stats on armor 2.0. It's not communicating anything.

Gold makes sense on weapons because weapons have a masterworked stat.

<img width="863" height="364" alt="image" src="https://github.com/user-attachments/assets/a022822f-7175-4e5d-861f-3f240a6db7d7" />
