### PR TITLE
Add progress bar to LO / Don't generate all tuning options

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -439,6 +439,13 @@ export default tseslint.config(
     },
   },
   {
+    // The process-worker needs to be extra fast, so we disable a few rules here.
+    files: ['src/app/loadout-builder/process-worker/**/*.ts'],
+    rules: {
+      '@typescript-eslint/prefer-for-of': 'off',
+    },
+  },
+  {
     name: 'tests',
     files: ['**/*.test.ts'],
     rules: {

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss
@@ -70,10 +70,23 @@
 }
 
 .speedReport {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  align-items: center;
   user-select: text;
+  gap: 0.5em;
   flex: 1;
-  > :global(.app-icon) {
-    margin-right: 0.5em;
+}
+
+.speedReportInner {
+  composes: flexRow from '../dim-ui/common.m.scss';
+  align-items: center;
+  gap: 1em;
+  flex: 1;
+
+  @include phone-portrait {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
   }
 }
 

--- a/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
+++ b/src/app/loadout-builder/LoadoutBuilder.m.scss.d.ts
@@ -10,6 +10,7 @@ interface CssExports {
   'page': string;
   'referenceTiersInfo': string;
   'speedReport': string;
+  'speedReportInner': string;
   'subclassSection': string;
   'toolbar': string;
   'undoRedo': string;

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -266,7 +266,7 @@ export default memo(function LoadoutBuilder({
     );
 
   // Run the actual loadout generation process in a web worker
-  const { result, processing } = useProcess({
+  const { result, processing, totalCombos, completedCombos } = useProcess({
     selectedStore,
     filteredItems,
     setBonuses,
@@ -439,11 +439,14 @@ export default memo(function LoadoutBuilder({
           {processing ? (
             <span className={styles.speedReport} role="status">
               <AppIcon icon={refreshIcon} spinning={true} />
-              <span>
-                {t('LoadoutBuilder.ProcessingSets', {
-                  character: selectedStore.name,
-                })}
-              </span>
+              <div className={styles.speedReportInner}>
+                <span>
+                  {t('LoadoutBuilder.ProcessingSets', {
+                    character: selectedStore.name,
+                  })}
+                </span>
+                <progress value={completedCombos} max={totalCombos || 1} />
+              </div>
             </span>
           ) : (
             result && (

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -94,9 +94,10 @@ function doGeneralModsFit(
     generalModCosts.sort((a, b) => b - a);
   }
 
-  return remainingEnergyCapacities.some((capacities) =>
-    generalModCosts.every((cost, index) => cost <= capacities[index]),
-  );
+  return remainingEnergyCapacities.some((capacities) => {
+    capacities.sort((a, b) => b - a);
+    return generalModCosts.every((cost, index) => cost <= capacities[index]);
+  });
 }
 
 /**

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -87,7 +87,7 @@ function doGeneralModsFit(
   if (pickedMods !== undefined && pickedMods.length) {
     generalModCosts = generalModCosts.slice();
     // Intentionally open-coded for performance
-    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+
     for (let i = 0; i < pickedMods.length; i++) {
       generalModCosts.push(...pickedMods[i].generalModsCosts);
     }

--- a/src/app/loadout-builder/process-worker/process-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.test.ts
@@ -126,30 +126,35 @@ describe('process-utils mod assignment', () => {
           helmet = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
+            desiredStatRanges: [],
           })[0];
         }
         if (!arms && isArmor2Arms(storeItem)) {
           arms = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
+            desiredStatRanges: [],
           })[0];
         }
         if (!chest && isArmor2Chest(storeItem)) {
           chest = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
+            desiredStatRanges: [],
           })[0];
         }
         if (!legs && isArmor2Legs(storeItem)) {
           legs = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
+            desiredStatRanges: [],
           })[0];
         }
         if (!classItem && isArmor2ClassItem(storeItem)) {
           classItem = mapDimItemToProcessItem({
             dimItem: storeItem,
             armorEnergyRules,
+            desiredStatRanges: [],
           })[0];
         }
 

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -165,6 +165,9 @@ export function updateMaxStats(
     info.activityModPermutations,
     armor,
   );
+  // You wouldn't believe it, but Firefox is actually slow loading constants
+  // from another module.
+  const maxStat = MAX_STAT;
 
   // Then, for every stat where we haven't shown that we can hit MAX_STAT with any
   // set, try to see if we can exceed the previous max by adding auto stat mods.
@@ -172,7 +175,7 @@ export function updateMaxStats(
     const value = setStats[statIndex];
     const filter = desiredStatRanges[statIndex];
     const statRange = statRanges[statIndex];
-    if (statRange.maxStat >= MAX_STAT) {
+    if (statRange.maxStat >= maxStat) {
       // We can already hit MAX_STAT for this stat, so skip it.
       continue;
     }
@@ -188,7 +191,7 @@ export function updateMaxStats(
     // assignment search that maximizes stats but with stat ranges that prevent
     // us from going over our minimum? Or maybe do a binary search for the
     // maximum we can reach?
-    while (statRange.maxStat < MAX_STAT) {
+    while (statRange.maxStat < maxStat) {
       // Now that tiers no longer matter (since Edge of Fate), we consider any
       // stat point increase a "tier". This should be a short-term change -
       // ideally we'd reconsider all these algorithms to see if they could be

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -63,7 +63,8 @@ function getRemainingEnergiesPerAssignment(
   /** Total remaining energy capacity across the set */
   setEnergy: number;
   /**
-   * For each valid permutation, how much energy is left on per item? These lists are sorted by remaining energy so they do not correspond to the input items.
+   * For each valid permutation, how much energy is left on per item? These
+   * lists are NOT sorted.
    */
   remainingEnergiesPerAssignment: number[][];
 } {
@@ -99,7 +100,6 @@ function getRemainingEnergiesPerAssignment(
         remainingEnergyCapacities[i] -= activityMod.energyCost;
       }
     }
-    remainingEnergyCapacities.sort((a, b) => b - a);
     remainingEnergiesPerAssignment.push(remainingEnergyCapacities);
   }
 
@@ -311,7 +311,6 @@ export function pickAndAssignSlotIndependentMods(
       remainingEnergyCapacities[idx] =
         item.remainingEnergyCapacity - (activityPermutation[idx]?.energyCost || 0);
     }
-    remainingEnergyCapacities.sort((a, b) => b - a);
 
     if (neededStats) {
       const result = chooseAutoMods(

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -107,6 +107,10 @@ function getRemainingEnergiesPerAssignment(
   return { setEnergy, remainingEnergiesPerAssignment };
 }
 
+// How many extra points we need to add to each stat to hit the minimums. We
+// reuse a single array to avoid allocations.
+const requiredMinimumExtraStats = [0, 0, 0, 0, 0, 0];
+
 /**
  * Updates the max stat range by trying to individually get the highest value in
  * each stat.
@@ -126,9 +130,6 @@ export function updateMaxStats(
   statRanges: MinMaxStat[], // mutated
 ): boolean {
   let foundAnyImprovement = false;
-
-  // How many extra points we need to add to each stat to hit the minimums.
-  const requiredMinimumExtraStats = [0, 0, 0, 0, 0, 0];
 
   // First, track absolutely required stats (and update existing maxes)
   for (let statIndex = 0; statIndex < desiredStatRanges.length; statIndex++) {
@@ -153,6 +154,8 @@ export function updateMaxStats(
     if (neededValue > 0) {
       // All sets need at least these extra stats to hit minimums
       requiredMinimumExtraStats[statIndex] = neededValue;
+    } else {
+      requiredMinimumExtraStats[statIndex] = 0;
     }
   }
 

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -71,11 +71,12 @@ function getRemainingEnergiesPerAssignment(
   const remainingEnergiesPerAssignment: number[][] = [];
 
   let setEnergy = 0;
-  for (const item of items) {
-    setEnergy += item.remainingEnergyCapacity;
+  for (let i = 0; i < items.length; i++) {
+    setEnergy += items[i].remainingEnergyCapacity;
   }
 
-  activityModLoop: for (const activityPermutation of activityModPermutations) {
+  activityModLoop: for (let p = 0; p < activityModPermutations.length; p++) {
+    const activityPermutation = activityModPermutations[p];
     const remainingEnergyCapacities = [0, 0, 0, 0, 0];
 
     // Check each item to see if it's possible to slot the activity mods in this

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -162,10 +162,8 @@ export function updateMaxStats(
     return foundAnyImprovement;
   }
 
-  const { remainingEnergiesPerAssignment, setEnergy } = getRemainingEnergiesPerAssignment(
-    info.activityModPermutations,
-    armor,
-  );
+  let remainingEnergyResult: ReturnType<typeof getRemainingEnergiesPerAssignment> | undefined;
+
   // You wouldn't believe it, but Firefox is actually slow loading constants
   // from another module.
   const maxStat = MAX_STAT;
@@ -180,6 +178,12 @@ export function updateMaxStats(
       // We can already hit MAX_STAT for this stat, so skip it.
       continue;
     }
+
+    remainingEnergyResult ??= getRemainingEnergiesPerAssignment(
+      info.activityModPermutations,
+      armor,
+    );
+    const { remainingEnergiesPerAssignment, setEnergy } = remainingEnergyResult;
 
     // Since we calculate the maximum stat value we can hit for a stat in
     // isolation, require all other stats to hit their constrained minimums, but

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -75,6 +75,7 @@ export function process(
     strictUpgrades,
     stopOnFirstSet,
   }: ProcessInputs,
+  onProgress: (completed: number) => void,
 ): ProcessResult {
   const pstart = performance.now();
 
@@ -181,6 +182,7 @@ export function process(
   const setBonusHashes = Object.keys(setBonuses).map((h) => Number(h));
   const setBonusCounts = Object.values(setBonuses);
 
+  let comboIndex = 0;
   itemLoop: for (const helm of helms) {
     const helmExotic = Number(helm.isExotic);
     const helmArtifice = Number(helm.isArtifice);
@@ -198,6 +200,11 @@ export function process(
           const legArtifice = Number(leg.isArtifice);
           const legStats = statsCache.get(leg)!;
           innerloop: for (const classItem of classItems) {
+            comboIndex++;
+            if (comboIndex % 100000 === 0) {
+              onProgress(comboIndex);
+            }
+
             const classItemExotic = Number(classItem.isExotic);
             const classItemArtifice = Number(classItem.isArtifice);
             const classItemStats = statsCache.get(classItem)!;

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -195,23 +195,28 @@ export async function process(
   }
 
   let comboCount = 0;
-  itemLoop: for (const helm of helms) {
+  itemLoop: for (let helmIdx = 0; helmIdx < helms.length; helmIdx++) {
+    const helm = helms[helmIdx];
     const helmExotic = Number(helm.isExotic);
     const helmArtifice = Number(helm.isArtifice);
     const helmStats = statsCache.get(helm)!;
-    for (const gaunt of gauntlets) {
+    for (let gauntIdx = 0; gauntIdx < gauntlets.length; gauntIdx++) {
+      const gaunt = gauntlets[gauntIdx];
       const gauntletExotic = Number(gaunt.isExotic);
       const gauntArtifice = Number(gaunt.isArtifice);
       const gauntStats = statsCache.get(gaunt)!;
-      for (const chest of chests) {
+      for (let chestIdx = 0; chestIdx < chests.length; chestIdx++) {
+        const chest = chests[chestIdx];
         const chestExotic = Number(chest.isExotic);
         const chestArtifice = Number(chest.isArtifice);
         const chestStats = statsCache.get(chest)!;
-        for (const leg of legs) {
+        for (let legIdx = 0; legIdx < legs.length; legIdx++) {
+          const leg = legs[legIdx];
           const legExotic = Number(leg.isExotic);
           const legArtifice = Number(leg.isArtifice);
           const legStats = statsCache.get(leg)!;
-          innerloop: for (const classItem of classItems) {
+          innerloop: for (let classItemIdx = 0; classItemIdx < classItems.length; classItemIdx++) {
+            const classItem = classItems[classItemIdx];
             comboCount++;
             if (comboCount >= 100000) {
               onProgress(comboCount);

--- a/src/app/loadout-builder/process/mappers.test.ts
+++ b/src/app/loadout-builder/process/mappers.test.ts
@@ -28,6 +28,7 @@ describe('lo process mappers', () => {
         assumeArmorMasterwork: AssumeArmorMasterwork.All,
       },
       modsForSlot: [],
+      desiredStatRanges: [],
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(10);
@@ -42,6 +43,7 @@ describe('lo process mappers', () => {
       dimItem: modifiedItem,
       armorEnergyRules: loDefaultArmorEnergyRules,
       modsForSlot: [],
+      desiredStatRanges: [],
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(modifiedItem.energy?.energyCapacity);
@@ -56,6 +58,7 @@ describe('lo process mappers', () => {
       dimItem: modifiedItem,
       armorEnergyRules: loDefaultArmorEnergyRules,
       modsForSlot: [],
+      desiredStatRanges: [],
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(MIN_LO_ITEM_ENERGY);

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -194,7 +194,6 @@ export function runProcess({
       if (cleanupRef === undefined) {
         return;
       }
-      console.log('Progress', completed, progressTotal, numCombinations);
       progressTotal += completed;
       onProgress?.(progressTotal, numCombinations);
     });

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -121,6 +121,7 @@ export function runProcess({
       mapDimItemToProcessItem({
         dimItem,
         armorEnergyRules,
+        desiredStatRanges,
         modsForSlot: bucketSpecificMods[bucketHash] || [],
       }).map((processItem) => ({
         dimItem,

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -176,10 +176,6 @@ export function runProcess({
   const inputSlices = sliceInputForConcurrency(input, longestItemsBucketHash, concurrency);
 
   let progressTotal = 0;
-  const handleProgress = proxy((completed: number) => {
-    progressTotal += completed;
-    onProgress?.(progressTotal, numCombinations);
-  });
 
   for (let i = 0; i < inputSlices.length; i++) {
     const { worker, cleanup: cleanupWorker } = createWorker();
@@ -194,6 +190,14 @@ export function runProcess({
       cleanupThisWorker();
     };
     const input = inputSlices[i];
+    const handleProgress = proxy((completed: number) => {
+      if (cleanupRef === undefined) {
+        return;
+      }
+      console.log('Progress', completed, progressTotal, numCombinations);
+      progressTotal += completed;
+      onProgress?.(progressTotal, numCombinations);
+    });
     const workerPromise = (async () => {
       try {
         return await worker.process(i + 1, input, handleProgress);

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -3,7 +3,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { armorStats } from 'app/search/d2-known-values';
 import { mapValues } from 'app/utils/collections';
-import { releaseProxy, wrap } from 'comlink';
+import { proxy, releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { chunk, maxBy } from 'es-toolkit';
 import { deepEqual } from 'fast-equals';
@@ -41,6 +41,7 @@ interface MappedItem {
 function createWorker() {
   const instance = new Worker(
     /* webpackChunkName: "lo-worker" */ new URL('../process-worker/ProcessWorker', import.meta.url),
+    { type: 'module' },
   );
 
   const worker = wrap<import('../process-worker/ProcessWorker').ProcessWorker>(instance);
@@ -71,6 +72,7 @@ export function runProcess({
   strictUpgrades,
   stopOnFirstSet,
   lastInput,
+  onProgress,
 }: {
   autoModDefs: AutoModDefs;
   filteredItems: ItemsByBucket;
@@ -84,6 +86,7 @@ export function runProcess({
   strictUpgrades: boolean;
   stopOnFirstSet: boolean;
   lastInput: ProcessInputs | undefined;
+  onProgress?: (completed: number, total: number) => void;
 }):
   | {
       cleanup: () => void;
@@ -131,7 +134,6 @@ export function runProcess({
     }
   }
 
-  // TODO: could potentially partition the problem (split the largest item category maybe) to spread across more cores
   const input: ProcessInputs = {
     filteredItems: processItems,
     modStatTotals: mapValues(modStatChanges, (stat) => stat.value),
@@ -160,14 +162,23 @@ export function runProcess({
   );
   const concurrency = Math.max(
     1,
-    // Don't spin up a ton of threads for smaller problems, leave at least one core free
-    Math.min((navigator.hardwareConcurrency || 1) - 1, Math.ceil(numCombinations / 5_000_000)),
+    // Don't spin up a ton of threads for smaller problems, leave half the cores free
+    Math.min(
+      Math.ceil((navigator.hardwareConcurrency || 1) / 2),
+      Math.ceil(numCombinations / 5_000_000),
+    ),
   );
 
   const longestItemsBucketHash = Number(
     maxBy(Object.entries(processItems), ([, items]) => items.length)![0],
   );
   const inputSlices = sliceInputForConcurrency(input, longestItemsBucketHash, concurrency);
+
+  let progressTotal = 0;
+  const handleProgress = proxy((completed: number) => {
+    progressTotal += completed;
+    onProgress?.(progressTotal, numCombinations);
+  });
 
   for (let i = 0; i < inputSlices.length; i++) {
     const { worker, cleanup: cleanupWorker } = createWorker();
@@ -184,7 +195,7 @@ export function runProcess({
     const input = inputSlices[i];
     const workerPromise = (async () => {
       try {
-        return await worker.process(i + 1, input);
+        return await worker.process(i + 1, input, handleProgress);
       } finally {
         cleanupThisWorker();
       }


### PR DESCRIPTION
1. Adds an incremental progress bar while LO is computing
2. Limits concurrency to half of available cores (no less than 1)
3. Pick a specific dump stat and only generate tuners for those. This is pretty effective in cutting down combos.