### PR TITLE
Allow tuning mods to be in loadouts

### DIFF
--- a/src/app/inventory/store/stats-conditional.ts
+++ b/src/app/inventory/store/stats-conditional.ts
@@ -139,7 +139,7 @@ export function isPlugStatActive(
     case 'archetypeArmorMasterwork':
       // New Armor 3.0 archetypes grant stats only to secondary stats (base 0) when masterworked,
       // so if there's already some base stat value, MW will not apply its investmentValue to this stat.
-      return !existingStat?.base;
+      return Boolean(existingStat && existingStat.base === 0);
     case 'classType':
       classType ??= item?.classType;
       if (classType === undefined) {

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,6 +1,7 @@
 import { EnergyIncrementsWithPresstip } from 'app/dim-ui/EnergyIncrements';
 import { t } from 'app/i18next-t';
 import { useItemPicker } from 'app/item-picker/item-picker';
+import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import Sockets from 'app/loadout/loadout-ui/Sockets';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
@@ -86,7 +87,7 @@ export default function GeneratedSetItem({
         lbDispatch({ type: 'lockExotic', lockedExoticHash: item.hash });
       }
     } else if (
-      plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice &&
+      !autoAssignmentPCHs.includes(plugCategoryHash) &&
       (!autoStatMods || plugCategoryHash !== PlugCategoryHashes.EnhancementsV2General)
     ) {
       lbDispatch({

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -27,13 +27,13 @@ import { findItemForLoadout, newLoadout, pickBackingStore } from 'app/loadout-dr
 import { EFFECTIVE_MAX_STAT, MAX_STAT } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
+import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName, armorStats } from 'app/search/d2-known-values';
 import { count, isEmpty, reorder } from 'app/utils/collections';
 import { emptyObject } from 'app/utils/empty';
 import { useHistory } from 'app/utils/undo-redo-history';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { keyBy, shuffle } from 'es-toolkit';
 import { useCallback, useMemo, useReducer } from 'react';
 import { useSelector } from 'react-redux';
@@ -207,11 +207,11 @@ const lbConfigInit = ({
     }
   }
 
-  // Also delete artifice mods -- artifice mods are always picked automatically
+  // Also delete always-auto-assigned mods since they are picked automatically
   // per set. In contrast we remove stat mods dynamically depending on the auto
   // stat mods setting.
   if (loadoutParameters.mods) {
-    loadoutParameters.mods = stripArtificeMods(defs, loadoutParameters.mods);
+    loadoutParameters.mods = stripAlwaysAutoAssignedMods(defs, loadoutParameters.mods);
   }
 
   loadout = { ...loadout, parameters: loadoutParameters };
@@ -227,17 +227,17 @@ const lbConfigInit = ({
 };
 
 /**
- * We never want to include artifice mods in the list of mods for a loadout
- * being edited by LO - they should be chosen by LO itself, and only re-added
- * when the loadout is saved.
+ * We never want to include always-auto-assigned mods in the list of mods for a
+ * loadout being edited by LO - they should be chosen by LO itself, and only
+ * re-added when the loadout is saved.
  */
-function stripArtificeMods(defs: D2ManifestDefinitions, mods: number[]) {
+function stripAlwaysAutoAssignedMods(defs: D2ManifestDefinitions, mods: number[]) {
   return mods.filter((modHash) => {
     const def = defs.InventoryItem.get(modHash);
     return (
-      !def ||
-      !isPluggableItem(def) ||
-      def.plug.plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice
+      def &&
+      isPluggableItem(def) &&
+      !autoAssignmentPCHs.some((h) => def.plug.plugCategoryHash === h)
     );
   });
 }
@@ -319,7 +319,7 @@ function lbConfigReducer(defs: D2ManifestDefinitions) {
 
           // Always check to make sure Artifice mods haven't snuck in - if they have, remove them
           const originalMods = updatedLoadout.parameters?.mods ?? [];
-          const strippedMods = stripArtificeMods(defs, originalMods);
+          const strippedMods = stripAlwaysAutoAssignedMods(defs, originalMods);
           if (strippedMods.length !== originalMods.length) {
             return updateMods(strippedMods)(updatedLoadout);
           }

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -121,6 +121,13 @@ export const generalSocketReusablePlugSetHash = 731468111;
  */
 export const artificeSocketReusablePlugSetHash = 4285066582;
 
+/**
+ * The reusablePlugSetHash for the tuning socket, which lets you trade off two
+ * stats.
+ * TODO: Find a way to generate this in d2ai.
+ */
+export const tuningSocketReusablePlugSetHash = 1155052024;
+
 /** Bonus to a single stat given by plugs in artifice armor's exclusive mod slot */
 export const artificeStatBoost = 3;
 /** Bonus to a single stat given by the "half tier mods" plugs in all armor's general mod slot */
@@ -131,6 +138,11 @@ export const minorStatBoost = 5;
  * is fairly engrained in some of the algorithms, so it wouldn't be quite trivial to change this.
  */
 export const majorStatBoost = 10;
+
+/** Bonus/sacrifice made to a stat when using a tuning mod. */
+export const tuningStatBoost = 5;
+/** Bonus to the three lowest stats when using "Balanced Tuning" */
+export const balancedTuningStatBoost = 1;
 
 /**
  * Special value for lockedExoticHash indicating the user would not like any exotics included in their loadouts.

--- a/src/app/loadout/ModPicker.tsx
+++ b/src/app/loadout/ModPicker.tsx
@@ -5,6 +5,7 @@ import {
   currentStoreSelector,
   profileResponseSelector,
 } from 'app/inventory/selectors';
+import { tuningSocketReusablePlugSetHash } from 'app/loadout-builder/types';
 import { ResolvedLoadoutMod } from 'app/loadout/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { unlockedItemsForCharacterOrProfilePlugSet } from 'app/records/plugset-helpers';
@@ -12,7 +13,7 @@ import { count, sumBy, uniqBy } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
 import { isClassCompatible, modMetadataByPlugCategoryHash } from 'app/utils/item-utils';
-import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
+import { getSocketsByCategoryHashes } from 'app/utils/socket-utils';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import { PlugCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import unstackableModHashes from 'data/d2/unstackable-mods.json';
@@ -77,10 +78,12 @@ function useUnlockedPlugSets(
 
       // Get all the armor mod sockets we can use for an item. Note that sockets without `plugged`
       // are considered disabled by the API
-      const modSockets = getSocketsByCategoryHash(
-        item.sockets,
+      const modSockets = getSocketsByCategoryHashes(item.sockets, [
         SocketCategoryHashes.ArmorMods,
-      ).filter((socket) => socket.socketDefinition.reusablePlugSetHash && socket.plugged);
+      ]).filter(
+        (socket) =>
+          socket.visibleInGame && socket.socketDefinition.reusablePlugSetHash && socket.plugged,
+      );
 
       // Group the sockets by their reusablePlugSetHash, this lets us get a count of available mods for
       // each socket in the case of bucket specific mods/sockets
@@ -98,6 +101,11 @@ function useUnlockedPlugSets(
           // TODO: For vaulted items, union all the unlocks and then be smart about picking the right store
           owner ?? currentStore!.id,
         );
+        for (const plugInfo of sockets[0].reusablePlugItems ?? emptyArray()) {
+          if (plugInfo.enabled && plugInfo.canInsert) {
+            unlockedPlugs.add(plugInfo.plugItemHash);
+          }
+        }
 
         const isArtificePlugSet = sockets[0].plugSet!.plugs.some(
           (p) => p?.plugDef.plug.plugCategoryHash === PlugCategoryHashes.EnhancementsArtifice,
@@ -129,7 +137,15 @@ function useUnlockedPlugSets(
           ? sockets.length
           : MAX_SLOT_INDEPENDENT_MODS;
 
-        if (plugs.length && !plugSetsByHash[plugSetHash] && !(isArtificePlugSet && usedArtifice)) {
+        if (
+          plugs.length &&
+          (!plugSetsByHash[plugSetHash] ||
+            // The tuning socket can have different unlocked mods on different
+            // items, so we need to merge them. Everything else should be
+            // identical.
+            plugSetHash === tuningSocketReusablePlugSetHash) &&
+          !(isArtificePlugSet && usedArtifice)
+        ) {
           usedArtifice ||= isArtificePlugSet;
 
           const isActivityMod = plugs.some(
@@ -138,16 +154,25 @@ function useUnlockedPlugSets(
               p.plug.plugCategoryHash === PlugCategoryHashes.EnhancementsArtifice,
           );
 
-          plugSetsByHash[plugSetHash] = {
-            plugSetHash,
-            maxSelectable,
-            selectionType: PlugSelectionType.Multi,
-            plugs,
-            selected: [],
-            overrideSelectedAndMax: isActivityMod
-              ? tl('LB.SelectModsCountActivityMods')
-              : undefined,
-          };
+          if (plugSetsByHash[plugSetHash]) {
+            // Mostly for the tuning mods, merge the plugs into the existing set
+            const existingPlugs = plugSetsByHash[plugSetHash].plugs;
+            plugSetsByHash[plugSetHash].plugs = uniqBy(
+              [...existingPlugs, ...plugs],
+              (plug) => plug.hash,
+            );
+          } else {
+            plugSetsByHash[plugSetHash] = {
+              plugSetHash,
+              maxSelectable,
+              selectionType: PlugSelectionType.Multi,
+              plugs,
+              selected: [],
+              overrideSelectedAndMax: isActivityMod
+                ? tl('LB.SelectModsCountActivityMods')
+                : undefined,
+            };
+          }
 
           if (isActivityMod) {
             plugSetsByHash[plugSetHash].getNumSelected = (allSelectedPlugs) =>

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -27,6 +27,7 @@ export const knownModPlugCategoryHashes = [
   ...armor2PlugCategoryHashes,
   ...activityModPlugCategoryHashes,
   PlugCategoryHashes.EnhancementsArtifice,
+  PlugCategoryHashes.CoreGearSystemsArmorTieringPlugsTuningMods,
 ];
 
 /**

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -11,10 +11,10 @@ import {
 } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { getSeason } from 'app/inventory/store/season';
+import { knownModPlugCategoryHashes } from 'app/loadout/known-values';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import {
   ARTIFICE_PERK_HASH,
-  armor2PlugCategoryHashes,
   killTrackerObjectivesByHash,
   killTrackerSocketTypeHash,
   tuningModToTunedStathash,
@@ -114,7 +114,7 @@ export const getModTypeTagByPlugCategoryHash = (plugCategoryHash: number): strin
 /** feed a **mod** definition into this */
 export const isArmor2Mod = (item: DestinyInventoryItemDefinition): boolean =>
   item.plug !== undefined &&
-  (armor2PlugCategoryHashes.includes(item.plug.plugCategoryHash) ||
+  (knownModPlugCategoryHashes.includes(item.plug.plugCategoryHash) ||
     specialtyModPlugCategoryHashes.includes(item.plug.plugCategoryHash));
 
 /** accepts a DimMasterwork or lack thereof */


### PR DESCRIPTION
This is a layer of changes extracted from #11391 that just lays the groundwork for being able to choose tuning mods:

1. Tuning mods can be chosen manually in the loadout editor with the mod picker.
2. The equipped loadout and any snapshotted in-game loadout will retain their tuning mods.
3. Temporarily, tuning mods can be selected manually in LO. This will be removed when we start auto-selecting them.
4. The mod assignment algorithm correctly places tuning mods, so they show up in LO sets and in the "Show Mod Placement" menu.
5. The stats for a loadout correctly include the effects of tuning mods EXCEPT for Balanced Tuning. Big changes will be needed to do that correctly since the existing code doesn't care what item the mod is plugged into, and Balanced Tuning's stat bonuses entirely depend on what item they're on.