### PR TITLE
Combine set bonus tooltips for same-set bonuses in StoreStats, adjust location slightly

### DIFF
--- a/src/app/item-popup/SetBonus.tsx
+++ b/src/app/item-popup/SetBonus.tsx
@@ -108,7 +108,7 @@ export function SetPerkIcon({
   );
 }
 
-function ContributingArmor({
+export function ContributingArmor({
   setBonus,
   store,
   showEquipped,

--- a/src/app/store-stats/CharacterSetBonus.tsx
+++ b/src/app/store-stats/CharacterSetBonus.tsx
@@ -1,29 +1,38 @@
+import { PressTip, Tooltip } from 'app/dim-ui/PressTip';
+import { t } from 'app/i18next-t';
 import { DimStore } from 'app/inventory/store-types';
 import { useCurrentSetBonus } from 'app/inventory/store/hooks';
-import { SetPerk } from 'app/item-popup/SetBonus';
+import { ContributingArmor, SetPerkIcon } from 'app/item-popup/SetBonus';
 import React from 'react';
 
 export function CharacterSetBonus({ store }: { store: DimStore }) {
   const setBonusStatus = useCurrentSetBonus(store.id);
-
-  return (
+  const tooltip = (
     <>
+      <Tooltip.Header text="set bonuses" />
       {Object.values(setBonusStatus.activeSetBonuses).map((sb) => (
         <React.Fragment key={sb!.setBonus.hash}>
+          <span>{sb!.setBonus.displayProperties.name}</span>
           {Object.values(sb!.activePerks).map((p) => (
-            <SetPerk
-              key={p.def.hash}
-              requiredSetCount={p.requirement}
-              perkDef={p.def}
-              setBonus={sb!.setBonus}
-              store={store}
-              active
-              noLabel
-              showEquipped
-            />
+            <React.Fragment key={p.def.hash}>
+              <span>{`${p.def.displayProperties.name} | ${t('Item.SetBonus.NPiece', { count: p.requirement })}`}</span>
+              {p.def.displayProperties.description}
+            </React.Fragment>
           ))}
+          {store && <ContributingArmor store={store} setBonus={sb!.setBonus} showEquipped={true} />}
         </React.Fragment>
       ))}
     </>
+  );
+  return (
+    <PressTip tooltip={tooltip} placement="top">
+      {Object.values(setBonusStatus.activeSetBonuses).map((sb) => (
+        <React.Fragment key={sb!.setBonus.hash}>
+          {Object.values(sb!.activePerks).map((p) => (
+            <SetPerkIcon key={p.def.hash} perkDef={p.def} active={true} />
+          ))}
+        </React.Fragment>
+      ))}
+    </PressTip>
   );
 }

--- a/src/app/store-stats/CharacterSetBonus.tsx
+++ b/src/app/store-stats/CharacterSetBonus.tsx
@@ -17,8 +17,10 @@ export function CharacterSetBonus({ store }: { store: DimStore }) {
               <Tooltip.Header text={sb!.setBonus.displayProperties.name} />
               {Object.values(sb!.activePerks).map((p) => (
                 <React.Fragment key={p.def.hash}>
-                  <div>{`${t('Item.SetBonus.NPiece', { count: p.requirement })} | ${p.def.displayProperties.name}`}</div>
+                  <strong>{`${t('Item.SetBonus.NPiece', { count: p.requirement })} | ${p.def.displayProperties.name}`}</strong>
+                  <br />
                   {p.def.displayProperties.description}
+                  <hr />
                 </React.Fragment>
               ))}
               {store && (

--- a/src/app/store-stats/CharacterSetBonus.tsx
+++ b/src/app/store-stats/CharacterSetBonus.tsx
@@ -7,32 +7,32 @@ import React from 'react';
 
 export function CharacterSetBonus({ store }: { store: DimStore }) {
   const setBonusStatus = useCurrentSetBonus(store.id);
-  const tooltip = (
-    <>
-      <Tooltip.Header text="set bonuses" />
-      {Object.values(setBonusStatus.activeSetBonuses).map((sb) => (
-        <React.Fragment key={sb!.setBonus.hash}>
-          <span>{sb!.setBonus.displayProperties.name}</span>
-          {Object.values(sb!.activePerks).map((p) => (
-            <React.Fragment key={p.def.hash}>
-              <span>{`${p.def.displayProperties.name} | ${t('Item.SetBonus.NPiece', { count: p.requirement })}`}</span>
-              {p.def.displayProperties.description}
-            </React.Fragment>
-          ))}
-          {store && <ContributingArmor store={store} setBonus={sb!.setBonus} showEquipped={true} />}
-        </React.Fragment>
-      ))}
-    </>
-  );
   return (
-    <PressTip tooltip={tooltip} placement="top">
+    <div>
       {Object.values(setBonusStatus.activeSetBonuses).map((sb) => (
-        <React.Fragment key={sb!.setBonus.hash}>
+        <PressTip
+          key={sb!.setBonus.hash}
+          tooltip={
+            <>
+              <Tooltip.Header text={sb!.setBonus.displayProperties.name} />
+              {Object.values(sb!.activePerks).map((p) => (
+                <React.Fragment key={p.def.hash}>
+                  <div>{`${t('Item.SetBonus.NPiece', { count: p.requirement })} | ${p.def.displayProperties.name}`}</div>
+                  {p.def.displayProperties.description}
+                </React.Fragment>
+              ))}
+              {store && (
+                <ContributingArmor store={store} setBonus={sb!.setBonus} showEquipped={true} />
+              )}
+            </>
+          }
+          placement="top"
+        >
           {Object.values(sb!.activePerks).map((p) => (
             <SetPerkIcon key={p.def.hash} perkDef={p.def} active={true} />
           ))}
-        </React.Fragment>
+        </PressTip>
       ))}
-    </PressTip>
+    </div>
   );
 }

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -86,7 +86,7 @@
 }
 
 .setBonuses {
-  --set-bonus-icon-size: 16px;
+  --set-bonus-icon-size: 18px;
   display: flex;
   flex-direction: row-reverse;
   gap: 4px;

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -87,9 +87,13 @@
 
 .setBonuses {
   composes: flexRow from '../dim-ui/common.m.scss';
+  display: flex;
   flex-direction: row-reverse;
   gap: 4px;
   & > div {
     display: flex;
+    & > div {
+      display: flex;
+    }
   }
 }

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -87,5 +87,9 @@
 
 .setBonuses {
   composes: flexRow from '../dim-ui/common.m.scss';
+  flex-direction: row-reverse;
   gap: 4px;
+  & > div {
+    display: flex;
+  }
 }

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -2,8 +2,8 @@
 
 .statContainer {
   max-width: 230px;
-  margin-top: 8px;
-  gap: 3px;
+  margin-top: 7px;
+  gap: 2px;
   color: var(--theme-header-characters-txt);
 
   // When the whole container is hovered, draw a box around any buttons. When
@@ -86,7 +86,7 @@
 }
 
 .setBonuses {
-  composes: flexRow from '../dim-ui/common.m.scss';
+  --set-bonus-icon-size: 16px;
   display: flex;
   flex-direction: row-reverse;
   gap: 4px;


### PR DESCRIPTION
This right-aligns the icons and merges the PressTip for 2 perks of the same set into a single tooltip where possible.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Combine the set bonus tooltips for items of the same set in character status