### PR TITLE
Fix: Tuned icon no longer wildly misplaced in Organizer/right align numbers

### DIFF
--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -14,10 +14,8 @@
 }
 
 .statValue {
-  composes: flexRow from '../dim-ui/common.m.scss';
-  align-items: center;
-  gap: 3px;
   min-width: 2ch; // Try to right-align 2-digit numbers
+  text-align: right;
 
   &.noMinWidth {
     min-width: unset;
@@ -27,6 +25,7 @@
 .bar {
   height: 80%;
   width: 100%;
+  position: relative;
   > span {
     display: block;
     background-color: rgb(255, 255, 255, 0.25);
@@ -46,5 +45,6 @@
 .tunedStatIcon {
   color: #fff;
   position: absolute;
+  left: 0;
   transform: scale(-1, 1);
 }


### PR DESCRIPTION
Temporary fix, maybe tuning icons don't belong in Organizer, but this is better than looking like they're in the wrong column.

Also numbers were supposed to be right aligned, but stat value containers were incorrectly set to flex when they only contained a single text number value..

Changelog: Fixed confusing Tuned Stat symbol placement in the Organizer.

Before
<img width="891" height="338" alt="image" src="https://github.com/user-attachments/assets/84332fe5-4a00-4a29-8ba3-15244874da1b" />

After
<img width="894" height="336" alt="image" src="https://github.com/user-attachments/assets/d63af701-d61d-4b79-82bc-1dbdad69caf6" />

Before
<img width="603" height="342" alt="image" src="https://github.com/user-attachments/assets/be71138f-ed8b-4a65-a471-9dcdb0cf33b0" />

After
<img width="595" height="340" alt="image" src="https://github.com/user-attachments/assets/d752a5eb-fa83-40e0-b859-8d16939ac298" />
