### PR TITLE
Fix "Invalid Search Query" analyzer issue

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -955,7 +955,11 @@
     },
     "InvalidSearchQuery": {
       "Name": "Invalid Search Query",
-      "Description": "This loadout was created with a search query in Loadout Optimizer that is no longer valid, or does not include the armor in this loadout."
+      "Description": "This loadout was created with a search query in Loadout Optimizer that is not valid."
+    },
+    "ItemsDoNotMatchSearchQuery": {
+      "Name": "Search Excludes Items",
+      "Description": "This loadout was created with a search query in Loadout Optimizer, and that search query excludes at least one of the items in the loadout."
     }
   },
   "Manifest": {

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -268,7 +268,7 @@ export async function analyzeLoadout(
             (item) =>
               item.classType === classType && item.bucket.inArmor && isLoadoutBuilderItem(item),
           );
-          const [filteredItems] = filterItems({
+          const [filteredItems, filterInfo] = filterItems({
             defs,
             items: armorForThisClass,
             pinnedItems: {},
@@ -288,12 +288,17 @@ export async function analyzeLoadout(
             loadoutParameters.query &&
             loadoutArmor.some(
               (item) =>
+                // The item exists in inventory
                 armorForThisClass.some((allItem) => allItem === item) &&
+                // But is not in the candidate items
                 !Object.values(filteredItems)
                   .flat()
                   .some((filteredItem) => filteredItem === item),
             )
           ) {
+            // Either the search filter excluded these items, OR they were strictly worse than some other item.
+            // TODO: Make a different explanation for this
+            // TODO: Suppress worse-item filtering in the above check
             findings.add(LoadoutFinding.InvalidSearchQuery);
           }
 

--- a/src/app/loadout-analyzer/finding-display.ts
+++ b/src/app/loadout-analyzer/finding-display.ts
@@ -1,5 +1,5 @@
 import { I18nKey, tl } from 'app/i18next-t';
-import { faArrowCircleUp, faExclamationTriangle, infoIcon } from 'app/shell/icons';
+import { faArrowCircleUp, faExclamationTriangle, infoIcon, searchIcon } from 'app/shell/icons';
 import { LoadoutFinding } from './types';
 
 export interface FindingDisplay {
@@ -68,5 +68,10 @@ export const findingDisplays: Record<LoadoutFinding, FindingDisplay> = {
     name: tl('LoadoutAnalysis.InvalidSearchQuery.Name'),
     description: tl('LoadoutAnalysis.InvalidSearchQuery.Description'),
     icon: faExclamationTriangle,
+  },
+  [LoadoutFinding.ItemsDoNotMatchSearchQuery]: {
+    name: tl('LoadoutAnalysis.ItemsDoNotMatchSearchQuery.Name'),
+    description: tl('LoadoutAnalysis.ItemsDoNotMatchSearchQuery.Description'),
+    icon: searchIcon,
   },
 };

--- a/src/app/loadout-analyzer/store.ts
+++ b/src/app/loadout-analyzer/store.ts
@@ -251,6 +251,7 @@ export class LoadoutBackgroundAnalyzer {
           [LoadoutFinding.UsesSeasonalMods]: new Set(),
           [LoadoutFinding.DoesNotSatisfyStatConstraints]: new Set(),
           [LoadoutFinding.InvalidSearchQuery]: new Set(),
+          [LoadoutFinding.ItemsDoNotMatchSearchQuery]: new Set(),
         },
       };
 

--- a/src/app/loadout-analyzer/types.ts
+++ b/src/app/loadout-analyzer/types.ts
@@ -62,8 +62,10 @@ export const enum LoadoutFinding {
   ModsDontFit,
   /** The armor set does not match the saved stat constraints. */
   DoesNotSatisfyStatConstraints,
-  /** The loadout parameters search query is invalid or the items don't match them */
+  /** The loadout parameters search query is invalid. */
   InvalidSearchQuery,
+  /** The loadout parameters search query excludes items in the loadout. */
+  ItemsDoNotMatchSearchQuery,
 }
 
 /** These aren't problems per se but they do block further analysis */

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -629,8 +629,12 @@
       "Name": "Deprecated Mods"
     },
     "InvalidSearchQuery": {
-      "Description": "This loadout was created with a search query in Loadout Optimizer that is no longer valid, or does not include the armor in this loadout.",
+      "Description": "This loadout was created with a search query in Loadout Optimizer that is not valid.",
       "Name": "Invalid Search Query"
+    },
+    "ItemsDoNotMatchSearchQuery": {
+      "Description": "This loadout was created with a search query in Loadout Optimizer, and that search query excludes at least one of the items in the loadout.",
+      "Name": "Search Excludes Items"
     },
     "MissingItems": {
       "Description": "Some of the items in this loadout are no longer in your inventory.",


### PR DESCRIPTION
Changelog: Loadout analyzer is more precise about calling out invalid search queries vs. loadouts whose search query excludes some of its armor.

This fixes the issue where "Invalid Search Query" was shown when the items were really excluded by the inherent statlower filtering in filterItems. I chose to handle this case by splitting the issue type, and then just removing the issue when "Better Stats Available" is shown since that definitely means there's a better item available.