### PR TITLE
Order LO sets by total stats after enabled stats

### DIFF
--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -43,7 +43,7 @@ export function TierlessSetStats({
   equippedHashes: Set<number>;
 }) {
   const defs = useD2Definitions()!;
-  const totalStats = sum(Object.values(stats)); // TODO: Is this useful?
+  const totalStats = sum(Object.values(stats));
   const countedStatsTotal = sumEnabledStats(stats, desiredStatRanges); // Total of the stats that were within the desired ranges
 
   // TODO: Lots of changes needed here once we drop tiers. Maybe we just show a

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,6 +1,8 @@
 import { sumBy } from 'app/utils/collections';
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
+import { sum } from 'es-toolkit';
 import { ArmorSet, ArmorStatHashes, ArmorStats, DesiredStatRange } from '../types';
+import { getPower } from '../utils';
 
 function getComparatorsForMatchedSetSorting(desiredStatRanges: DesiredStatRange[]) {
   const comparators: Comparator<ArmorSet>[] = [
@@ -14,6 +16,12 @@ function getComparatorsForMatchedSetSorting(desiredStatRanges: DesiredStatRange[
       ),
     );
   }
+
+  comparators.push(
+    // Finally sort by total stats, then by power
+    compareBy((s) => -sum(Object.values(s.stats))),
+    compareBy((s) => -getPower(s.armor.map((i) => i[0]))),
+  );
   return comparators;
 }
 


### PR DESCRIPTION
Changelog: Builds in Loadout Optimizer are now sorted by enabled stats, then each enabled stat in order, then total stats (including disabled stats). Before, they were not sorted by total stats, so if you had some stats disabled you could get very low-stat builds near the top.
