### PR TITLE
Adjust enhancedArrow so that perk names that take up multiple lines center the arrow instead of putting it on the top line

### DIFF
--- a/src/app/item-feed/Highlights.m.scss
+++ b/src/app/item-feed/Highlights.m.scss
@@ -31,8 +31,7 @@
   flex-direction: row;
   align-items: center;
   gap: 2px;
-
-  > img {
+  img {
     height: 24px;
     width: 24px;
     margin-left: -1px;
@@ -40,7 +39,8 @@
 }
 // copy pasted from src/app/item-popup/PlugTooltip.m.scss
 .enhancedArrow {
-  &::before {
+  display: flex;
+  &::after {
     content: '';
     display: inline-block;
     width: 9px;
@@ -48,7 +48,8 @@
     vertical-align: text-bottom;
     mask-image: url('images/enhancedArrow.svg');
     background-color: $enhancedYellow;
-    margin-right: 3px;
+    margin-left: 1px;
+    margin-top: 4px;
   }
 }
 

--- a/src/app/item-feed/Highlights.tsx
+++ b/src/app/item-feed/Highlights.tsx
@@ -52,14 +52,14 @@ export default function Highlights({ item }: { item: DimItem }) {
                   tooltip={() => <DimPlugTooltip item={item} plug={p} />}
                   className={styles.perk}
                 >
-                  <DefItemIcon itemDef={p.plugDef} borderless={true} />
-                  <span
+                  <div
                     className={clsx({
                       [styles.enhancedArrow]: isEnhancedPerk(p.plugDef),
                     })}
                   >
-                    {p.plugDef.displayProperties.name}
-                  </span>
+                    <DefItemIcon itemDef={p.plugDef} borderless={true} />
+                  </div>
+                  {p.plugDef.displayProperties.name}
                 </PressTip>
               ))}
             </div>

--- a/src/app/organizer/Columns.m.scss
+++ b/src/app/organizer/Columns.m.scss
@@ -140,7 +140,7 @@
   composes: flexRow from '../dim-ui/common.m.scss';
   composes: noWrap;
   align-items: flex-start;
-  gap: 3px;
+  gap: 2px;
 }
 .miniPerkContainer {
   --item-size: 18px;
@@ -164,7 +164,9 @@
 }
 // copy pasted from src/app/item-popup/PlugTooltip.m.scss
 .enhancedArrow {
-  &::before {
+  width: 30px;
+  display: flex;
+  &::after {
     content: '';
     display: inline-block;
     width: 9px;
@@ -172,7 +174,8 @@
     vertical-align: text-bottom;
     mask-image: url('images/enhancedArrow.svg');
     background-color: $enhancedYellow;
-    margin-right: 3px;
+    margin-left: 1px;
+    margin-top: 1px;
   }
 }
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -1163,16 +1163,14 @@ function PerksCell({
                     : undefined
                 }
               >
-                <div className={styles.miniPerkContainer}>
-                  <DefItemIcon itemDef={p.plugDef} borderless={true} />
-                </div>
-                <span
-                  className={clsx({
+                <div
+                  className={clsx(styles.miniPerkContainer, {
                     [styles.enhancedArrow]: isEnhancedPerk(p.plugDef),
                   })}
                 >
-                  {p.plugDef.displayProperties.name}
-                </span>
+                  <DefItemIcon itemDef={p.plugDef} borderless={true} />
+                </div>
+                {p.plugDef.displayProperties.name}
               </div>
             </PressTip>
           ))}


### PR DESCRIPTION

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Changelog: Adjust enhanced perk arrow when perk name takes up more than 1 line

<details>
<summary>Screenshots (old, then new)</summary>
<img width="302" height="755" alt="Screenshot 2025-08-25 at 12 23 15 AM" src="https://github.com/user-attachments/assets/dc5c81ea-7c25-49d4-b443-b84b80018c46" />
<img width="291" height="757" alt="Screenshot 2025-08-25 at 12 23 10 AM" src="https://github.com/user-attachments/assets/374b6b2a-3635-46f4-8051-f599387a01d2" />

<img width="1708" height="816" alt="Screenshot 2025-08-25 at 12 22 56 AM" src="https://github.com/user-attachments/assets/da9eeeae-1525-4391-9c5c-8ea203afb645" />
<img width="1707" height="822" alt="Screenshot 2025-08-25 at 12 22 42 AM" src="https://github.com/user-attachments/assets/316bbd6c-ea83-4b19-a406-24242faca711" />


</details>
