### PR TITLE
Filter out vendor items that can't be purchased

### DIFF
--- a/src/app/vendors/selectors.ts
+++ b/src/app/vendors/selectors.ts
@@ -122,7 +122,7 @@ export const characterVendorItemsSelector = createSelector(
       vendorGroups
         .flatMap((vg) => vg.vendors)
         .concat(Object.values(subVendors))
-        .flatMap((vs) => vs.items.map((vi) => vi.item))
+        .flatMap((vs) => vs.items.filter((vi) => vi.canBeSold).map((vi) => vi.item))
         .filter((i) => !i?.itemCategoryHashes.includes(ItemCategoryHashes.Dummies)),
     );
   },


### PR DESCRIPTION
Changelog: Loadout Optimizer and Compare will only show vendor items that you can actually buy.
