### PR TITLE
Finishers are no longer lockable

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -496,7 +496,7 @@ export function makeItem(
     classTypeNameLocalized: getClassTypeNameLocalized(defs)(classType),
     element,
     energy: itemInstanceData.energy ?? null,
-    lockable: normalBucket.hash !== BucketHashes.Finishers ? item.lockable : true,
+    lockable: item.lockable,
     trackable: Boolean(item.itemInstanceId && itemDef.objectives?.questlineItemHash),
     tracked: Boolean(item.state & ItemState.Tracked),
     locked: Boolean(item.state & ItemState.Locked),


### PR DESCRIPTION
Fixes #11434 

Changelog: Finishers are no longer lockable (Bungie doesn't allow it)