### PR TITLE
Incremental progress towards showing correct plug stats

### DIFF
--- a/src/app/inventory/store/stats-conditional.ts
+++ b/src/app/inventory/store/stats-conditional.ts
@@ -120,9 +120,25 @@ function getPlugInvestmentStatActivationRule(
  */
 export function isPlugStatActive(
   rule: PlugStatActivationRule,
-  item: DimItem | undefined,
-  classType?: DestinyClass,
-  existingStat?: DimStat, // The stat as it existed before deciding whether to apply this plug
+  // These options are often necessary to determine if the stat is active.
+  // Providing item and existingStat/statHash is best.
+  {
+    item,
+    classType,
+    existingStat,
+    statHash,
+  }: {
+    item?: DimItem;
+    /** The class we're plugging into, if we aren't plugging an actual item. */
+    classType?: DestinyClass;
+    /**
+     * The existing stat on the item before applying this plug's stat. Defaults
+     * if item and statHash are provided.
+     */
+    existingStat?: DimStat;
+    /** The stat being considered, if existingStat isn't provided */
+    statHash?: number;
+  },
 ): boolean {
   if (!rule) {
     return true;
@@ -137,6 +153,9 @@ export function isPlugStatActive(
       return false;
 
     case 'archetypeArmorMasterwork':
+      if (!existingStat && statHash && item) {
+        existingStat = item.stats?.find((s) => s.statHash === statHash);
+      }
       // New Armor 3.0 archetypes grant stats only to secondary stats (base 0) when masterworked,
       // so if there's already some base stat value, MW will not apply its investmentValue to this stat.
       return Boolean(existingStat && existingStat.base === 0);

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -344,12 +344,10 @@ function applyPlugsToStats(
 
         // check special conditionals
         if (
-          !isPlugStatActive(
-            pluggedInvestmentStat.activationRule,
-            createdItem,
-            undefined,
+          !isPlugStatActive(pluggedInvestmentStat.activationRule, {
+            item: createdItem,
             existingStat,
-          )
+          })
         ) {
           continue;
         }
@@ -431,7 +429,7 @@ function attachPlugStats(
     for (const plugInvestmentStat of mapAndFilterInvestmentStats(activePlug.plugDef)) {
       const existingStat = statsByHash[plugInvestmentStat.statTypeHash];
       if (
-        !isPlugStatActive(plugInvestmentStat.activationRule, createdItem, undefined, existingStat)
+        !isPlugStatActive(plugInvestmentStat.activationRule, { item: createdItem, existingStat })
       ) {
         continue;
       }
@@ -476,11 +474,16 @@ function attachPlugStats(
     const plugStats: DimPlug['stats'] = {};
 
     for (const plugInvestmentStat of mapAndFilterInvestmentStats(plug.plugDef)) {
-      if (!isPlugStatActive(plugInvestmentStat.activationRule, createdItem)) {
+      const itemStat = statsByHash[plugInvestmentStat.statTypeHash];
+      if (
+        !isPlugStatActive(plugInvestmentStat.activationRule, {
+          item: createdItem,
+          existingStat: itemStat,
+        })
+      ) {
         continue;
       }
       const plugStatInvestmentValue = getPlugStatValue(createdItem, plugInvestmentStat);
-      const itemStat = statsByHash[plugInvestmentStat.statTypeHash];
       const statDisplay = statDisplaysByStatHash[plugInvestmentStat.statTypeHash];
 
       let plugStatValue = plugStatInvestmentValue;

--- a/src/app/item-popup/PlugTooltip.tsx
+++ b/src/app/item-popup/PlugTooltip.tsx
@@ -78,13 +78,15 @@ export function PlugDefTooltip({
   classType,
   automaticallyPicked,
   disabledByAutoStatMods,
+  item,
 }: {
   def: PluggableInventoryItemDefinition;
   classType?: DestinyClass;
   automaticallyPicked?: boolean;
   disabledByAutoStatMods?: boolean;
+  item?: DimItem;
 }) {
-  const stats = getPlugDefStats(def, classType);
+  const stats = getPlugDefStats(def, classType, item);
   return (
     <PlugTooltip
       def={def}

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -143,7 +143,7 @@ export default function SocketDetailsSelectedPlug({
       return undefined;
     }
 
-    if (!isPlugStatActive(stat.activationRule, item)) {
+    if (!isPlugStatActive(stat.activationRule, { item, existingStat: itemStat })) {
       return undefined;
     }
 

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -17,6 +17,7 @@ import {
   LOCKED_EXOTIC_NO_EXOTIC,
   MIN_LO_ITEM_ENERGY,
   ResolvedStatConstraint,
+  autoAssignmentPCHs,
   inGameArmorEnergyRules,
 } from 'app/loadout-builder/types';
 import {
@@ -28,7 +29,6 @@ import { fullyResolveLoadout } from 'app/loadout/ingame/selectors';
 import { MAX_STAT } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout/loadout-types';
-import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import { ModMap, categorizeArmorMods, fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
 import { ItemFilter } from 'app/search/filter-types';

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -28,6 +28,7 @@ import { fullyResolveLoadout } from 'app/loadout/ingame/selectors';
 import { MAX_STAT } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout/loadout-types';
+import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import { ModMap, categorizeArmorMods, fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
 import { ItemFilter } from 'app/search/filter-types';
@@ -261,7 +262,7 @@ export async function analyzeLoadout(
           const modsToUse = originalLoadoutMods.filter(
             (mod) =>
               // drop artifice mods (always picked automatically per set)
-              mod.resolvedMod.plug.plugCategoryHash !== PlugCategoryHashes.EnhancementsArtifice &&
+              !autoAssignmentPCHs.includes(mod.resolvedMod.plug.plugCategoryHash) &&
               // drop general mods if picked automatically
               (!loadoutParameters?.autoStatMods ||
                 mod.resolvedMod.plug.plugCategoryHash !== PlugCategoryHashes.EnhancementsV2General),

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -23,7 +23,6 @@ import {
   LoadoutEditSubclassSection,
 } from 'app/loadout/loadout-edit/LoadoutEdit';
 import { Loadout } from 'app/loadout/loadout-types';
-import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import { loadoutsSelector } from 'app/loadout/loadouts-selector';
 import { categorizeArmorMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
@@ -74,6 +73,7 @@ import {
   ArmorEnergyRules,
   LOCKED_EXOTIC_ANY_EXOTIC,
   ResolvedStatConstraint,
+  autoAssignmentPCHs,
   loDefaultArmorEnergyRules,
 } from './types';
 import useEquippedHashes from './useEquippedHashes';

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -1,7 +1,6 @@
 import { EnergyIncrementsWithPresstip } from 'app/dim-ui/EnergyIncrements';
 import { t } from 'app/i18next-t';
 import { useItemPicker } from 'app/item-picker/item-picker';
-import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import Sockets from 'app/loadout/loadout-ui/Sockets';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
@@ -13,6 +12,7 @@ import { Dispatch } from 'react';
 import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-types';
 import LoadoutBuilderItem from '../LoadoutBuilderItem';
 import { LoadoutBuilderAction } from '../loadout-builder-reducer';
+import { autoAssignmentPCHs } from '../types';
 import styles from './GeneratedSetItem.m.scss';
 
 /**

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -6,7 +6,6 @@ import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import Sockets from 'app/loadout/loadout-ui/Sockets';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
 import { getArmorArchetypeSocket } from 'app/utils/socket-utils';
-import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { Dispatch } from 'react';
@@ -128,13 +127,7 @@ export default function GeneratedSetItem({
               <AppIcon icon={lockIcon} />
             </button>
           ) : (
-            archetype && (
-              <PlugDef
-                className={styles.archetype}
-                forClassType={DestinyClass.Unknown}
-                plug={archetype}
-              />
-            )
+            archetype && <PlugDef className={styles.archetype} item={item} plug={archetype} />
           )}
         </div>
         <Sockets

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -6,6 +6,7 @@ import PlugDef from 'app/loadout/loadout-ui/PlugDef';
 import Sockets from 'app/loadout/loadout-ui/Sockets';
 import { AppIcon, faRandom, lockIcon } from 'app/shell/icons';
 import { getArmorArchetypeSocket } from 'app/utils/socket-utils';
+import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
 import { Dispatch } from 'react';
@@ -127,7 +128,13 @@ export default function GeneratedSetItem({
               <AppIcon icon={lockIcon} />
             </button>
           ) : (
-            archetype && <PlugDef className={styles.archetype} item={item} plug={archetype} />
+            archetype && (
+              <PlugDef
+                className={styles.archetype}
+                forClassType={DestinyClass.Unknown}
+                plug={archetype}
+              />
+            )
           )}
         </div>
         <Sockets

--- a/src/app/loadout-builder/loadout-builder-reducer.ts
+++ b/src/app/loadout-builder/loadout-builder-reducer.ts
@@ -27,7 +27,6 @@ import { findItemForLoadout, newLoadout, pickBackingStore } from 'app/loadout-dr
 import { EFFECTIVE_MAX_STAT, MAX_STAT } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
-import { autoAssignmentPCHs } from 'app/loadout/loadout-ui/LoadoutMods';
 import { showNotification } from 'app/notifications/notifications';
 import { armor2PlugCategoryHashesByName, armorStats } from 'app/search/d2-known-values';
 import { count, isEmpty, reorder } from 'app/utils/collections';
@@ -44,6 +43,7 @@ import {
   ExcludedItems,
   PinnedItems,
   ResolvedStatConstraint,
+  autoAssignmentPCHs,
 } from './types';
 
 interface LoadoutBuilderUI {

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -1,7 +1,7 @@
 import { AssumeArmorMasterwork, StatConstraint } from '@destinyitemmanager/dim-api-types';
 import { D2Categories } from 'app/destiny2/d2-bucket-categories';
 import { DimCharacterStat } from 'app/inventory/store-types';
-import { BucketHashes, StatHashes } from 'data/d2/generated-enums';
+import { BucketHashes, PlugCategoryHashes, StatHashes } from 'data/d2/generated-enums';
 import { DimItem, PluggableInventoryItemDefinition } from '../inventory/item-types';
 import { ProcessItem } from './process-worker/types';
 
@@ -108,6 +108,9 @@ export type ArmorStatHashes =
 
 export type StatRanges = { [statHash in ArmorStatHashes]: MinMaxStat };
 export type ArmorStats = { [statHash in ArmorStatHashes]: number };
+
+/** Do not allow the user to choose artifice mods manually in Loadout Optimizer since we're supposed to be doing that */
+export const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
 
 /**
  * The reusablePlugSetHash from armour 2.0's general socket.

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -519,7 +519,7 @@ function FashionSocket({
         <PlugDef
           onClick={handleOrnamentClick}
           plug={plug as PluggableInventoryItemDefinition}
-          forClassType={undefined}
+          item={exampleItem}
         />
       ) : (
         <PressTip

--- a/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEditSubclass.tsx
@@ -123,11 +123,7 @@ export default function LoadoutEditSubclass({
             {plugs?.map(
               (plug) =>
                 plug.socketCategoryHash !== SocketCategoryHashes.Super && (
-                  <PlugDef
-                    key={getModRenderKey(plug.plug)}
-                    plug={plug.plug}
-                    forClassType={subclass?.item.classType}
-                  />
+                  <PlugDef key={getModRenderKey(plug.plug)} plug={plug.plug} item={subclass.item} />
                 ),
             )}
           </div>

--- a/src/app/loadout/loadout-ui/FashionMods.tsx
+++ b/src/app/loadout/loadout-ui/FashionMods.tsx
@@ -43,13 +43,11 @@ export function FashionMods({
       <PlugDef
         className={clsx({ [styles.missingItem]: !canSlotShader })}
         plug={(shaderItem ?? defaultShader) as PluggableInventoryItemDefinition}
-        forClassType={undefined}
       />
       {ornamentItem ? (
         <PlugDef
           className={clsx({ [styles.missingItem]: !canSlotOrnament })}
           plug={ornamentItem as PluggableInventoryItemDefinition}
-          forClassType={undefined}
         />
       ) : (
         <PressTip tooltip={<div>{t('FashionDrawer.NoPreference')}</div>}>

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -24,7 +24,7 @@ import PlugDef from './PlugDef';
 /** Do not allow the user to choose artifice mods manually in Loadout Optimizer since we're supposed to be doing that */
 export const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
 
-const LoadoutModMemo = memo(function LoadoutMod({
+const LoadoutMod = memo(function LoadoutMod({
   mod,
   className,
   classType,
@@ -45,6 +45,7 @@ const LoadoutModMemo = memo(function LoadoutMod({
     <PlugDef
       className={className}
       plug={mod.resolvedMod}
+      // TODO: if there's an item we can assign this mod to, pass that item in
       forClassType={classType}
       onClose={onClose}
       disabledByAutoStatMods={
@@ -124,7 +125,7 @@ export const LoadoutMods = memo(function LoadoutMods({
     <div>
       <div className={styles.modsGrid}>
         {allMods.map((mod) => (
-          <LoadoutModMemo
+          <LoadoutMod
             className={clsx({
               [styles.missingItem]: !(
                 unlockedPlugSetItems.has(mod.resolvedMod.hash) ||
@@ -273,7 +274,7 @@ export const LoadoutArtifactUnlocks = memo(function LoadoutArtifactUnlocks({
                 mod.resolvedMod.hash,
               );
               return (
-                <LoadoutModMemo
+                <LoadoutMod
                   key={mod.resolvedMod.hash}
                   mod={mod}
                   className={clsx({

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -4,6 +4,7 @@ import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { artifactUnlocksSelector, unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
 import { hashesToPluggableItems } from 'app/inventory/store/sockets';
+import { autoAssignmentPCHs } from 'app/loadout-builder/types';
 import { Loadout, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
@@ -20,9 +21,6 @@ import { useLoadoutMods } from '../mod-assignment-drawer/selectors';
 import { createGetModRenderKey } from '../mod-utils';
 import styles from './LoadoutMods.m.scss';
 import PlugDef from './PlugDef';
-
-/** Do not allow the user to choose artifice mods manually in Loadout Optimizer since we're supposed to be doing that */
-export const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
 
 const LoadoutMod = memo(function LoadoutMod({
   mod,

--- a/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutSubclassSection.tsx
@@ -37,13 +37,7 @@ export default function LoadoutSubclassSection({
         })}
       >
         {subclass ? (
-          <PressTip
-            tooltip={() =>
-              superPlug && (
-                <PlugDefTooltip def={superPlug?.plug} classType={subclass?.item.classType} />
-              )
-            }
-          >
+          <PressTip tooltip={() => superPlug && <PlugDefTooltip def={superPlug?.plug} />}>
             <DraggableInventoryItem item={subclass.item}>
               <ItemPopupTrigger
                 item={subclass.item}
@@ -76,11 +70,7 @@ export default function LoadoutSubclassSection({
           {plugs?.map(
             (plug) =>
               plug.socketCategoryHash !== SocketCategoryHashes.Super && (
-                <PlugDef
-                  key={getModRenderKey(plug.plug)}
-                  plug={plug.plug}
-                  forClassType={subclass?.item.classType}
-                />
+                <PlugDef key={getModRenderKey(plug.plug)} plug={plug.plug} item={subclass?.item} />
               ),
           )}
         </div>

--- a/src/app/loadout/loadout-ui/PlugDef.tsx
+++ b/src/app/loadout/loadout-ui/PlugDef.tsx
@@ -1,7 +1,7 @@
 import ClosableContainer from 'app/dim-ui/ClosableContainer';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
-import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { PlugDefTooltip } from 'app/item-popup/PlugTooltip';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
@@ -17,6 +17,7 @@ export default function PlugDef({
   automaticallyPicked,
   disabledByAutoStatMods,
   forClassType,
+  item,
 }: {
   plug: PluggableInventoryItemDefinition;
   className?: string;
@@ -24,7 +25,10 @@ export default function PlugDef({
   onClose?: () => void;
   automaticallyPicked?: boolean;
   disabledByAutoStatMods?: boolean;
-  forClassType: DestinyClass | undefined;
+  /** The class this plug is or will be plugged into, if we don't have the item. */
+  forClassType?: DestinyClass;
+  /** The item this plug is or will be plugged into. */
+  item?: DimItem;
 }) {
   const contents = (
     <div
@@ -41,6 +45,7 @@ export default function PlugDef({
             automaticallyPicked={automaticallyPicked}
             disabledByAutoStatMods={disabledByAutoStatMods}
             classType={forClassType}
+            item={item}
           />
         )}
       >

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -119,7 +119,7 @@ function Sockets({
           plug={plugDef}
           onClick={onSocketClick ? () => onSocketClick(plugDef, whitelist) : undefined}
           automaticallyPicked={automaticallyPicked}
-          forClassType={item.classType}
+          item={item}
         />
       ))}
       {item.vendor && <VendorItemPlug item={item} />}

--- a/src/app/loadout/plug-drawer/Footer.tsx
+++ b/src/app/loadout/plug-drawer/Footer.tsx
@@ -8,15 +8,6 @@ import { createGetModRenderKey } from '../mod-utils';
 import styles from './Footer.m.scss';
 import { PlugSelectionType, PlugSet } from './types';
 
-interface Props {
-  isPhonePortrait: boolean;
-  plugSets: PlugSet[];
-  classType: DestinyClass;
-  acceptButtonText: string;
-  onSubmit: (event: React.FormEvent | KeyboardEvent) => void;
-  handlePlugSelected: (plug: PluggableInventoryItemDefinition) => void;
-}
-
 export default function Footer({
   isPhonePortrait,
   plugSets,
@@ -24,10 +15,18 @@ export default function Footer({
   acceptButtonText,
   onSubmit,
   handlePlugSelected,
-}: Props) {
+}: {
+  isPhonePortrait: boolean;
+  plugSets: PlugSet[];
+  classType: DestinyClass;
+  acceptButtonText: string;
+  onSubmit: (event: React.FormEvent | KeyboardEvent) => void;
+  handlePlugSelected: (plug: PluggableInventoryItemDefinition) => void;
+}) {
   useHotkey('enter', acceptButtonText, onSubmit);
   const getModRenderKey = createGetModRenderKey();
 
+  // TODO: Plumb in the item we're picking for, if there is one
   return (
     <div className={styles.footer}>
       <button type="button" className={styles.submitButton} onClick={onSubmit}>

--- a/src/app/loadout/plug-drawer/SelectablePlug.tsx
+++ b/src/app/loadout/plug-drawer/SelectablePlug.tsx
@@ -138,7 +138,7 @@ function SelectablePlugDetails({
   plug: PluggableInventoryItemDefinition;
   classType: DestinyClass;
 }) {
-  const stats = getPlugDefStats(plug, classType);
+  const stats = getPlugDefStats(plug, classType, undefined);
 
   const plugDescriptions = usePlugDescriptions(plug, stats);
 

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -116,7 +116,12 @@ export function getTotalModStatChanges(
       for (const stat of mapAndFilterInvestmentStats(mod)) {
         if (
           stat.statTypeHash in totals &&
-          isPlugStatActive(stat.activationRule, undefined, characterClass)
+          // TODO: For balanced tuning mod, we need to know the existing stat
+          // value on the actual item that will be plugged into
+          isPlugStatActive(stat.activationRule, {
+            classType: characterClass,
+            statHash: stat.statTypeHash,
+          })
         ) {
           const value = stat.value * modCount;
           totals[stat.statTypeHash as ArmorStatHashes].value += value;

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -1,6 +1,6 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { bungieNetPath } from 'app/dim-ui/BungieImage';
-import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimCharacterStatSource } from 'app/inventory/store-types';
 import { hashesToPluggableItems } from 'app/inventory/store/sockets';
 import {
@@ -91,6 +91,7 @@ export function getTotalModStatChanges(
    * but are active often enough to be important for loadout building.
    */
   includeRuntimeStatBenefits: boolean,
+  modToItem?: Map<PluggableInventoryItemDefinition, DimItem>,
 ) {
   const subclassPlugs = subclass?.loadoutItem.socketOverrides
     ? hashesToPluggableItems(defs, Object.values(subclass.loadoutItem.socketOverrides))
@@ -116,11 +117,10 @@ export function getTotalModStatChanges(
       for (const stat of mapAndFilterInvestmentStats(mod)) {
         if (
           stat.statTypeHash in totals &&
-          // TODO: For balanced tuning mod, we need to know the existing stat
-          // value on the actual item that will be plugged into
           isPlugStatActive(stat.activationRule, {
             classType: characterClass,
             statHash: stat.statTypeHash,
+            item: modToItem?.get(mod),
           })
         ) {
           const value = stat.value * modCount;

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -299,6 +299,7 @@ function getPerkDescriptions(
 export function getPlugDefStats(
   plugDef: PluggableInventoryItemDefinition,
   classType: DestinyClass | undefined,
+  item: DimItem | undefined,
 ) {
   return mapAndFilterInvestmentStats(plugDef)
     .filter(
@@ -306,8 +307,7 @@ export function getPlugDefStats(
         (isAllowedItemStat(stat.statTypeHash) || isAllowedPlugStat(stat.statTypeHash)) &&
         // TODO: For balanced tuning mod, we need to know the existing stat
         // value on the actual item that will be plugged into
-        (classType === undefined ||
-          isPlugStatActive(stat.activationRule, { classType, statHash: stat.statTypeHash })),
+        isPlugStatActive(stat.activationRule, { classType, item, statHash: stat.statTypeHash }),
     )
     .map((stat) => ({
       statHash: stat.statTypeHash,

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -304,7 +304,10 @@ export function getPlugDefStats(
     .filter(
       (stat) =>
         (isAllowedItemStat(stat.statTypeHash) || isAllowedPlugStat(stat.statTypeHash)) &&
-        (classType === undefined || isPlugStatActive(stat.activationRule, undefined, classType)),
+        // TODO: For balanced tuning mod, we need to know the existing stat
+        // value on the actual item that will be plugged into
+        (classType === undefined ||
+          isPlugStatActive(stat.activationRule, { classType, statHash: stat.statTypeHash })),
     )
     .map((stat) => ({
       statHash: stat.statTypeHash,

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -305,8 +305,6 @@ export function getPlugDefStats(
     .filter(
       (stat) =>
         (isAllowedItemStat(stat.statTypeHash) || isAllowedPlugStat(stat.statTypeHash)) &&
-        // TODO: For balanced tuning mod, we need to know the existing stat
-        // value on the actual item that will be plugged into
         isPlugStatActive(stat.activationRule, { classType, item, statHash: stat.statTypeHash }),
     )
     .map((stat) => ({


### PR DESCRIPTION
This plumbs the item being plugged into down to a bunch of things (but not everything, sadly) in order to make the stat previews (tooltips, calculations, etc.) more accurate. The main takeaway is that "Balanced Tuning" mods show correct stats on the Loadouts page now, but not on the LO generated sets list. It's a step.