### PR TITLE
Fix: Update tuned stat icon because Bungie changed it

### DIFF
--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -19,7 +19,7 @@ import { weaponMasterworkY2SocketTypeHash } from 'app/search/d2-known-values';
 import Checkbox from 'app/settings/Checkbox';
 import { useSetting } from 'app/settings/hooks';
 import { Settings } from 'app/settings/initial-settings';
-import { AppIcon, faList, settingsIcon, tuningStatIcon } from 'app/shell/icons';
+import { AppIcon, faList, settingsIcon, tunedStatIcon } from 'app/shell/icons';
 import { masterworkHammer } from 'app/shell/icons/custom/MasterworkHammer';
 import { acquisitionRecencyComparator } from 'app/shell/item-comparators';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
@@ -243,10 +243,10 @@ export default function Compare({ session }: { session: CompareSession }) {
         <>
           <span className={styles.comparisonModeHint}>
             <AppIcon icon={settingsIcon} />
-            <AppIcon icon={tuningStatIcon} />
+            <AppIcon icon={tunedStatIcon} />
           </span>
           <div className={styles.comparisonModeInfo}>
-            <AppIcon icon={tuningStatIcon} /> {t('Organizer.Columns.BaseStats')}
+            <AppIcon icon={tunedStatIcon} /> {t('Organizer.Columns.BaseStats')}
             <span className={styles.comparisonModeDescription}>
               {t('Compare.BaseStatsDescription')}
             </span>

--- a/src/app/compare/Compare.tsx
+++ b/src/app/compare/Compare.tsx
@@ -19,7 +19,7 @@ import { weaponMasterworkY2SocketTypeHash } from 'app/search/d2-known-values';
 import Checkbox from 'app/settings/Checkbox';
 import { useSetting } from 'app/settings/hooks';
 import { Settings } from 'app/settings/initial-settings';
-import { AppIcon, faList, settingsIcon, tunedStatIcon } from 'app/shell/icons';
+import { AppIcon, faList, settingsIcon, statBarsIcon } from 'app/shell/icons';
 import { masterworkHammer } from 'app/shell/icons/custom/MasterworkHammer';
 import { acquisitionRecencyComparator } from 'app/shell/item-comparators';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
@@ -243,10 +243,10 @@ export default function Compare({ session }: { session: CompareSession }) {
         <>
           <span className={styles.comparisonModeHint}>
             <AppIcon icon={settingsIcon} />
-            <AppIcon icon={tunedStatIcon} />
+            <AppIcon icon={statBarsIcon} />
           </span>
           <div className={styles.comparisonModeInfo}>
-            <AppIcon icon={tunedStatIcon} /> {t('Organizer.Columns.BaseStats')}
+            <AppIcon icon={statBarsIcon} /> {t('Organizer.Columns.BaseStats')}
             <span className={styles.comparisonModeDescription}>
               {t('Compare.BaseStatsDescription')}
             </span>

--- a/src/app/compare/CompareStat.m.scss
+++ b/src/app/compare/CompareStat.m.scss
@@ -52,13 +52,12 @@
   color: #fff;
   position: absolute;
   left: 0;
-  transform: scale(-1, 1);
   background-color: transparent !important;
   line-height: 1;
   white-space: pre;
   sup {
     position: absolute;
-    right: 100%;
+    left: 100%;
   }
 }
 

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -1,7 +1,7 @@
 import AnimatedNumber from 'app/dim-ui/AnimatedNumber';
 import RecoilStat, { recoilValue } from 'app/item-popup/RecoilStat';
 import { getCompareColor, percent } from 'app/shell/formatters';
-import { AppIcon, tuningStatIcon } from 'app/shell/icons';
+import { AppIcon, tunedStatIcon } from 'app/shell/icons';
 import { artificeIcon } from 'app/shell/icons/custom/Artifice';
 import { getArmor3TuningStat, isArtifice } from 'app/utils/item-utils';
 import clsx from 'clsx';
@@ -39,7 +39,7 @@ export default function CompareStat({
   const syntheticStat = Boolean(stat?.statHash && stat.statHash < 0);
   // If this is Artifice armor and a custom or Total stat
   const showArtificeIcon = isArtifice(item) && syntheticStat;
-  const extraIcon = showTunerIcon ? tuningStatIcon : showArtificeIcon ? artificeIcon : undefined;
+  const extraIcon = showTunerIcon ? tunedStatIcon : showArtificeIcon ? artificeIcon : undefined;
   const showBar = stat?.bar && item.bucket.inArmor;
 
   return (
@@ -60,8 +60,8 @@ export default function CompareStat({
                 [styles.smaller]: showArtificeIcon,
               })}
             >
-              {(showArtificeIcon || relevantStatHashes) && <sup>+</sup>}
               <AppIcon icon={extraIcon} />
+              {showArtificeIcon && <sup>+</sup>}
             </span>
           )}
           {showBar && (

--- a/src/app/item-popup/ItemStat.tsx
+++ b/src/app/item-popup/ItemStat.tsx
@@ -9,7 +9,7 @@ import { D1Item, D1Stat, DimItem, DimSocket, DimStat } from 'app/inventory/item-
 import { statsMs } from 'app/inventory/store/stats';
 import { TOTAL_STAT_HASH, armorStats, statfulOrnaments } from 'app/search/d2-known-values';
 import { getD1QualityColor, percent } from 'app/shell/formatters';
-import { AppIcon, helpIcon, tuningStatIcon } from 'app/shell/icons';
+import { AppIcon, helpIcon, tunedStatIcon } from 'app/shell/icons';
 import { userGuideUrl } from 'app/shell/links';
 import { sumBy } from 'app/utils/collections';
 import { compareBy, reverseComparator } from 'app/utils/comparators';
@@ -164,7 +164,7 @@ export default function ItemStat({
         title={stat.displayProperties.description}
       >
         {stat.statHash === itemStatInfo?.tunedStatHash && (
-          <AppIcon icon={tuningStatIcon} className={styles.tunableSymbol} />
+          <AppIcon icon={tunedStatIcon} className={styles.tunableSymbol} />
         )}{' '}
         {stat.statHash in statLabels
           ? t(statLabels[stat.statHash as StatHashes]!)

--- a/src/app/shell/icons/custom/StatBarsIcon.ts
+++ b/src/app/shell/icons/custom/StatBarsIcon.ts
@@ -1,7 +1,7 @@
 import { makeCustomIcon } from './utils';
 
-export const dimTuningStatIcon = makeCustomIcon(
-  'TuningStat',
+export const statBarsIcon = makeCustomIcon(
+  'StatBars',
   20,
   32,
   'M10 6.5h10v4h-10zM5 14.5h15v4h-15zM0 22.5h20v4h-20z',

--- a/src/app/shell/icons/custom/TunedStatIcon.ts
+++ b/src/app/shell/icons/custom/TunedStatIcon.ts
@@ -1,0 +1,8 @@
+import { makeCustomIcon } from './utils';
+
+export const tunedStatIcon = makeCustomIcon(
+  'TunedStat',
+  32,
+  32,
+  'M2,14.25 h28 v3.5 h-28zM2,10.5 l7,-7 l7,7 h-4.5 l-2.5,-2.5 l-2.5,2.5 zM30,21.5 l-7,7 l-7,-7 h4.5 l2.5,2.5 l2.5,-2.5 z',
+);

--- a/src/app/shell/icons/index.ts
+++ b/src/app/shell/icons/index.ts
@@ -10,6 +10,6 @@ export { dimPowerIcon as powerIndicatorIcon } from './custom/Power';
 export { dimPowerAltIcon as powerActionIcon } from './custom/PowerAlt';
 export { dimShapedIcon as shapedIcon } from './custom/Shaped';
 export { dimTitanIcon as titanIcon } from './custom/Titan';
-export { dimTuningStatIcon as tuningStatIcon } from './custom/TuningStat';
+export { tunedStatIcon } from './custom/TunedStatIcon';
 export { dimWarlockIcon as warlockIcon } from './custom/Warlock';
 export * from './Library.js';

--- a/src/app/shell/icons/index.ts
+++ b/src/app/shell/icons/index.ts
@@ -9,6 +9,7 @@ export { dimHunterIcon as hunterIcon } from './custom/Hunter';
 export { dimPowerIcon as powerIndicatorIcon } from './custom/Power';
 export { dimPowerAltIcon as powerActionIcon } from './custom/PowerAlt';
 export { dimShapedIcon as shapedIcon } from './custom/Shaped';
+export { statBarsIcon } from './custom/StatBarsIcon';
 export { dimTitanIcon as titanIcon } from './custom/Titan';
 export { tunedStatIcon } from './custom/TunedStatIcon';
 export { dimWarlockIcon as warlockIcon } from './custom/Warlock';


### PR DESCRIPTION
Old:
<img width="308" height="139" alt="image" src="https://github.com/user-attachments/assets/49b8be33-9330-4b33-b4e9-1f4ff4a889f4" />

New:
<img width="176" height="70" alt="image" src="https://github.com/user-attachments/assets/db55d2cb-9ef8-44fa-93d4-89354481c48b" />

DIM:
<img width="206" height="107" alt="image" src="https://github.com/user-attachments/assets/73e7933b-9213-44b0-955c-9945563bd3c3" />

The new icon is better in theory but the lines felt too thin next to text in DIM, so they are thickened up a bit and arrow vertical spacing is increased to accommodate.

Changelog: Updated tuned stat icon.