### PR TITLE
LO: Try harder to find a dump stat

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -278,7 +278,7 @@ export default tseslint.config(
       'prefer-promise-reject-errors': 'error',
       'prefer-spread': 'error',
       radix: 'error',
-      yoda: 'error',
+      yoda: ['error', { exceptRange: true }],
       'prefer-template': 'error',
       'class-methods-use-this': ['error', { exceptMethods: ['render'] }],
       'no-unmodified-loop-condition': 'error',


### PR DESCRIPTION
Fixes a user-reported problem when optimizing all 6 stats with nothing under 175 max, causing no default dump stat.