### PR TITLE
Handle `masterwork:<3` correctly

### DIFF
--- a/src/app/search/items/search-filters/range-overload.ts
+++ b/src/app/search/items/search-filters/range-overload.ts
@@ -31,7 +31,7 @@ const overloadedRangeFilters: ItemFilterDefinition[] = [
       }
       // "masterwork:<5" case
       if (compare) {
-        return (item) => Boolean(item.masterworkInfo?.tier && compare(item.masterworkInfo.tier));
+        return (item) => item.masterworkInfo && compare(item.masterworkInfo.tier ?? 0);
       }
       // "masterwork:range" case
       const searchedMasterworkStatHash = statHashByName[filterValue];


### PR DESCRIPTION
Changelog: Armor with no masterwork tier matches `masterwork:0` now.
