### PR TITLE
Xur acquired catalyst fix

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1475,6 +1475,7 @@
     "Collections": "Collections",
     "Engram": "Rank",
     "FilterToUnacquired": "Only show uncollected items",
+    "AlreadyAcquired": "Already Acquired",
     "HideSilverItems": "Hide Silver items",
     "NoItems": "This Vendor is currently not offering any items.",
     "Vendors": "Vendors",

--- a/src/app/vendors/d2-vendors.ts
+++ b/src/app/vendors/d2-vendors.ts
@@ -1,4 +1,5 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { t } from 'app/i18next-t';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { VendorHashes, silverItemHash } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
@@ -225,9 +226,10 @@ export function filterVendorGroups(
 }
 
 export function filterToUnacquired(ownedItemHashes: Set<number>): VendorFilterFunction {
-  return ({ owned, item, collectibleState }) =>
+  return ({ owned, item, collectibleState, failureStrings }) =>
     item &&
     !owned &&
+    !(failureStrings.includes(t('Vendors.AlreadyAcquired')) && item.isExotic) &&
     (collectibleState !== undefined
       ? (collectibleState & DestinyCollectibleState.NotAcquired) !== 0
       : (item.itemCategoryHashes.includes(ItemCategoryHashes.Mods_Mod) ||

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1455,6 +1455,7 @@
     "SortRecords": "Sort triumphs by completion"
   },
   "Vendors": {
+    "AlreadyAcquired": "Already Acquired",
     "Collections": "Collections",
     "Engram": "Rank",
     "FilterToUnacquired": "Only show uncollected items",


### PR DESCRIPTION
Changelog: Fix Xur showing exotic catalysts you have already acquired while "Only show uncollected items" is enabled

OLD
<img width="1202" height="905" alt="image" src="https://github.com/user-attachments/assets/91552710-e5a8-4641-84d4-e1414749e847" />

NEW
<img width="1207" height="903" alt="image" src="https://github.com/user-attachments/assets/b6671653-ed86-457d-8e0d-41918887bd1c" />
