### PR TITLE
Tuned stat icon in Compare, fix bar widths with negative stat

### DIFF
--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -42,3 +42,9 @@
   height: 4px;
   width: 4px;
 }
+
+.tunedStatIcon {
+  color: #fff;
+  position: absolute;
+  transform: scale(-1, 1);
+}

--- a/src/app/compare/CompareStat.m.scss.d.ts
+++ b/src/app/compare/CompareStat.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'range': string;
   'stat': string;
   'statValue': string;
+  'tunedStatIcon': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -1,6 +1,8 @@
 import AnimatedNumber from 'app/dim-ui/AnimatedNumber';
 import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { getCompareColor, percent } from 'app/shell/formatters';
+import { AppIcon, tuningStatIcon } from 'app/shell/icons';
+import { getArmor3TuningStat } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { StatHashes } from 'data/d2/generated-enums';
 import { D1Stat, DimItem, DimStat } from '../inventory/item-types';
@@ -25,6 +27,7 @@ export default function CompareStat({
       item.masterworkInfo?.stats?.some((s) => s.isPrimary && s.hash === stat.statHash),
   );
   const color = getCompareColor(statRange(stat, min, max, value));
+  const tunedStatHash = getArmor3TuningStat(item);
 
   return (
     <div className={styles.stat} style={{ color }}>
@@ -37,7 +40,10 @@ export default function CompareStat({
       />
       {value !== 0 && stat?.bar && item.bucket.sort === 'Armor' && (
         <span className={styles.bar}>
-          <span style={{ width: percent(value / stat.maximumValue) }} />
+          {Boolean(tunedStatHash && tunedStatHash === stat?.statHash) && (
+            <AppIcon icon={tuningStatIcon} className={styles.tunedStatIcon} />
+          )}
+          <span style={{ width: percent(Math.max(0, value) / stat.maximumValue) }} />
         </span>
       )}
       {stat?.statHash === StatHashes.RecoilDirection && <RecoilStat value={value} />}

--- a/src/app/item-popup/ItemStats.tsx
+++ b/src/app/item-popup/ItemStats.tsx
@@ -1,4 +1,3 @@
-import { useD2Definitions } from 'app/manifest/selectors';
 import { getArmor3StatFocus, getArmor3TuningStat, isArmor3, isD1Item } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { DimItem, DimStat } from '../inventory/item-types';
@@ -14,14 +13,12 @@ export default function ItemStats({
   item?: DimItem;
   className?: string;
 }) {
-  const defs = useD2Definitions();
-
   stats ||= item?.stats;
 
   if (!stats?.length) {
     return null;
   }
-  const tunedStatHash = item && defs && getArmor3TuningStat(item, defs);
+  const tunedStatHash = item && getArmor3TuningStat(item);
   const statFocus = item && isArmor3(item) ? getArmor3StatFocus(item) : undefined;
 
   const hasIcons = stats.some(

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -255,7 +255,6 @@ export function filterItems({
 
       const strictlyWorseItemIds = computeStatDupeLower(
         finalFilteredItems,
-        defs,
         // Consider all stats, even if they're not enabled - we still want the
         // highest total stats.
         armorStats,

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -408,3 +408,37 @@ export const enum ModsWithConditionalStats {
 }
 
 export const ARTIFICE_PERK_HASH = 3727270518; // InventoryItem "Artifice Armor"
+
+// TODO: replace with d2ai?
+export const tuningModToTunedStathash: Record<number, StatHashes> = {
+  309000506: StatHashes.Grenade,
+  311164277: StatHashes.Melee,
+  323635379: StatHashes.Class,
+  388618952: StatHashes.Health,
+  455024236: StatHashes.Grenade,
+  534630542: StatHashes.Melee,
+  673231129: StatHashes.Super,
+  691392383: StatHashes.Weapons,
+  891771298: StatHashes.Weapons,
+  957763733: StatHashes.Class,
+  1510949672: StatHashes.Class,
+  1672416975: StatHashes.Grenade,
+  1879022254: StatHashes.Class,
+  1918710127: StatHashes.Weapons,
+  1922571986: StatHashes.Grenade,
+  2125798995: StatHashes.Health,
+  2244422610: StatHashes.Super,
+  3121760799: StatHashes.Weapons,
+  3284443097: StatHashes.Weapons,
+  3310526732: StatHashes.Health,
+  3554800389: StatHashes.Super,
+  3681082702: StatHashes.Health,
+  3946669007: StatHashes.Super,
+  4020349587: StatHashes.Melee,
+  4026414261: StatHashes.Super,
+  4030660414: StatHashes.Class,
+  4088823605: StatHashes.Health,
+  4116389173: StatHashes.Grenade,
+  4164883102: StatHashes.Melee,
+  4210715468: StatHashes.Melee,
+};

--- a/src/app/search/items/search-filters/dupes.ts
+++ b/src/app/search/items/search-filters/dupes.ts
@@ -155,15 +155,15 @@ const dupeFilters: ItemFilterDefinition[] = [
   {
     keywords: 'statlower',
     description: tl('Filter.StatLower'),
-    filter: ({ allItems, d2Definitions }) => {
-      const duplicates = computeStatDupeLower(allItems, d2Definitions);
+    filter: ({ allItems }) => {
+      const duplicates = computeStatDupeLower(allItems);
       return (item) => item.bucket.inArmor && duplicates.has(item.id);
     },
   },
   {
     keywords: 'customstatlower',
     description: tl('Filter.CustomStatLower'),
-    filter: ({ allItems, customStats, d2Definitions }) => {
+    filter: ({ allItems, customStats }) => {
       const duplicateSetsByClass: Partial<Record<DimItem['classType'], Set<string>[]>> = {};
 
       for (const customStat of customStats) {
@@ -176,7 +176,7 @@ const dupeFilters: ItemFilterDefinition[] = [
           }
         }
         (duplicateSetsByClass[customStat.class] ||= []).push(
-          computeStatDupeLower(allItems, d2Definitions, relevantStatHashes),
+          computeStatDupeLower(allItems, relevantStatHashes),
         );
       }
 
@@ -231,7 +231,7 @@ const dupeFilters: ItemFilterDefinition[] = [
     keywords: ['statdupe'],
     description: tl('Filter.DupeStats'),
     destinyVersion: 2,
-    filter: ({ allItems, d2Definitions }) => {
+    filter: ({ allItems }) => {
       const collector: Record<string, string[]> = {};
       for (const item of allItems) {
         if (
@@ -249,9 +249,7 @@ const dupeFilters: ItemFilterDefinition[] = [
         }
 
         // *Stat-related* reasons an item's stats might not be directly comparable to another item's.
-        const statExceptionKey = isArtifice(item)
-          ? 'artifice'
-          : getArmor3TuningStat(item, d2Definitions!);
+        const statExceptionKey = isArtifice(item) ? 'artifice' : getArmor3TuningStat(item);
 
         const statValues = filterMap(item.stats, (s) => {
           if (armorStats.includes(s.statHash)) {

--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -169,12 +169,12 @@ const statFilters: ItemFilterDefinition[] = [
     format: 'query',
     suggestions: Object.keys(realD2ArmorStatHashByName),
     destinyVersion: 2,
-    filter: ({ filterValue, d2Definitions }) => {
+    filter: ({ filterValue }) => {
       const seekingStatHash = realD2ArmorStatHashByName[filterValue];
       if (!seekingStatHash) {
         throw Error(`invalid stat name: "${filterValue}"`);
       }
-      return (item) => getArmor3TuningStat(item, d2Definitions!) === seekingStatHash;
+      return (item) => getArmor3TuningStat(item) === seekingStatHash;
     },
   },
 ];

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -17,6 +17,7 @@ import {
   armor2PlugCategoryHashes,
   killTrackerObjectivesByHash,
   killTrackerSocketTypeHash,
+  tuningModToTunedStathash,
 } from 'app/search/d2-known-values';
 import { damageNamesByEnum } from 'app/search/search-filter-values';
 import modSocketMetadata, {
@@ -429,14 +430,10 @@ export function getArmor3StatFocus(item: DimItem): StatHashes[] {
  * Returns the stat hash of the item's tunable stat.
  * This stat can be upgraded at the cost of another stat.
  *
- * This heuristic relies on the following assumptions:
- * - Every armor with tuning has Balanced Tuning (3122197216) which provides +1 to several stats.
- * - Armor with e.g. a melee tuning, has several available plugs which raise Melee stat by 5 (and none which raise other stats by that much)
+ * Every armor with tuning has Balanced Tuning (3122197216) which provides +1 to several stats,
+ * so this seeks an available plug item that's one of the +5/-5 mods.
  */
-export function getArmor3TuningStat(
-  item: DimItem,
-  defs: D2ManifestDefinitions,
-): number | undefined {
+export function getArmor3TuningStat(item: DimItem): number | undefined {
   const reusablePlugItems = item.bucket.inArmor
     ? getArmor3TuningSocket(item)?.reusablePlugItems
     : undefined;
@@ -444,12 +441,9 @@ export function getArmor3TuningStat(
     return;
   }
 
-  for (const reusablePlug of reusablePlugItems) {
-    const positiveHash = defs.InventoryItem.get(reusablePlug.plugItemHash).investmentStats.find(
-      (s) => s.value > 1,
-    );
-    if (positiveHash) {
-      return positiveHash.statTypeHash;
+  for (const { plugItemHash } of reusablePlugItems) {
+    if (plugItemHash in tuningModToTunedStathash) {
+      return tuningModToTunedStathash[plugItemHash];
     }
   }
   return undefined;

--- a/src/app/utils/stats.ts
+++ b/src/app/utils/stats.ts
@@ -1,5 +1,4 @@
 import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
-import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem } from 'app/inventory/item-types';
 import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
 import { armorStats } from 'app/search/d2-known-values';
@@ -15,7 +14,6 @@ import { StatsSet } from './stats-set';
  */
 export function computeStatDupeLower(
   allItems: DimItem[],
-  defs: D2ManifestDefinitions | undefined,
   /** By default, the 6 armor stats. To optimize a custom stat, a subset is passed. */
   relevantArmorStatHashes: number[] = armorStats,
   /**
@@ -54,7 +52,7 @@ export function computeStatDupeLower(
       const optimizingStats = getArmorStats(item);
       const statMixes = [optimizingStats.map((s) => s.value)]; // Start with the unadjusted stat mix.
 
-      const tuningStatHash = defs ? getArmor3TuningStat(item, defs) : undefined;
+      const tuningStatHash = getArmor3TuningStat(item);
       if (tuningStatHash) {
         // If we can tune to benefit a relevant hash, include tuning mod tradeoff stat mixes.
         if (relevantArmorStatHashes.includes(tuningStatHash)) {


### PR DESCRIPTION
Fixes #11363
Fixes #11362 

Removes the need for defs in getArmor3TuningStat.