### PR TITLE
Clean out redundant perk descriptions

### DIFF
--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -366,7 +366,9 @@ function getNonReusableModSockets(item: DimItem) {
       !socketContainsIntrinsicPlug(s) &&
       !s.plugged.plugDef.plug.plugCategoryIdentifier.includes('masterwork') &&
       (s.plugged.plugDef.itemCategoryHashes?.some((h) => modItemCategoryHashes.has(h)) ||
-        statfulOrnaments.includes(s.plugged.plugDef.hash)),
+        statfulOrnaments.includes(s.plugged.plugDef.hash) ||
+        // Tuning mods don't have the ArmorMods item category hash
+        s.plugged.plugDef.plug.plugCategoryIdentifier.includes('tuning.mods')),
   );
 }
 /**

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -25,7 +25,7 @@ import {
 import clsx from 'clsx';
 import enhancedIntrinsics from 'data/d2/crafting-enhanced-intrinsics';
 import { TraitHashes } from 'data/d2/generated-enums';
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { DimItem, DimPlug, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import Objective from '../progress/Objective';
 import styles from './PlugTooltip.m.scss';
@@ -147,13 +147,17 @@ function PlugTooltip({
   const bungieDescription =
     plugDescriptions.perks.length > 0 &&
     plugDescriptions.perks.map((perkDesc) => (
-      <div key={perkDesc.perkHash}>
-        {perkDesc.name && <div className={styles.perkName}>{perkDesc.name}</div>}
-        {perkDesc.description && <RichDestinyText text={perkDesc.description} />}
+      <React.Fragment key={perkDesc.perkHash}>
+        {perkDesc.name && !perkDesc.name.match(/^\+.*▲/m) && (
+          <div className={styles.perkName}>{perkDesc.name}</div>
+        )}
+        {perkDesc.description && perkDesc.description !== perkDesc.name && (
+          <RichDestinyText text={perkDesc.description} />
+        )}
         {!hideRequirements && perkDesc.requirement && (
           <RichDestinyText text={perkDesc.requirement} className={styles.requirement} />
         )}
-      </div>
+      </React.Fragment>
     ));
   const clarityDescriptionSection = plugDescriptions.communityInsight && (
     <Tooltip.Section className={styles.communityInsightSection}>


### PR DESCRIPTION
Changelog: Tuning mod stat changes are reflected in the stat bars in the item popup.
Changelog: Removed redundant stat effect text in mod tooltip.

I don't know if the negative stat effect displays correctly because I don't have an example of any of the tradeoff mods inserted into the tuning slot.

Fixes #11333
