### PR TITLE
Show wishlist titles

### DIFF
--- a/src/app/armory/AllWishlistRolls.m.scss
+++ b/src/app/armory/AllWishlistRolls.m.scss
@@ -33,3 +33,17 @@
   justify-content: center;
   margin: 1px;
 }
+
+.rollGroup {
+  h3 {
+    &:has(+ .subtitle) {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.subtitle {
+  color: var(--theme-text-secondary);
+  margin-top: 0.1em;
+  margin-bottom: 0.5em;
+}

--- a/src/app/armory/AllWishlistRolls.m.scss.d.ts
+++ b/src/app/armory/AllWishlistRolls.m.scss.d.ts
@@ -5,6 +5,8 @@ interface CssExports {
   'notes': string;
   'orGroup': string;
   'roll': string;
+  'rollGroup': string;
+  'subtitle': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -6,8 +6,8 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { faExclamationTriangle } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { compareBy } from 'app/utils/comparators';
-import { wishListRollsForItemHashSelector } from 'app/wishlists/selectors';
-import { WishListRoll } from 'app/wishlists/types';
+import { wishListInfosSelector, wishListRollsForItemHashSelector } from 'app/wishlists/selectors';
+import { WishListInfo, WishListRoll } from 'app/wishlists/types';
 import { partition } from 'es-toolkit';
 import { useSelector } from 'react-redux';
 import styles from './AllWishlistRolls.m.scss';
@@ -80,6 +80,7 @@ function WishlistRolls({
   realAvailablePlugHashes?: number[];
 }) {
   const defs = useD2Definitions()!;
+  const wishlistInfos = useSelector(wishListInfosSelector);
   const groupedWishlistRolls = Object.groupBy(wishlistRolls, (r) => r.notes || t('Armory.NoNotes'));
 
   const templateSockets = getCraftingTemplate(defs, item.hash)?.sockets?.socketEntries;
@@ -117,13 +118,23 @@ function WishlistRolls({
 
   // TODO: group by making a tree of least cardinality -> most?
 
+  const usedTitles = new Set<string>();
+  function useTitle(info: WishListInfo) {
+    if (info.title && !usedTitles.has(info.title)) {
+      usedTitles.add(info.title);
+      return <h3>{info.title}</h3>;
+    }
+  }
+
   return (
     <>
       {Object.entries(groupedWishlistRolls).map(([notes, rolls]) => {
         const consolidatedRolls = consolidateRollsForOneWeapon(defs, item, rolls);
+        const info = wishlistInfos[rolls[0].sourceWishListIndex ?? -1];
 
         return (
           <div key={notes}>
+            {useTitle(info)}
             <div className={styles.notes}>{notes}</div>
             <ul>
               {consolidatedRolls.map((cr) => {

--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -1,3 +1,4 @@
+import ExternalLink from 'app/dim-ui/ExternalLink';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { DimItem, DimPlug, DimSocket } from 'app/inventory/item-types';
@@ -7,7 +8,7 @@ import { faExclamationTriangle } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { compareBy } from 'app/utils/comparators';
 import { wishListInfosSelector, wishListRollsForItemHashSelector } from 'app/wishlists/selectors';
-import { WishListInfo, WishListRoll } from 'app/wishlists/types';
+import { WishListRoll } from 'app/wishlists/types';
 import { partition } from 'es-toolkit';
 import { useSelector } from 'react-redux';
 import styles from './AllWishlistRolls.m.scss';
@@ -119,10 +120,16 @@ function WishlistRolls({
   // TODO: group by making a tree of least cardinality -> most?
 
   const usedTitles = new Set<string>();
-  function useTitle(info: WishListInfo) {
-    if (info.title && !usedTitles.has(info.title)) {
-      usedTitles.add(info.title);
-      return <h3>{info.title}</h3>;
+  function useTitle(roll: WishListRoll) {
+    if (roll.title && !usedTitles.has(roll.title)) {
+      usedTitles.add(roll.title);
+      const url = wishlistInfos?.[roll.sourceWishListIndex ?? -1]?.url;
+      return (
+        <>
+          <h3>{url ? <ExternalLink href={url}>{roll.title}</ExternalLink> : roll.title}</h3>
+          {roll.description && <p className={styles.subtitle}>{roll.description}</p>}
+        </>
+      );
     }
   }
 
@@ -130,12 +137,11 @@ function WishlistRolls({
     <>
       {Object.entries(groupedWishlistRolls).map(([notes, rolls]) => {
         const consolidatedRolls = consolidateRollsForOneWeapon(defs, item, rolls);
-        const info = wishlistInfos[rolls[0].sourceWishListIndex ?? -1];
 
         return (
-          <div key={notes}>
-            {useTitle(info)}
-            <div className={styles.notes}>{notes}</div>
+          <div key={notes} className={styles.rollGroup}>
+            {useTitle(rolls[0])}
+            <p className={styles.notes}>{notes}</p>
             <ul>
               {consolidatedRolls.map((cr) => {
                 // groups [outlaw, enhanced outlaw, rampage]

--- a/src/app/wishlists/selectors.ts
+++ b/src/app/wishlists/selectors.ts
@@ -6,6 +6,8 @@ import { getInventoryWishListRoll, InventoryWishListRoll } from './wishlists';
 
 export const wishListsSelector = (state: RootState) => state.wishLists;
 
+export const wishListInfosSelector = (state: RootState) => state.wishLists.wishListAndInfo.infos;
+
 export const wishListsLastFetchedSelector = (state: RootState) =>
   wishListsSelector(state).lastFetched;
 

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -44,6 +44,10 @@ export interface WishListRoll {
    * from. Not set on some old wishlists from storage.
    */
   sourceWishListIndex?: number;
+
+  /** Optional title and description from the curator. */
+  title?: string;
+  description?: string;
 }
 
 export interface WishListAndInfo {

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -38,12 +38,20 @@ export interface WishListRoll {
 
   /** Optional notes from the curator. */
   notes?: string;
+
+  /**
+   * The index into the "infos" list for which wishlist this roll was sourced
+   * from. Not set on some old wishlists from storage.
+   */
+  sourceWishListIndex?: number;
 }
 
 export interface WishListAndInfo {
+  /** A merged list of wish list rolls from each of the source wish lists. */
   wishListRolls: WishListRoll[];
   /** The URL(s) we fetched the wish list(s) from */
   source?: string;
+  /** Information about the wishlists themselves that contribute to the rolls. */
   infos: WishListInfo[];
 }
 

--- a/src/app/wishlists/wishlist-file.test.ts
+++ b/src/app/wishlists/wishlist-file.test.ts
@@ -10,6 +10,9 @@ const cases: [wishlist: string, result: WishListRoll][] = [
       notes: 'Enh Over, Enh FocuFury',
       isExpertMode: true,
       isUndesirable: false,
+      description: undefined,
+      sourceWishListIndex: 0,
+      title: undefined,
     },
   ],
 ];

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -73,6 +73,7 @@ export function toWishList(files: [url: string | undefined, contents: string][])
             } else {
               info.dupeRolls++;
             }
+            roll.sourceWishListIndex = wishList.infos.length;
           }
         }
       }

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -8,12 +8,12 @@ const TAG = 'wishlist';
  * The title should follow the following format:
  * title:This Is My Source File Title.
  */
-const titleLabel = 'title:';
+const titleLabel = /^@?title:(.*?)\s*$/;
 /**
  * The description should follow the following format:
  * description:This Is My Source File Description And Maybe It Is Longer.
  */
-const descriptionLabel = 'description:';
+const descriptionLabel = /^@?description:(.*?)\s*$/;
 /**
  * Notes apply to all rolls until an empty line or comment.
  */
@@ -43,7 +43,9 @@ export function toWishList(files: [url: string | undefined, contents: string][])
         dupeRolls: 0,
       };
       let blockNotes: string | undefined = undefined;
-
+      let title: string | undefined = undefined;
+      let description: string | undefined = undefined;
+      let match: RegExpExecArray | null = null;
       const lines = fileText.split('\n');
       for (const line of lines) {
         if (line.startsWith(notesLabel)) {
@@ -51,10 +53,16 @@ export function toWishList(files: [url: string | undefined, contents: string][])
         } else if (line.length === 0 || line.startsWith('//')) {
           // Empty lines and comments reset the block note
           blockNotes = undefined;
-        } else if (!info.title && line.startsWith(titleLabel)) {
-          info.title = line.slice(titleLabel.length);
-        } else if (!info.description && line.startsWith(descriptionLabel)) {
-          info.description = line.slice(descriptionLabel.length);
+        } else if ((match = titleLabel.exec(line))) {
+          title = match[1];
+          if (!info.title) {
+            info.title = title;
+          }
+        } else if ((match = descriptionLabel.exec(line))) {
+          description = match[1];
+          if (!info.description) {
+            info.description = description;
+          }
         } else {
           const roll =
             toDimWishListRoll(line, blockNotes) ||
@@ -74,6 +82,8 @@ export function toWishList(files: [url: string | undefined, contents: string][])
               info.dupeRolls++;
             }
             roll.sourceWishListIndex = wishList.infos.length;
+            roll.title = title;
+            roll.description = description;
           }
         }
       }


### PR DESCRIPTION
Changelog: Added wishlist title/description and link to source to the Armory page.

It was never intended to have title/description repeat within a wishlist, but it's a consequence of Voltron concatenating different sources so I figured I'd roll with it. They also sometimes put an `@` at the beginning of the line, IDK.

<img width="663" height="374" alt="Screenshot 2025-09-06 at 12 17 54 PM" src="https://github.com/user-attachments/assets/52484a9d-fce7-48d7-9732-43da8bab5e55" />
<img width="559" height="206" alt="Screenshot 2025-09-06 at 12 18 05 PM" src="https://github.com/user-attachments/assets/ce3cf346-13f5-4f63-94f5-d200e01cdcbb" />
