### PR TITLE
Improve auto refresh

### DIFF
--- a/src/app/dim-ui/AutoRefresh.tsx
+++ b/src/app/dim-ui/AutoRefresh.tsx
@@ -130,7 +130,7 @@ function useScheduledAutoRefresh() {
   useEffect(() => {
     startTimer();
     return () => clearTimer();
-  }, [startTimer]);
+  }, [startTimer, autoRefresh /* start/stop the timer if autorefresh changes */]);
 
   return startTimer;
 }

--- a/src/app/inventory/cross-tab.ts
+++ b/src/app/inventory/cross-tab.ts
@@ -1,6 +1,6 @@
 import { infoLog } from 'app/utils/log';
 import { BucketHashes } from 'data/d2/generated-enums';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export const crossTabChannel =
   'BroadcastChannel' in globalThis ? new BroadcastChannel('dim') : undefined;
@@ -25,23 +25,20 @@ export interface ItemMovedMessage {
 export type CrossTabMessage = StoreUpdatedMessage | ItemMovedMessage;
 
 export function useCrossTabUpdates(callback: (m: CrossTabMessage) => void) {
-  const onMsg = useCallback(
-    (m: MessageEvent<CrossTabMessage>) => {
+  useEffect(() => {
+    if (!crossTabChannel) {
+      return;
+    }
+    const onMsg = (m: MessageEvent<CrossTabMessage>) => {
       const message = m.data;
       infoLog('cross-tab', 'message', message.type, message);
       if (message.type) {
         callback(message);
       }
-    },
-    [callback],
-  );
-  useEffect(() => {
-    if (!crossTabChannel) {
-      return;
-    }
+    };
     crossTabChannel.addEventListener('message', onMsg);
     return () => crossTabChannel.removeEventListener('message', onMsg);
-  }, [onMsg]);
+  }, [callback]);
 }
 
 export function notifyOtherTabsStoreUpdated() {

--- a/src/app/inventory/store/hooks.ts
+++ b/src/app/inventory/store/hooks.ts
@@ -10,6 +10,7 @@ import {
 } from 'bungie-api-ts/destiny2';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 import { itemMoved } from '../actions';
 import { CrossTabMessage, useCrossTabUpdates } from '../cross-tab';
 import { loadStores as d1LoadStores } from '../d1-stores';
@@ -49,12 +50,14 @@ export function useLoadStores(account: DestinyAccount | undefined) {
     }, [account, dispatch]),
   );
 
+  const { pathname } = useLocation();
+  const onOptimizerPage = pathname.endsWith('/optimizer');
   const onMessage = useCallback(
     (msg: CrossTabMessage) => {
       switch (msg.type) {
         case 'stores-updated':
           // This is only implemented for D2
-          if (account?.destinyVersion === 2) {
+          if (account?.destinyVersion === 2 && !onOptimizerPage) {
             return dispatch(d2LoadStores({ fromOtherTab: true }));
           }
           break;
@@ -65,7 +68,7 @@ export function useLoadStores(account: DestinyAccount | undefined) {
           break;
       }
     },
-    [account?.destinyVersion, dispatch],
+    [account?.destinyVersion, dispatch, onOptimizerPage],
   );
   useCrossTabUpdates(onMessage);
 


### PR DESCRIPTION
I found a case where the autorefresh timer *maybe* could get disconnected. Adding a dependency on autorefreshability makes sure it'll be triggered.

I also paused the cross-tab store refresh on the Optimizer page.