### PR TITLE
Un-deprecate the is:infusionfodder filter

### DIFF
--- a/src/app/search/items/search-filters/dupes-deprecated.ts
+++ b/src/app/search/items/search-filters/dupes-deprecated.ts
@@ -76,7 +76,6 @@ export const deprecatedDupeFilters: ItemFilterDefinition[] = [
     keywords: 'infusionfodder',
     description: tl('Filter.InfusionFodder'),
     destinyVersion: 2,
-    deprecated: true,
     filter: ({ allItems }) => {
       const duplicates: { [dupeID: string]: DimItem[] } = {};
 

--- a/src/app/search/items/search-filters/dupes.ts
+++ b/src/app/search/items/search-filters/dupes.ts
@@ -208,20 +208,9 @@ const dupeTypeLookupRaw: Record<
       return destinyClasses.flatMap((destinyClass) => armorsByDestinyClass.get(destinyClass)!);
     },
   },
-
-  // Finds items within the group that could be infused using another item in the
-  // group for glimmer only.
-  infuse: {
-    keyGenerator: (item) => {
-      if (item.infusable) {
-        return item.hash.toString();
-      }
-    },
-    confirmItemsInGroup: (items) => items.filter((item) => items.some((i) => i.power < item.power)),
-  },
 };
 
-const lowerComparatorTypes = ['statlower', 'customstatlower', 'infuse'];
+const lowerComparatorTypes = ['statlower', 'customstatlower'];
 
 const dupeFilters: ItemFilterDefinition[] = [
   {
@@ -250,7 +239,6 @@ const dupeFilters: ItemFilterDefinition[] = [
       perks: tl('Filter.DupePerks'),
       statlower: tl('Filter.StatLower'),
       customstatlower: tl('Filter.CustomStatLower'),
-      infuse: tl('Filter.InfusionFodder'),
     },
     destinyVersion: 2,
     filter: (context) => {

--- a/src/app/search/items/search-filters/dupes.ts
+++ b/src/app/search/items/search-filters/dupes.ts
@@ -208,9 +208,20 @@ const dupeTypeLookupRaw: Record<
       return destinyClasses.flatMap((destinyClass) => armorsByDestinyClass.get(destinyClass)!);
     },
   },
+
+  // Finds items within the group that could be infused using another item in the
+  // group for glimmer only.
+  infuse: {
+    keyGenerator: (item) => {
+      if (item.infusable) {
+        return item.hash.toString();
+      }
+    },
+    confirmItemsInGroup: (items) => items.filter((item) => items.some((i) => i.power < item.power)),
+  },
 };
 
-const lowerComparatorTypes = ['statlower', 'customstatlower'];
+const lowerComparatorTypes = ['statlower', 'customstatlower', 'infuse'];
 
 const dupeFilters: ItemFilterDefinition[] = [
   {
@@ -239,6 +250,7 @@ const dupeFilters: ItemFilterDefinition[] = [
       perks: tl('Filter.DupePerks'),
       statlower: tl('Filter.StatLower'),
       customstatlower: tl('Filter.CustomStatLower'),
+      infuse: tl('Filter.InfusionFodder'),
     },
     destinyVersion: 2,
     filter: (context) => {


### PR DESCRIPTION
Changelog: Un-deprecated the `is:infusionfodder` filter.

Fixes #11428