### PR TITLE
Fix Organizer shift-click perk filter not functioning correctly

### DIFF
--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -1163,17 +1163,13 @@ function PerksCell({
                     : undefined
                 }
               >
-                <div
-                  className={styles.miniPerkContainer}
-                  data-filter-value={p.plugDef.displayProperties.name}
-                >
+                <div className={styles.miniPerkContainer}>
                   <DefItemIcon itemDef={p.plugDef} borderless={true} />
                 </div>
                 <span
                   className={clsx({
                     [styles.enhancedArrow]: isEnhancedPerk(p.plugDef),
                   })}
-                  data-filter-value={p.plugDef.displayProperties.name}
                 >
                   {p.plugDef.displayProperties.name}
                 </span>

--- a/src/app/organizer/ItemTable.tsx
+++ b/src/app/organizer/ItemTable.tsx
@@ -284,7 +284,9 @@ export default function ItemTable({ categories }: { categories: ItemCategoryTree
             if (e.shiftKey) {
               const node = e.target as HTMLElement;
               const filter = column.filter!(
-                node.dataset.filterValue ?? row.values[column.id],
+                node.dataset.filterValue ??
+                  node.parentElement?.dataset.filterValue ?? // look for filter-value at most 1 element up
+                  row.values[column.id],
                 row.item,
               );
               if (filter !== undefined) {


### PR DESCRIPTION
~~Adds the perk name as filter value to the enhancedArrow span and the perk icon~~
Looks at parent filter-value if not present on currently-clicked element
Adjusts padding for multiPerk and non-multiPerk columns to line up

Regression from #11204 

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Changelog: Fix Organizer shift-click filter behavior for perks