### PR TITLE
Look harder for matching queries when unsaving

### DIFF
--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -1278,7 +1278,21 @@ function saveSearch(
   }
   query = canonical;
 
-  const existingSearch = draft.searches[destinyVersion].find((s) => s.query === query);
+  // Look for any existing search, either by exact query match or canonical match
+  let existingSearch = draft.searches[destinyVersion].find((s) => s.query === query);
+
+  if (!existingSearch && !saved) {
+    // If we're trying to unsave a search that doesn't exist, maybe it's saved under another version.
+    existingSearch = draft.searches[destinyVersion].find((s) => {
+      if (!s.saved) {
+        return false;
+      }
+      const { canonical } = parseAndValidateQuery(s.query, filtersMap, {
+        customStats: draft.settings.customStats ?? [],
+      } as FilterContext);
+      return canonical === query;
+    });
+  }
 
   if (!existingSearch && saveable) {
     // Save this as a "used" search first. This may happen if it's a type of


### PR DESCRIPTION
Changelog: Fixed a case where some old searches could not be unsaved. Remember that you can also *delete* searches from the Search History page or by clicking the X in the autocomplete dropdown.

This should fix #11194