### PR TITLE
LO: Support auto assigning tuning mods

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -629,6 +629,7 @@
   },
   "LoadoutBuilder": {
     "AutomaticallyPicked": "This mod was added automatically to improve build stats.",
+    "AlwaysAutoMods": "Artifice and Tuning mods will always be chosen automatically.",
     "DisabledByAutoStatMods": "Stat mods are being chosen automatically by Loadout Optimizer.",
     "AutoStatMods": "Automatically add stat mods",
     "All": "All",

--- a/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
+++ b/src/app/loadout-builder/filter/TierlessStatConstraintEditor.tsx
@@ -423,8 +423,8 @@ function StatBar({
         <div
           className={clsx(styles.statBarFill, { [styles.processing]: processing })}
           style={{
-            left: percent(range.minStat / MAX_STAT),
-            width: percent((range.maxStat - range.minStat) / MAX_STAT),
+            left: percent(Math.max(0, range.minStat) / MAX_STAT),
+            width: percent(Math.min(range.maxStat - range.minStat, MAX_STAT) / MAX_STAT),
           }}
         />
       )}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -93,6 +93,7 @@ export default memo(function GeneratedSet({
   // Assign the chosen mods to items so we can display them as if they were slotted
   const [itemModAssignments, resultingItemEnergies] = useMemo(() => {
     const allMods = [...lockedMods, ...autoMods];
+    // TODO: this isn't assigning the tuning mods correctly, and we aren't calculating balanced tuning stats correctly either.
     const { itemModAssignments, unassignedMods, invalidMods, resultingItemEnergies } = fitMostMods({
       defs,
       items: displayedItems,

--- a/src/app/loadout-builder/process-worker/process-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.test.ts
@@ -126,31 +126,31 @@ describe('process-utils mod assignment', () => {
           helmet = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
-          });
+          })[0];
         }
         if (!arms && isArmor2Arms(storeItem)) {
           arms = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
-          });
+          })[0];
         }
         if (!chest && isArmor2Chest(storeItem)) {
           chest = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
-          });
+          })[0];
         }
         if (!legs && isArmor2Legs(storeItem)) {
           legs = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
-          });
+          })[0];
         }
         if (!classItem && isArmor2ClassItem(storeItem)) {
           classItem = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
-          });
+          })[0];
         }
 
         if (helmet && arms && chest && legs && classItem) {

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -89,7 +89,7 @@ export function process({
   for (const item of ArmorBucketHashes.flatMap((h) => filteredItems[h])) {
     statsCache.set(
       item,
-      statOrder.map((statHash) => Math.max(item.stats[statHash], 0)),
+      statOrder.map((statHash) => item.stats[statHash]),
     );
   }
 
@@ -436,6 +436,12 @@ export function process({
 
     let hasStrictUpgrade = false;
 
+    const helmStats = statsCache.get(armor[0])!;
+    const gauntStats = statsCache.get(armor[1])!;
+    const chestStats = statsCache.get(armor[2])!;
+    const legStats = statsCache.get(armor[3])!;
+    const classItemStats = statsCache.get(armor[4])!;
+
     for (let i = 0; i < statOrder.length; i++) {
       const statHash = statOrder[i];
       const value = stats[i] + bonusStats[i];
@@ -448,11 +454,11 @@ export function process({
         statFilter.minStat < statFilter.maxStat &&
         !hasStrictUpgrade
       ) {
-        const statValue = Math.min(Math.max(value, 0), MAX_STAT);
-        hasStrictUpgrade ||= statValue > statFilter.minStat;
+        hasStrictUpgrade ||= value > statFilter.minStat;
       }
 
-      armorOnlyStats[statHash] = stats[i] - modStatsInStatOrder[i];
+      armorOnlyStats[statHash] =
+        helmStats[i] + gauntStats[i] + chestStats[i] + legStats[i] + classItemStats[i];
     }
 
     if (strictUpgrades && !hasStrictUpgrade) {

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -1,6 +1,6 @@
 import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { MAX_STAT } from 'app/loadout/known-values';
-import { filterMap } from 'app/utils/collections';
+import { compact, filterMap } from 'app/utils/collections';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { infoLog } from '../../utils/log';
 import {
@@ -397,6 +397,17 @@ export function process({
             // This encodes each stat value (0-200) into 8 bits, packed into a single integer.
             // Only non-ignored stats are included, maintaining lexical ordering for priority.
             const numericStatMix = encodeStatMix(finalStats, desiredStatRanges);
+
+            // Add on any tuning mods that were preset on the items.
+            mods.push(
+              ...compact([
+                helm.includedTuningMod,
+                gaunt.includedTuningMod,
+                chest.includedTuningMod,
+                leg.includedTuningMod,
+                classItem.includedTuningMod,
+              ]),
+            );
 
             processStatistics.numValidSets++;
             // And now insert our set using the predicted total tier and numeric stat mix.

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -31,6 +31,11 @@ export interface ProcessItem {
   stats: { [statHash: number]: number };
   compatibleModSeasons?: string[];
   setBonus?: number;
+  /**
+   * This is a pre-set tuning mod on the item. This hash should be passed along
+   * to the ArmorSet.statMods list.
+   */
+  includedTuningMod?: number;
 }
 
 export type ProcessItemsByBucket = {

--- a/src/app/loadout-builder/process/mappers.test.ts
+++ b/src/app/loadout-builder/process/mappers.test.ts
@@ -28,7 +28,7 @@ describe('lo process mappers', () => {
         assumeArmorMasterwork: AssumeArmorMasterwork.All,
       },
       modsForSlot: [],
-    });
+    })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(10);
   });
@@ -42,7 +42,7 @@ describe('lo process mappers', () => {
       dimItem: modifiedItem,
       armorEnergyRules: loDefaultArmorEnergyRules,
       modsForSlot: [],
-    });
+    })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(modifiedItem.energy?.energyCapacity);
   });
@@ -56,7 +56,7 @@ describe('lo process mappers', () => {
       dimItem: modifiedItem,
       armorEnergyRules: loDefaultArmorEnergyRules,
       modsForSlot: [],
-    });
+    })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(MIN_LO_ITEM_ENERGY);
   });

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -1,5 +1,9 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { isPluggableItem } from 'app/inventory/store/sockets';
+import {
+  isPlugStatActive,
+  mapAndFilterInvestmentStats,
+} from 'app/inventory/store/stats-conditional';
 import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
 import { calculateAssumedItemEnergy, isAssumedArtifice } from 'app/loadout/armor-upgrade-utils';
 import {
@@ -98,8 +102,11 @@ export function mapDimItemToProcessItem({
         const def = plug.plugDef;
         if (isPluggableItem(def) && def.investmentStats?.length) {
           const tunedStats = { ...stats };
-          for (const { statTypeHash, value } of def.investmentStats) {
-            if (statTypeHash in armorStats) {
+          for (const { statTypeHash, activationRule, value } of mapAndFilterInvestmentStats(def)) {
+            if (
+              armorStats.includes(statTypeHash) &&
+              isPlugStatActive(activationRule, { item: dimItem, statHash: statTypeHash })
+            ) {
               tunedStats[statTypeHash] = Math.min(MAX_STAT, tunedStats[statTypeHash] + value);
             }
           }

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -108,14 +108,16 @@ export function runProcess({
     const bucketHash = parseInt(bucketHashStr, 10) as ArmorBucketHash;
     processItems[bucketHash] = [];
 
-    const mappedItems: MappedItem[] = items.map((dimItem) => ({
-      dimItem,
-      processItem: mapDimItemToProcessItem({
+    const mappedItems: MappedItem[] = items.flatMap((dimItem) =>
+      mapDimItemToProcessItem({
         dimItem,
         armorEnergyRules,
         modsForSlot: bucketSpecificMods[bucketHash] || [],
-      }),
-    }));
+      }).map((processItem) => ({
+        dimItem,
+        processItem,
+      })),
+    );
 
     for (const mappedItem of mappedItems) {
       processItems[bucketHash].push(mappedItem.processItem);

--- a/src/app/loadout-builder/types.ts
+++ b/src/app/loadout-builder/types.ts
@@ -109,8 +109,11 @@ export type ArmorStatHashes =
 export type StatRanges = { [statHash in ArmorStatHashes]: MinMaxStat };
 export type ArmorStats = { [statHash in ArmorStatHashes]: number };
 
-/** Do not allow the user to choose artifice mods manually in Loadout Optimizer since we're supposed to be doing that */
-export const autoAssignmentPCHs = [PlugCategoryHashes.EnhancementsArtifice];
+/** Do not allow the user to choose artifice/tuning mods manually in Loadout Optimizer since we're supposed to be doing that */
+export const autoAssignmentPCHs = [
+  PlugCategoryHashes.EnhancementsArtifice,
+  PlugCategoryHashes.CoreGearSystemsArmorTieringPlugsTuningMods,
+];
 
 /**
  * The reusablePlugSetHash from armour 2.0's general socket.

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -334,28 +334,21 @@ export function getLoadoutStats(
   }
 
   // Assign the chosen mods to items so we can display them as if they were slotted
-  const { itemModAssignments } = fitMostMods({
+  const { itemModAssignments, unassignedMods } = fitMostMods({
     defs,
     items: armor,
     plannedMods: mods,
     armorEnergyRules: armorEnergyRules ?? inGameArmorEnergyRules,
   });
-  const modToItem = new Map<PluggableInventoryItemDefinition, DimItem>(
-    Object.entries(itemModAssignments).flatMap(([itemId, mods]) =>
-      filterMap(mods, (m) => {
-        const item = armor.find((i) => i.id === itemId);
-        return item ? ([m, item] as const) : undefined;
-      }),
-    ),
-  );
 
   const modStats = getTotalModStatChanges(
     defs,
-    mods,
+    unassignedMods,
     subclass,
     classType,
     includeRuntimeStatBenefits,
-    modToItem,
+    itemModAssignments,
+    armor,
   );
 
   for (const [statHash, value] of Object.entries(modStats)) {

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss
@@ -53,3 +53,10 @@
   margin-top: 8px;
   gap: 4px;
 }
+
+.fineprint {
+  font-size: 0.85em;
+  color: var(--theme-text-secondary);
+  text-wrap: pretty;
+  margin-top: 4px;
+}

--- a/src/app/loadout/loadout-ui/LoadoutMods.m.scss.d.ts
+++ b/src/app/loadout/loadout-ui/LoadoutMods.m.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'artifactUnlock': string;
   'buttons': string;
+  'fineprint': string;
   'missingItem': string;
   'modsGrid': string;
   'modsPlaceholder': string;

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -185,13 +185,16 @@ export const LoadoutMods = memo(function LoadoutMods({
             )}
 
             {$featureFlags.loAutoStatMods && onAutoStatModsChanged && (
-              <CheckButton
-                onChange={onAutoStatModsChanged}
-                name="autoStatMods"
-                checked={Boolean(autoStatMods)}
-              >
-                {t('LoadoutBuilder.AutoStatMods')}
-              </CheckButton>
+              <>
+                <CheckButton
+                  onChange={onAutoStatModsChanged}
+                  name="autoStatMods"
+                  checked={Boolean(autoStatMods)}
+                >
+                  {t('LoadoutBuilder.AutoStatMods')}
+                </CheckButton>
+                <div className={styles.fineprint}>{t('LoadoutBuilder.AlwaysAutoMods')}</div>
+              </>
             )}
           </div>
         )}

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -186,6 +186,7 @@ export function getTotalModStatChanges(
   processPlugs(lockedModAssignments, 'armorPlug');
 
   if (includeRuntimeStatBenefits) {
+    const lockedMods = lockedModAssignments.map(([m]) => m);
     const fontCounts = getFontMods(lockedMods);
     for (const statHash of armorStats) {
       const fonts = fontCounts[statHash];

--- a/src/app/loadout/stats.ts
+++ b/src/app/loadout/stats.ts
@@ -11,7 +11,7 @@ import { ArmorStatHashes, ModStatChanges } from 'app/loadout-builder/types';
 import { ResolvedLoadoutItem } from 'app/loadout/loadout-types';
 import { mapToOtherModCostVariant } from 'app/loadout/mod-utils';
 import { armorStats } from 'app/search/d2-known-values';
-import { mapValues } from 'app/utils/collections';
+import { filterMap, mapValues } from 'app/utils/collections';
 import { emptyArray } from 'app/utils/empty';
 import { HashLookup } from 'app/utils/util-types';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -76,12 +76,32 @@ export function includesRuntimeStatMods(modHashes: number[]) {
 }
 
 /**
+ * Given a mod assignment mapping (which goes from item ID to assigned mods),
+ * produce a list of mod, item pairs. This is meant to be used in
+ * getTotalModStatChanges.
+ */
+function invertModAssignments(
+  itemModAssignments: {
+    [itemInstanceId: string]: PluggableInventoryItemDefinition[];
+  },
+  armor: DimItem[],
+): [PluggableInventoryItemDefinition, DimItem][] {
+  return Object.entries(itemModAssignments).flatMap(([itemId, mods]) =>
+    filterMap(mods, (m): [PluggableInventoryItemDefinition, DimItem] | undefined => {
+      const item = armor.find((i) => i.id === itemId);
+      return item ? ([m, item] as const) : undefined;
+    }),
+  );
+}
+
+/**
  * This sums up the total stat contributions across mods passed in. These are then applied
  * to the loadouts after all the items' base stat values have been summed. This mimics how mods
  * affect stat values in game and allows us to do some preprocessing.
  */
 export function getTotalModStatChanges(
   defs: D2ManifestDefinitions,
+  /** The mods to compute stats for. When itemModAssignments is passed, this should be the list of unassigned mods. */
   lockedMods: PluggableInventoryItemDefinition[],
   subclass: ResolvedLoadoutItem | undefined,
   characterClass: DestinyClass,
@@ -91,7 +111,16 @@ export function getTotalModStatChanges(
    * but are active often enough to be important for loadout building.
    */
   includeRuntimeStatBenefits: boolean,
-  modToItem?: Map<PluggableInventoryItemDefinition, DimItem>,
+  /**
+   * When getting mod benefits for auto stat mods, we need to know what the
+   * items we assigned to are, so that we can correctly calculate conditional
+   * stats.
+   */
+  itemModAssignments?: {
+    [itemInstanceId: string]: PluggableInventoryItemDefinition[];
+  },
+  /** When itemModAssigments is provided, we also need the list of items. */
+  armor?: DimItem[],
 ) {
   const subclassPlugs = subclass?.loadoutItem.socketOverrides
     ? hashesToPluggableItems(defs, Object.values(subclass.loadoutItem.socketOverrides))
@@ -106,40 +135,55 @@ export function getTotalModStatChanges(
     [StatHashes.Melee]: { value: 0, breakdown: [] },
   };
 
+  const lockedModAssignments = (
+    [
+      ...(itemModAssignments && armor ? invertModAssignments(itemModAssignments, armor) : []),
+      ...lockedMods.map((m) => [m, undefined]),
+    ] as [PluggableInventoryItemDefinition, DimItem | undefined][]
+  ).sort(([a], [b]) => a.hash - b.hash);
+
   const processPlugs = (
-    plugs: PluggableInventoryItemDefinition[],
+    modAssignments:
+      | PluggableInventoryItemDefinition[]
+      | [PluggableInventoryItemDefinition, DimItem | undefined][],
     source: DimCharacterStatSource,
   ) => {
-    const grouped = Map.groupBy(plugs, (plug) => plug.hash);
-    for (const plugCopies of grouped.values()) {
-      const mod = plugCopies[0];
-      const modCount = plugCopies.length;
+    for (const modAssignment of modAssignments) {
+      const [mod, item] = Array.isArray(modAssignment) ? modAssignment : [modAssignment, undefined];
       for (const stat of mapAndFilterInvestmentStats(mod)) {
         if (
           stat.statTypeHash in totals &&
           isPlugStatActive(stat.activationRule, {
             classType: characterClass,
             statHash: stat.statTypeHash,
-            item: modToItem?.get(mod),
+            item,
           })
         ) {
-          const value = stat.value * modCount;
+          const value = stat.value;
           totals[stat.statTypeHash as ArmorStatHashes].value += value;
-          totals[stat.statTypeHash as ArmorStatHashes].breakdown!.push({
-            name: mod.displayProperties.name,
-            icon: bungieNetPath(mod.displayProperties.icon),
-            hash: mod.hash,
-            count: modCount,
-            source,
-            value,
-          });
+          const breakdown = totals[stat.statTypeHash as ArmorStatHashes].breakdown!;
+          const lastEntry = breakdown[breakdown.length - 1];
+          if (lastEntry?.hash === mod.hash) {
+            // merge stacks of the same mod
+            lastEntry.count!++;
+            lastEntry.value += value;
+          } else {
+            totals[stat.statTypeHash as ArmorStatHashes].breakdown!.push({
+              name: mod.displayProperties.name,
+              icon: bungieNetPath(mod.displayProperties.icon),
+              hash: mod.hash,
+              count: 1,
+              source,
+              value,
+            });
+          }
         }
       }
     }
   };
 
   processPlugs(subclassPlugs, 'subclassPlug');
-  processPlugs(lockedMods, 'armorPlug');
+  processPlugs(lockedModAssignments, 'armorPlug');
 
   if (includeRuntimeStatBenefits) {
     const fontCounts = getFontMods(lockedMods);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -665,6 +665,7 @@
   },
   "LoadoutBuilder": {
     "All": "All",
+    "AlwaysAutoMods": "Artifice and Tuning mods will always be chosen automatically.",
     "AnyExotic": "Any Exotic",
     "AnyExoticDescription": "Sets must contain an exotic, but any exotic will do.",
     "Artifice": "Artifice",


### PR DESCRIPTION
This implements the "simple" version of assigning tuning mods, which just makes 6 copies of every tunable item instead of having the LO process try and actually assign the mods. It makes the LO much slower, because it has to process a lot more combinations. But it seems to work. In the future we can try to speed this up but I'd rather just have it available.

Changelog: Loadout Optimizer now automatically assigns Tier 5 tuning mods where available. This can make major differences in what stats you can achieve!
