### PR TITLE
A third click on a sorting column will remove it as a sort

### DIFF
--- a/src/app/dim-ui/table-columns.ts
+++ b/src/app/dim-ui/table-columns.ts
@@ -15,28 +15,34 @@ export function useTableColumnSorts(defaultSorts: ColumnSort[]) {
 
   // Toggle sorting of columns. If shift is held (the additive param), adds this column to the sort.
   const toggleColumnSort = useCallback(
-    (columnId: string, additive: boolean, defaultDirection?: SortDirection) => () =>
-      setColumnSorts((sorts) => {
-        const newColumnSorts = additive
-          ? Array.from(sorts) // start with a copy of the existing sorts
-          : sorts.filter((s) => s.columnId === columnId); // otherwise just this column
-        const index = newColumnSorts.findIndex((s) => s.columnId === columnId);
-        if (index >= 0) {
-          // This column is already in the sort, flip the direction
-          const columnSort = newColumnSorts[index];
-          newColumnSorts[index] = {
-            ...columnSort,
-            sort: columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC,
-          };
-        } else {
-          // Add the column to the sort
-          newColumnSorts.push({
-            columnId: columnId,
-            sort: defaultDirection || SortDirection.ASC,
-          });
-        }
-        return newColumnSorts;
-      }),
+    (columnId: string, additive: boolean, defaultDirection: SortDirection = SortDirection.ASC) =>
+      () =>
+        setColumnSorts((sorts) => {
+          const newColumnSorts = additive
+            ? Array.from(sorts) // start with a copy of the existing sorts
+            : sorts.filter((s) => s.columnId === columnId); // otherwise just this column
+          const index = newColumnSorts.findIndex((s) => s.columnId === columnId);
+          if (index >= 0) {
+            // This column is already in the sort, flip the direction
+            const columnSort = newColumnSorts[index];
+            if (columnSort.sort === defaultDirection || !additive) {
+              newColumnSorts[index] = {
+                ...columnSort,
+                sort:
+                  columnSort.sort === SortDirection.ASC ? SortDirection.DESC : SortDirection.ASC,
+              };
+            } else {
+              newColumnSorts.splice(index, 1); // remove the column from the sort
+            }
+          } else {
+            // Add the column to the sort
+            newColumnSorts.push({
+              columnId: columnId,
+              sort: defaultDirection,
+            });
+          }
+          return newColumnSorts;
+        }),
     [],
   );
 


### PR DESCRIPTION
Changelog: In Compare and Organizer, when you hold shift and click a column to change its sorting, we now remove the sort entirely on the third click.

Fixes #11375 