### PR TITLE
Fix solstice challenges, clean up ranks

### DIFF
--- a/src/app/inventory/store/well-rested.ts
+++ b/src/app/inventory/store/well-rested.ts
@@ -18,7 +18,7 @@ export function isWellRested(
   requiredXP?: number;
 } {
   const { season, seasonPass } = getCurrentSeasonInfo(defs, profileInfo);
-  if (!season?.seasonPassProgressionHash) {
+  if (!season) {
     return {
       wellRested: false,
     };

--- a/src/app/manifest/selectors.ts
+++ b/src/app/manifest/selectors.ts
@@ -1,13 +1,12 @@
 import { destinyVersionSelector } from 'app/accounts/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
-import { ProgressionHashes } from 'data/d2/generated-enums';
 import { useSelector } from 'react-redux';
 
 export const destiny2CoreSettingsSelector = (state: RootState) =>
   state.manifest.destiny2CoreSettings;
 
-export const rankProgressionHashesSelector = (state: RootState): ProgressionHashes[] =>
+export const rankProgressionHashesSelector = (state: RootState): number[] =>
   state.manifest.destiny2CoreSettings?.currentRankProgressionHashes ?? emptyArray<number>();
 
 const d1ManifestSelector = (state: RootState) => state.manifest.d1Manifest;

--- a/src/app/manifest/selectors.ts
+++ b/src/app/manifest/selectors.ts
@@ -1,12 +1,13 @@
 import { destinyVersionSelector } from 'app/accounts/selectors';
 import { RootState } from 'app/store/types';
 import { emptyArray } from 'app/utils/empty';
+import { ProgressionHashes } from 'data/d2/generated-enums';
 import { useSelector } from 'react-redux';
 
 export const destiny2CoreSettingsSelector = (state: RootState) =>
   state.manifest.destiny2CoreSettings;
 
-export const rankProgressionHashesSelector = (state: RootState) =>
+export const rankProgressionHashesSelector = (state: RootState): ProgressionHashes[] =>
   state.manifest.destiny2CoreSettings?.currentRankProgressionHashes ?? emptyArray<number>();
 
 const d1ManifestSelector = (state: RootState) => state.manifest.d1Manifest;

--- a/src/app/progress/Event.tsx
+++ b/src/app/progress/Event.tsx
@@ -58,12 +58,12 @@ export function Event({
   const classSpecificNode =
     classSpecificNodeHash && defs.PresentationNode.get(classSpecificNodeHash.presentationNodeHash);
 
-  if (!classSpecificNode) {
-    return null;
-  }
+  const presentationNodes = classSpecificNode
+    ? [classSpecificNode]
+    : childrenNodes.map((n) => defs.PresentationNode.get(n.presentationNodeHash));
 
-  const records = filterMap(classSpecificNode.children.records, (h) =>
-    toRecord(defs, profileResponse, h.recordHash),
+  const records = presentationNodes.flatMap((n) =>
+    filterMap(n.children.records, (h) => toRecord(defs, profileResponse, h.recordHash)),
   );
 
   const pursuits = records

--- a/src/app/progress/Milestones.tsx
+++ b/src/app/progress/Milestones.tsx
@@ -12,8 +12,6 @@ import styles from './Milestones.m.scss';
 import Pursuit from './Pursuit';
 import PursuitGrid from './PursuitGrid';
 import { sortPursuits } from './Pursuits';
-import SeasonalRank from './SeasonalRank';
-import WellRestedPerkIcon from './WellRestedPerkIcon';
 import { getEngramPowerBonus } from './engrams';
 import { milestoneToItems } from './milestone-items';
 import { getCharacterProgressions } from './selectors';
@@ -35,7 +33,6 @@ export default function Milestones({
 }) {
   const defs = useD2Definitions()!;
   const profileMilestones = milestonesForProfile(defs, profileInfo, store.id);
-  const characterProgressions = getCharacterProgressions(profileInfo, store.id);
   const dropPower = useSelector(dropPowerLevelSelector(store.id));
 
   const milestoneItems = uniqBy(
@@ -54,13 +51,6 @@ export default function Milestones({
 
   return (
     <>
-      {characterProgressions && (
-        <PursuitGrid>
-          <SeasonalRank store={store} profileInfo={profileInfo} />
-          <WellRestedPerkIcon profileInfo={profileInfo} />
-          {/* <PowerCaps /> */}
-        </PursuitGrid>
-      )}
       {[...milestonesByPower.keys()].sort(sortPowerBonus).map((powerBonus) => (
         <div key={powerBonus ?? -1}>
           <h2 className={styles.header}>

--- a/src/app/progress/Progress.tsx
+++ b/src/app/progress/Progress.tsx
@@ -28,7 +28,9 @@ import Pursuits from './Pursuits';
 import Raids from './Raids';
 import Ranks from './Ranks';
 import SeasonalChallenges from './SeasonalChallenges';
+import SeasonalRank from './SeasonalRank';
 import { TrackedTriumphs } from './TrackedTriumphs';
+import WellRestedPerkIcon from './WellRestedPerkIcon';
 
 export default function Progress({ account }: { account: DestinyAccount }) {
   const defs = useD2Definitions();
@@ -141,7 +143,10 @@ export default function Progress({ account }: { account: DestinyAccount }) {
           <section id="ranks">
             <CollapsibleTitle title={t('Progress.CrucibleRank')} sectionId="profile-ranks">
               <div className="progress-row">
-                <Ranks profileInfo={profileInfo} />
+                <Ranks profileInfo={profileInfo}>
+                  <SeasonalRank store={selectedStore} profileInfo={profileInfo} />
+                  <WellRestedPerkIcon profileInfo={profileInfo} />
+                </Ranks>
               </div>
             </CollapsibleTitle>
           </section>

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -38,6 +38,20 @@ const rankProgressionToStreakProgression: LookupTable<ProgressionHashes, number>
   [ProgressionHashes.StrangeFavor]: 1999336308,
 };
 
+// This set contains progression hashes that should not be displayed in the
+// Ranks component. The API still returns them, but they are no longer visible
+// in the game.
+const hideProgressionHashes = new Set([
+  784742260, // Engram Ensiders (Rahool)
+  2411069437, // Gunsmith Rank
+  1471185389, // Xûr Rank
+  527867935, // Strange Favor (Dares of Eternity)
+]);
+
+// This doesn't show up in the automatic progression hashes, but it is mildly
+// useful in that it will affect your Crucible reward multiplier.
+const crucibleRewardRankProgressionHash = 2206541810;
+
 /**
  * Displays all ranks for the account
  */
@@ -47,8 +61,9 @@ export default function Ranks({ profileInfo }: { profileInfo: DestinyProfileResp
 
   return (
     <PursuitGrid ranks>
-      {progressionHashes.map(
-        (progressionHash: ProgressionHashes) =>
+      {[crucibleRewardRankProgressionHash, ...progressionHashes].map(
+        (progressionHash) =>
+          !hideProgressionHashes.has(progressionHash) &&
           firstCharacterProgression[progressionHash] && (
             <ReputationRank
               key={progressionHash}

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -55,12 +55,19 @@ const crucibleRewardRankProgressionHash = 2206541810;
 /**
  * Displays all ranks for the account
  */
-export default function Ranks({ profileInfo }: { profileInfo: DestinyProfileResponse }) {
+export default function Ranks({
+  profileInfo,
+  children,
+}: {
+  profileInfo: DestinyProfileResponse;
+  children?: React.ReactNode;
+}) {
   const firstCharacterProgression = getCharacterProgressions(profileInfo)?.progressions ?? {};
   const progressionHashes = useSelector(rankProgressionHashesSelector);
 
   return (
     <PursuitGrid ranks>
+      {children}
       {[crucibleRewardRankProgressionHash, ...progressionHashes].map(
         (progressionHash) =>
           !hideProgressionHashes.has(progressionHash) &&

--- a/src/app/progress/Ranks.tsx
+++ b/src/app/progress/Ranks.tsx
@@ -34,7 +34,7 @@ import { getCharacterProgressions } from './selectors';
 //   }))
 // );
 
-const rankProgressionToStreakProgression: LookupTable<ProgressionHashes, number> = {
+const rankProgressionToStreakProgression: LookupTable<number, number> = {
   [ProgressionHashes.StrangeFavor]: 1999336308,
 };
 


### PR DESCRIPTION
Changelog: Filtered down the list of reputation ranks shown on the Progress page, and included the Crucible reward rank.
Changelog: Solstice challenges should appear on the Progress page now.
Changelog: Moved season pass rank info to the Ranks section in Progress.
Changelog: Fixed "Well Rested" perk detection, moved it to the Ranks section in Progress.

<img width="1223" height="568" alt="Screenshot 2025-08-16 at 11 35 07 AM" src="https://github.com/user-attachments/assets/d0d060b0-bf65-419d-8611-9203f1e6b90b" />
