### PR TITLE
Don't try to save set bonuses with a count of zero

### DIFF
--- a/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.tsx
@@ -191,6 +191,18 @@ export function SetBonusPicker({
     />
   );
 
+  const handlePerkClick = (setHash: number, perkRequiredCount: number) => () => {
+    setSetBonuses((setBonuses) => {
+      const newSetBonuses = { ...setBonuses };
+      if ((setBonuses[setHash] || 0) === perkRequiredCount) {
+        delete newSetBonuses[setHash];
+      } else {
+        newSetBonuses[setHash] = perkRequiredCount;
+      }
+      return newSetBonuses;
+    });
+  };
+
   return (
     <Sheet
       header={
@@ -214,15 +226,6 @@ export function SetBonusPicker({
           <TileGrid key={set.hash} header={set.displayProperties.name}>
             {set.setPerks.map((perk) => {
               const perkDef = defs.SandboxPerk.get(perk.sandboxPerkHash);
-              const handleClick = () => {
-                setSetBonuses({
-                  ...setBonuses,
-                  [set.hash]:
-                    (setBonuses[set.hash] || 0) === perk.requiredSetCount
-                      ? 0
-                      : perk.requiredSetCount,
-                });
-              };
               return (
                 <TileGridTile
                   key={perkDef.hash}
@@ -237,7 +240,7 @@ export function SetBonusPicker({
                     </>
                   }
                   icon={<SetPerkIcon perkDef={perkDef} active={selected(perk, set.hash)} />}
-                  onClick={handleClick}
+                  onClick={handlePerkClick(set.hash, perk.requiredSetCount)}
                 >
                   {perkDef.displayProperties.description}
                 </TileGridTile>

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -29,7 +29,7 @@ import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName, armorStats } from 'app/search/d2-known-values';
-import { count, reorder } from 'app/utils/collections';
+import { count, isEmpty, reorder } from 'app/utils/collections';
 import { emptyObject } from 'app/utils/empty';
 import { useHistory } from 'app/utils/undo-redo-history';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -504,7 +504,13 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         return updateLoadout(state, updateMods(newMods));
       }
       case 'setSetBonuses': {
-        return updateLoadout(state, setLoadoutParameters({ setBonuses: action.setBonuses }));
+        console.log('Setting set bonuses', action.setBonuses);
+        return updateLoadout(
+          state,
+          setLoadoutParameters({
+            setBonuses: isEmpty(action.setBonuses) ? undefined : action.setBonuses,
+          }),
+        );
       }
       case 'removeSetBonuses': {
         return updateLoadout(state, setLoadoutParameters({ setBonuses: undefined }));

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -504,7 +504,6 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
         return updateLoadout(state, updateMods(newMods));
       }
       case 'setSetBonuses': {
-        console.log('Setting set bonuses', action.setBonuses);
         return updateLoadout(
           state,
           setLoadoutParameters({


### PR DESCRIPTION
Changelog: Fixed a bug where removing set bonuses by un-clicking them from the set bonus picker could result in a loadout that couldn't be saved.