### PR TITLE
Parallelize Loadout Optimizer to run on multiple cores

### DIFF
--- a/src/app/loadout-analyzer/analysis.test.ts
+++ b/src/app/loadout-analyzer/analysis.test.ts
@@ -4,10 +4,10 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { ProcessInputs } from 'app/loadout-builder/process-worker/process';
-import { ProcessResult } from 'app/loadout-builder/process-worker/types';
+import { ProcessStatistics } from 'app/loadout-builder/process-worker/types';
 import { getAutoMods } from 'app/loadout-builder/process/mappers';
-import type { runProcess } from 'app/loadout-builder/process/process-wrapper';
-import { ArmorBucketHashes, ArmorSet, StatRanges } from 'app/loadout-builder/types';
+import type { runProcess, RunProcessResult } from 'app/loadout-builder/process/process-wrapper';
+import { ArmorBucketHashes, StatRanges } from 'app/loadout-builder/types';
 import { randomSubclassConfiguration } from 'app/loadout-drawer/auto-loadouts';
 import { addItem, setLoadoutParameters } from 'app/loadout-drawer/loadout-drawer-reducer';
 import {
@@ -46,7 +46,7 @@ const analyze = async (
 
 function noopProcessWorkerMock(..._args: Parameters<typeof runProcess>): {
   cleanup: () => void;
-  resultPromise: Promise<Omit<ProcessResult, 'sets'> & { sets: ArmorSet[]; processTime: number }>;
+  resultPromise: Promise<RunProcessResult>;
   input: ProcessInputs;
 } {
   return {
@@ -55,7 +55,7 @@ function noopProcessWorkerMock(..._args: Parameters<typeof runProcess>): {
       combos: 0,
       processTime: 0,
       sets: [],
-      processInfo: undefined,
+      processInfo: undefined as unknown as ProcessStatistics,
       statRangesFiltered: Object.fromEntries(
         armorStats.map((h) => [
           h,

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -325,11 +325,10 @@ export function pickAndAssignSlotIndependentMods(
       if (result) {
         return result;
       }
-    } else {
-      remainingEnergyCapacities.sort((a, b) => b - a);
-      if (info.generalModCosts.every((cost, index) => cost <= remainingEnergyCapacities[index])) {
-        return [];
-      }
+    } else if (
+      info.generalModCosts.every((cost, index) => cost <= remainingEnergyCapacities[index])
+    ) {
+      return [];
     }
   }
 

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -59,18 +59,21 @@ export interface ProcessInputs {
  * @param filteredItems pared down list of items to process sets from
  * @param modStatTotals Stats that are applied to final stat totals, think general and other mod stats
  */
-export function process({
-  filteredItems,
-  modStatTotals,
-  lockedMods,
-  setBonuses,
-  desiredStatRanges,
-  anyExotic,
-  autoModOptions,
-  autoStatMods,
-  strictUpgrades,
-  stopOnFirstSet,
-}: ProcessInputs): ProcessResult {
+export function process(
+  workerNum: number,
+  {
+    filteredItems,
+    modStatTotals,
+    lockedMods,
+    setBonuses,
+    desiredStatRanges,
+    anyExotic,
+    autoModOptions,
+    autoStatMods,
+    strictUpgrades,
+    stopOnFirstSet,
+  }: ProcessInputs,
+): ProcessResult {
   const pstart = performance.now();
 
   // For efficiency, we'll handle most stats as flat arrays in the order the user prioritized their stats.
@@ -106,13 +109,21 @@ export function process({
   const numItems =
     helms.length + gauntlets.length + chests.length + legs.length + classItems.length;
 
-  infoLog('loadout optimizer', 'Processing', combos, 'combinations from', numItems, 'items', {
-    helms: helms.length,
-    gauntlets: gauntlets.length,
-    chests: chests.length,
-    legs: legs.length,
-    classItems: classItems.length,
-  });
+  infoLog(
+    `loadout optimizer thread ${workerNum}`,
+    'Processing',
+    combos,
+    'combinations from',
+    numItems,
+    'items',
+    {
+      helms: helms.length,
+      gauntlets: gauntlets.length,
+      chests: chests.length,
+      legs: legs.length,
+      classItems: classItems.length,
+    },
+  );
 
   if (combos === 0) {
     return { sets: [], combos: 0 };
@@ -459,7 +470,7 @@ export function process({
   const totalTime = performance.now() - pstart;
 
   infoLog(
-    'loadout optimizer',
+    `loadout optimizer thread ${workerNum}`,
     'found',
     processStatistics.numValidSets,
     'stat mixes after processing',

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -273,9 +273,9 @@ export function process({
             // Check which stats we're under the stat minimums on.
             let totalStats = 0;
             for (let index = 0; index < 6; index++) {
-              const value = effectiveStats[index];
               const filter = desiredStatRanges[index];
               if (filter.maxStat > 0 /* non-ignored stat */) {
+                const value = effectiveStats[index];
                 // Update the minimum stat range while we're here
                 const statRange = statRanges[index];
                 if (value < statRange.minStat) {

--- a/src/app/loadout-builder/process-worker/set-tracker.test.ts
+++ b/src/app/loadout-builder/process-worker/set-tracker.test.ts
@@ -1,5 +1,7 @@
 import { armorStats } from 'app/search/d2-known-values';
-import { decodeStatMix, encodeStatMix, HeapSetTracker } from './set-tracker';
+import { sum } from 'es-toolkit';
+import { getPower } from '../utils';
+import { decodeStatMix, encodeStatMix, HeapEntry, HeapSetTracker } from './set-tracker';
 import { ProcessItem } from './types';
 
 const createMockArmor = (id: string, power: number): ProcessItem => ({
@@ -16,7 +18,9 @@ const createMockArmor = (id: string, power: number): ProcessItem => ({
  * Essential functional tests for both SetTracker and HeapSetTracker.
  * Covers core behaviors needed by process.ts.
  */
-const trackerImplementations = [{ name: 'HeapSetTracker', ctor: HeapSetTracker }];
+const trackerImplementations = [
+  { name: 'HeapSetTracker', ctor: HeapSetTracker<{ armor: ProcessItem[] }> },
+];
 
 for (const { name, ctor } of trackerImplementations) {
   describe(name, () => {
@@ -26,38 +30,52 @@ for (const { name, ctor } of trackerImplementations) {
       minStat: 10,
     }));
 
+    const makeInsert =
+      (tracker: HeapSetTracker<{ armor: ProcessItem[] }>) =>
+      (
+        enabledStatsTotal: number,
+        statMix: number,
+        armor: ProcessItem[],
+        stats: number[],
+      ): boolean => {
+        const power = getPower(armor);
+        const entry: HeapEntry<{ armor: ProcessItem[] }> = {
+          enabledStatsTotal,
+          statMix,
+          power,
+          armor,
+          statsTotal: sum(stats),
+        };
+        return tracker.insert(entry);
+      };
+
     it('should handle basic insertion, ordering, and retrieval', () => {
       const tracker = new ctor(5);
+      const insert = makeInsert(tracker);
 
       // Insert sets with different tiers and stat mixes
       expect(
-        tracker.insert(
+        insert(
           10,
           encodeStatMix([5, 5, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('a', 1000)],
           [5, 5, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(
-        tracker.insert(
+        insert(
           12,
           encodeStatMix([6, 6, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('b', 1200)],
           [6, 6, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(
-        tracker.insert(
+        insert(
           10,
           encodeStatMix([4, 6, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('c', 1100)],
           [4, 6, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
 
@@ -72,60 +90,51 @@ for (const { name, ctor } of trackerImplementations) {
 
     it('should handle capacity limits and trimming correctly', () => {
       const tracker = new ctor(3);
+      const insert = makeInsert(tracker);
 
       // Fill to capacity
       expect(
-        tracker.insert(
+        insert(
           10,
           encodeStatMix([5, 5, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('a', 1000)],
           [5, 5, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(
-        tracker.insert(
+        insert(
           12,
           encodeStatMix([6, 6, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('b', 1000)],
           [6, 6, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(
-        tracker.insert(
+        insert(
           8,
           encodeStatMix([4, 4, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('c', 1000)],
           [4, 4, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(tracker.totalSets).toBe(3);
 
       // Insert low tier - should be rejected
-      const lowResult = tracker.insert(
+      const lowResult = insert(
         6,
         encodeStatMix([3, 3, 0, 0, 0, 0], desiredStatRanges),
         [createMockArmor('d', 1000)],
         [3, 3, 0, 0, 0, 0],
-        [],
-        [],
       );
       expect(lowResult).toBe(false);
       expect(tracker.totalSets).toBe(3);
 
       // Insert high tier - should succeed but cause trimming
-      const highResult = tracker.insert(
+      const highResult = insert(
         14,
         encodeStatMix([7, 7, 0, 0, 0, 0], desiredStatRanges),
         [createMockArmor('e', 1000)],
         [7, 7, 0, 0, 0, 0],
-        [],
-        [],
       );
       expect(highResult).toBe(false); // trimWorstSet returns false
       expect(tracker.totalSets).toBe(3);
@@ -138,6 +147,7 @@ for (const { name, ctor } of trackerImplementations) {
 
     it('should implement couldInsert correctly for hot path optimization', () => {
       const tracker = new ctor(2);
+      const insert = makeInsert(tracker);
 
       // Empty tracker accepts everything
       expect(tracker.couldInsert(5)).toBe(true);
@@ -145,23 +155,19 @@ for (const { name, ctor } of trackerImplementations) {
 
       // Fill to capacity
       expect(
-        tracker.insert(
+        insert(
           10,
           encodeStatMix([5, 5, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('a', 1000)],
           [5, 5, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
       expect(
-        tracker.insert(
+        insert(
           8,
           encodeStatMix([4, 4, 0, 0, 0, 0], desiredStatRanges),
           [createMockArmor('b', 1000)],
           [4, 4, 0, 0, 0, 0],
-          [],
-          [],
         ),
       ).toBe(true);
 
@@ -173,25 +179,22 @@ for (const { name, ctor } of trackerImplementations) {
 
     it('should handle duplicate detection', () => {
       const tracker = new ctor(5);
+      const insert = makeInsert(tracker);
 
       // Insert first item
-      tracker.insert(
+      insert(
         10,
         encodeStatMix([5, 5, 0, 0, 0, 0], desiredStatRanges),
         [createMockArmor('a', 1000)],
         [5, 5, 0, 0, 0, 0],
-        [],
-        [],
       );
 
       // SetTracker contract allows duplicates
-      const result = tracker.insert(
+      const result = insert(
         10,
         encodeStatMix([5, 5, 0, 0, 0, 0], desiredStatRanges),
         [createMockArmor('b', 900)],
         [5, 5, 0, 0, 0, 0],
-        [],
-        [],
       );
       expect(result).toBe(true);
       expect(tracker.totalSets).toBe(2);

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -6,9 +6,9 @@ export interface ProcessResult {
   /** The total number of combinations considered. */
   combos: number;
   /** The stat ranges of all sets that matched our filters & mod selection. */
-  statRangesFiltered?: StatRanges;
+  statRangesFiltered: StatRanges;
   /** Statistics about how many sets passed/failed the constraints, for error reporting */
-  processInfo?: ProcessStatistics;
+  processInfo: ProcessStatistics;
 }
 
 /**

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -46,15 +46,15 @@ export interface ProcessArmorSet {
   readonly armor: readonly string[];
   /** Which stat mods were added? */
   readonly statMods: number[];
-}
 
-export interface IntermediateProcessArmorSet {
-  /** The overall stats for the loadout as a whole, EXCLUDING auto stat mods. */
-  stats: number[];
-  /** The first (highest-power) valid set from this stat mix. */
-  armor: ProcessItem[];
-  mods: number[];
-  bonusStats: number[];
+  /** Sum of enabled stats values. */
+  readonly enabledStatsTotal: number;
+  /** Sum of all stats including disabled/maxed stats. */
+  readonly statsTotal: number;
+  /** Encoded stat mix as a 48-bit integer. */
+  readonly statMix: number;
+  /** Power level of the armor set. */
+  readonly power: number;
 }
 
 export interface ProcessMod {

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -1,12 +1,19 @@
 import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
+import { armorStats } from 'app/search/d2-known-values';
 import { mapValues } from 'app/utils/collections';
 import { releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
+import { chunk, maxBy, sum } from 'es-toolkit';
 import { deepEqual } from 'fast-equals';
 import type { ProcessInputs } from '../process-worker/process';
-import { ProcessItem, ProcessItemsByBucket, ProcessResult } from '../process-worker/types';
+import {
+  ProcessItem,
+  ProcessItemsByBucket,
+  ProcessResult,
+  ProcessStatistics,
+} from '../process-worker/types';
 import {
   ArmorBucketHash,
   ArmorEnergyRules,
@@ -15,6 +22,7 @@ import {
   DesiredStatRange,
   ItemsByBucket,
   ModStatChanges,
+  StatRanges,
 } from '../types';
 import {
   hydrateArmorSet,
@@ -42,6 +50,8 @@ function createWorker() {
 
   return { worker, cleanup };
 }
+
+type RunProcessResult = Omit<ProcessResult, 'sets'> & { sets: ArmorSet[]; processTime: number };
 
 export function runProcess({
   autoModDefs,
@@ -72,20 +82,11 @@ export function runProcess({
 }):
   | {
       cleanup: () => void;
-      resultPromise: Promise<
-        Omit<ProcessResult, 'sets'> & { sets: ArmorSet[]; processTime: number }
-      >;
+      resultPromise: Promise<RunProcessResult>;
       input: ProcessInputs;
     }
   | undefined {
   const processStart = performance.now();
-  const { worker, cleanup: cleanupWorker } = createWorker();
-  let cleanupRef: (() => void) | undefined = cleanupWorker;
-  const cleanup = () => {
-    cleanupRef?.();
-    cleanupRef = undefined;
-  };
-
   const { bucketSpecificMods, activityMods, generalMods } = lockedModMap;
 
   const lockedProcessMods = {
@@ -142,21 +143,134 @@ export function runProcess({
     return undefined;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  let cleanup = () => {};
+  const workerPromises: Promise<ProcessResult>[] = [];
+
+  const numCombinations = Object.values(processItems).reduce(
+    (total, items) => total * Math.max(1, items.length),
+    1,
+  );
+  const concurrency = Math.max(
+    1,
+    // Don't spin up a ton of threads for small problems
+    Math.min(navigator.hardwareConcurrency || 1, Math.ceil(numCombinations / 100000)),
+  );
+
+  const longestItemsBucketHash = Number(
+    maxBy(Object.entries(processItems), ([, items]) => items.length)![0],
+  );
+  const inputSlices = sliceInputForConcurrency(input, longestItemsBucketHash, concurrency);
+
+  for (let i = 0; i < inputSlices.length; i++) {
+    const { worker, cleanup: cleanupWorker } = createWorker();
+    let cleanupRef: (() => void) | undefined = cleanupWorker;
+    const existingCleanup = cleanup;
+    const cleanupThisWorker = () => {
+      cleanupRef?.();
+      cleanupRef = undefined;
+    };
+    cleanup = () => {
+      existingCleanup();
+      cleanupThisWorker();
+    };
+    const input = inputSlices[i];
+    const workerPromise = (async () => {
+      try {
+        return await worker.process(i + 1, input);
+      } finally {
+        cleanupThisWorker();
+      }
+    })();
+    workerPromises.push(workerPromise);
+  }
+
   return {
     cleanup,
     input,
-    resultPromise: new Promise((resolve) => {
-      worker
-        .process(input)
-        .then((result) => {
-          const hydratedSets = result.sets.map((set) => hydrateArmorSet(set, itemsById));
-          const processTime = performance.now() - processStart;
-          resolve({ ...result, sets: hydratedSets, processTime });
-        })
-        // Cleanup the worker, we don't need it anymore.
-        .finally(() => {
-          cleanup();
-        });
+    resultPromise: Promise.all(workerPromises).then((results) => {
+      const result = combineResults(results);
+      const hydratedSets = result.sets.map((set) => hydrateArmorSet(set, itemsById));
+      const processTime = performance.now() - processStart;
+      return { ...result, sets: hydratedSets, processTime };
     }),
   };
+}
+function combineResults(results: ProcessResult[]): ProcessResult {
+  const firstResult = results.shift()!;
+  if (results.length === 0) {
+    return firstResult;
+  }
+
+  return results.reduce(
+    (combined, result) => ({
+      // TODO: need to sort these!
+      sets: [...combined.sets, ...result.sets].sort(
+        (a, b) => sum(Object.values(a.stats)) - sum(Object.values(b.stats)),
+      ),
+      combos: combined.combos + result.combos,
+      statRangesFiltered: combineStatRanges(combined.statRangesFiltered, result.statRangesFiltered),
+      processInfo: combineProcessInfo(combined.processInfo, result.processInfo),
+    }),
+    firstResult,
+  );
+}
+
+function combineStatRanges(a: StatRanges, b: StatRanges): StatRanges {
+  for (const statHash of armorStats) {
+    const range = a[statHash];
+    range.maxStat = Math.max(range.maxStat, b[statHash].maxStat);
+    range.minStat = Math.min(range.minStat, b[statHash].minStat);
+  }
+  return a;
+}
+
+function combineProcessInfo(a: ProcessStatistics, b: ProcessStatistics): ProcessStatistics {
+  a.numProcessed += b.numProcessed;
+  a.numValidSets += b.numValidSets;
+  a.statistics.lowerBoundsExceeded.timesChecked += b.statistics.lowerBoundsExceeded.timesChecked;
+  a.statistics.lowerBoundsExceeded.timesFailed += b.statistics.lowerBoundsExceeded.timesFailed;
+  a.statistics.modsStatistics.autoModsPick.timesChecked +=
+    b.statistics.modsStatistics.autoModsPick.timesChecked;
+  a.statistics.modsStatistics.autoModsPick.timesFailed +=
+    b.statistics.modsStatistics.autoModsPick.timesFailed;
+  a.statistics.modsStatistics.earlyModsCheck.timesChecked +=
+    b.statistics.modsStatistics.earlyModsCheck.timesChecked;
+  a.statistics.modsStatistics.earlyModsCheck.timesFailed +=
+    b.statistics.modsStatistics.earlyModsCheck.timesFailed;
+  a.statistics.modsStatistics.finalAssignment.autoModsAssignmentFailed +=
+    b.statistics.modsStatistics.finalAssignment.autoModsAssignmentFailed;
+  a.statistics.modsStatistics.finalAssignment.modAssignmentAttempted +=
+    b.statistics.modsStatistics.finalAssignment.modAssignmentAttempted;
+  a.statistics.modsStatistics.finalAssignment.modsAssignmentFailed +=
+    b.statistics.modsStatistics.finalAssignment.modsAssignmentFailed;
+  a.statistics.skipReasons.doubleExotic += b.statistics.skipReasons.doubleExotic;
+  a.statistics.skipReasons.insufficientSetBonus += b.statistics.skipReasons.insufficientSetBonus;
+  a.statistics.skipReasons.noExotic += b.statistics.skipReasons.noExotic;
+  a.statistics.skipReasons.skippedLowTier += b.statistics.skipReasons.skippedLowTier;
+  return a;
+}
+
+function sliceInputForConcurrency(
+  input: ProcessInputs,
+  longestItemsBucketHash: number,
+  concurrency: number,
+) {
+  if (concurrency <= 1) {
+    return [input];
+  }
+
+  const itemsToSlice = input.filteredItems[longestItemsBucketHash as ArmorBucketHash];
+  if (itemsToSlice.length <= 1) {
+    return [input];
+  }
+
+  const sliceSize = Math.ceil(itemsToSlice.length / concurrency);
+  return chunk(itemsToSlice, sliceSize).map((itemsSlice) => ({
+    ...input,
+    filteredItems: {
+      ...input.filteredItems,
+      [longestItemsBucketHash]: itemsSlice,
+    },
+  }));
 }

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -158,8 +158,8 @@ export function runProcess({
   );
   const concurrency = Math.max(
     1,
-    // Don't spin up a ton of threads for small problems
-    Math.min(navigator.hardwareConcurrency || 1, Math.ceil(numCombinations / 100000)),
+    // Don't spin up a ton of threads for smaller problems, leave at least one core free
+    Math.min((navigator.hardwareConcurrency || 1) - 1, Math.ceil(numCombinations / 5_000_000)),
   );
 
   const longestItemsBucketHash = Number(


### PR DESCRIPTION
This parallelizes Loadout Optimizer to make use of multiple CPU cores, by splitting up the problem into chunks and then merging them in the end. There's some overhead, so I have a heuristic that leaves at least one core free, and avoids splitting up the problem too finely.

On my 10-core M1 Max, this is a significant speedup, going from >7s to 1.3s with 30M combos.

Changelog: Loadout Optimizer will now utilize multiple CPU cores.

Fixes #11346 