### PR TITLE
Allow `is:modded` to match non-armor

### DIFF
--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -156,13 +156,12 @@ const socketFilters: ItemFilterDefinition[] = [
     description: tl('Filter.Mods.Y3'),
     destinyVersion: 2,
     filter: () => (item) =>
-      Boolean(item.energy) &&
       item.sockets?.allSockets.some((socket) =>
         Boolean(
           socket.plugged &&
             !emptySocketHashes.includes(socket.plugged.plugDef.hash) &&
             socket.plugged.plugDef.plug?.plugCategoryIdentifier.match(
-              /(v400.weapon.mod_(guns|damage|magazine)|enhancements.)/,
+              /(v400.weapon.mod_(guns|damage|magazine)|enhancements.|v900.weapon.mod_)/,
             ) &&
             // enforce that this provides a perk (excludes empty slots)
             socket.plugged.plugDef.perks.length,


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Resolves #11301, though it also matches other things that can have mods now, like ghost shells. I'm not sure if that's desirable. If not, I can work on restricting it to just weapons and armor. 

The existing description looks to be "Shows items with any mods applied." which seems like it should cover the changed behavior already.

Changelog: `is:modded` can match items other than armor