### PR TITLE
Improve autocomplete for dupe:

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -49,7 +49,6 @@ exports[`filterComplete autocomplete terms for |sni| 1`] = `
 
 exports[`filterComplete autocomplete terms for |stat:| 1`] = `
 [
-  "stat:",
   "stat:rpm:",
   "stat:rof:",
   "stat:charge:",

--- a/src/app/search/autocomplete.test.ts
+++ b/src/app/search/autocomplete.test.ts
@@ -28,7 +28,7 @@ describe('autocompleteTermSuggestions', () => {
   const cases: [query: string, expected: string][] = [
     ['is:haspower is:b', 'is:haspower is:bow'],
     ['(is:blue ju|n)', '(is:blue tag:junk)'],
-    ['is:bow is:v|oid', 'is:bow is:void'],
+    ['is:bow is:v|oi', 'is:bow is:void'],
     ['season:>outl', 'season:>outlaw'],
     ['not(', 'Expected failure'],
     ['memento:', 'memento:any'],

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -434,7 +434,7 @@ export function makeFilterComplete<I, FilterCtx, SuggestionsCtx>(
           .filter((t) => multiqueryTermsLookup[possibleKeyword]!.includes(t)),
       );
       const stem = `${typedSegments[0]}:${[...existingTerms].join('+')}${existingTerms.size ? '+' : ''}`;
-      suggestions.unshift(
+      suggestions.push(
         ...filterMap(multiqueryTermsLookup[possibleKeyword], (t) => {
           if (!existingTerms.has(t)) {
             const newTerm = stem + t;

--- a/src/app/search/autocomplete.ts
+++ b/src/app/search/autocomplete.ts
@@ -424,6 +424,29 @@ export function makeFilterComplete<I, FilterCtx, SuggestionsCtx>(
 
     // TODO: sort this first?? it depends on term in one place
 
+    if (multiqueryTermsLookup[possibleKeyword] && filterNames.includes(possibleKeyword)) {
+      // For multiquery filters, if the user has typed a + (or hasn't typed
+      // anything) they're looking to add another query term, so offer to append
+      // one.
+      const existingTerms = new Set(
+        (typedSegments[1] || '')
+          .split('+')
+          .filter((t) => multiqueryTermsLookup[possibleKeyword]!.includes(t)),
+      );
+      const stem = `${typedSegments[0]}:${[...existingTerms].join('+')}${existingTerms.size ? '+' : ''}`;
+      suggestions.unshift(
+        ...filterMap(multiqueryTermsLookup[possibleKeyword], (t) => {
+          if (!existingTerms.has(t)) {
+            const newTerm = stem + t;
+            return {
+              rawText: newTerm,
+              plainText: newTerm,
+            };
+          }
+        }),
+      );
+    }
+
     suggestions = suggestions.sort(
       chainComparator(
         // ---------------
@@ -487,26 +510,7 @@ export function makeFilterComplete<I, FilterCtx, SuggestionsCtx>(
         compareBy((word) => !mathCheck.test(word.plainText)),
       ),
     );
-
-    if (filterNames.includes(possibleKeyword)) {
-      // For multiquery filters, if the user has typed a + they're looking to add another query term,
-      // so offer to append one.
-      if (multiqueryTermsLookup[possibleKeyword] && typedPlain.endsWith('+')) {
-        const existingTerms = new Set((typedSegments[1] || '').split('+'));
-        suggestions.unshift(
-          ...filterMap(multiqueryTermsLookup[possibleKeyword], (t) => {
-            if (!existingTerms.has(t)) {
-              return {
-                rawText: typedPlain + t,
-                plainText: typedPlain + t,
-              };
-            }
-          }),
-        );
-      }
-
-      return suggestions.map((suggestion) => suggestion.rawText);
-    } else if (suggestions.length) {
+    if (suggestions.length) {
       // we will always add in (later) a suggestion of "what you've already typed so far"
       // so prevent "what's been typed" from appearing in the returned suggestions from this function
       const deDuped = new Set(suggestions.map((suggestion) => suggestion.rawText));


### PR DESCRIPTION
Changelog: Improve autocomplete for the new `dupe:` filter.

This improves the autocomplete for `dupe:` by:

1. Autocompleting all single terms after typing `dupe:`
2. Continuing to offer suggestions typing `+` and then partially typing a term.
3. Go back to removing a possible duplicate match (if you've already typed it all)
4. Sort these suggestions in the same way we do all other suggestions.