### PR TITLE
Cache loadout analyzer results

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -411,10 +411,10 @@ function profileLoaded(
 
   let searches = state.searches ?? {};
   if (account && (profileResponse.searches || profileResponse.deletedSearchHashes?.length)) {
-    const existingSearches = profileResponse.sync
-      ? state.searches[account.destinyVersion]
-      : undefined;
-    const newSearches = [...(existingSearches ?? [])];
+    const existingSearches = profileResponse.sync ? state.searches[account.destinyVersion] : [];
+    const newSearches = !profileResponse.searches?.length
+      ? existingSearches
+      : [...existingSearches];
     for (const search of profileResponse.searches ?? []) {
       const foundSearchIndex = newSearches.findIndex(
         (s) => s.query === search.query && search.type === s.type,
@@ -437,17 +437,27 @@ function profileLoaded(
   let profiles = state.profiles;
   if (account) {
     const existingProfile = state.profiles[profileKey];
-    const existingLoadouts = profileResponse.sync ? existingProfile?.loadouts : undefined;
-    const newLoadouts = {
-      ...existingLoadouts,
-      ...keyBy(profileResponse.loadouts ?? [], (l) => l.id),
-    };
+    const existingLoadouts = profileResponse.sync ? existingProfile?.loadouts : {};
+    const newLoadouts =
+      profileResponse.sync &&
+      !profileResponse.loadouts?.length &&
+      !profileResponse.deletedLoadoutIds?.length
+        ? existingLoadouts
+        : {
+            ...existingLoadouts,
+            ...keyBy(profileResponse.loadouts ?? [], (l) => l.id),
+          };
     for (const l of profileResponse.deletedLoadoutIds ?? []) {
       delete newLoadouts[l];
     }
 
-    const existingTags = profileResponse.sync ? existingProfile?.tags : undefined;
-    const newTags = { ...existingTags, ...keyBy(profileResponse.tags ?? [], (t) => t.id) };
+    const existingTags = profileResponse.sync ? existingProfile?.tags : {};
+    const newTags =
+      profileResponse.sync &&
+      !profileResponse.tags?.length &&
+      !profileResponse.deletedTagsIds?.length
+        ? existingTags
+        : { ...existingTags, ...keyBy(profileResponse.tags ?? [], (t) => t.id) };
     for (const t of profileResponse.deletedTagsIds ?? []) {
       delete newTags[t];
     }

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -9,6 +9,7 @@ import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-ty
 import { DimCharacterStat } from 'app/inventory/store-types';
 import { filterItems } from 'app/loadout-builder/item-filter';
 import { resolveStatConstraints } from 'app/loadout-builder/loadout-params';
+import { ProcessInputs } from 'app/loadout-builder/process-worker/process';
 import type { runProcess } from 'app/loadout-builder/process/process-wrapper';
 import {
   ArmorEnergyRules,
@@ -47,6 +48,12 @@ import {
   blockAnalysisFindings,
 } from './types';
 import { mergeStrictUpgradeStatConstraints } from './utils';
+
+// TODO: This cache should be part of the loadout analyzer state, not global.
+const resultsCache = new WeakMap<
+  Loadout,
+  { hasStrictUpgrade: boolean; lastInput: ProcessInputs }
+>();
 
 export async function analyzeLoadout(
   {
@@ -321,7 +328,10 @@ export async function analyzeLoadout(
             );
 
           try {
-            const { resultPromise } = worker({
+            const { hasStrictUpgrade: lastHasStrictUpgrade, lastInput } =
+              resultsCache.get(loadout) ?? {};
+
+            const processInfo = worker({
               anyExotic: loadoutParameters.exoticArmorHash === LOCKED_EXOTIC_ANY_EXOTIC,
               armorEnergyRules,
               autoModDefs,
@@ -333,10 +343,18 @@ export async function analyzeLoadout(
               desiredStatRanges: mergedDesiredStatRanges,
               stopOnFirstSet: true,
               strictUpgrades: !mergedConstraintsImplyStrictUpgrade,
-              lastInput: undefined, // TODO: it would be nice to memoize these inputs too
-            })!;
+              lastInput,
+            });
+            if (processInfo === undefined) {
+              // If the inputs are the same as last time, we can skip the worker and just
+              // reuse the last result.
+              hasStrictUpgrade = Boolean(lastHasStrictUpgrade);
+            } else {
+              const { resultPromise, input } = processInfo;
+              hasStrictUpgrade = Boolean((await resultPromise).sets.length);
+              resultsCache.set(loadout, { hasStrictUpgrade, lastInput: input });
+            }
 
-            hasStrictUpgrade = Boolean((await resultPromise).sets.length);
             if (hasStrictUpgrade) {
               findings.add(LoadoutFinding.BetterStatsAvailable);
             }


### PR DESCRIPTION
This is not as much caching as I'd like to eventually have, but it *does* skip running Loadout Optimizer on a loadout if it really hasn't changed in a significant way. Should feel much faster.

Changelog: Sped up loadout analyzer when loadouts and inventory haven't changed.
