### PR TITLE
Change well rested clamp to start at 1

### DIFF
--- a/src/app/inventory/store/well-rested.ts
+++ b/src/app/inventory/store/well-rested.ts
@@ -58,9 +58,9 @@ export function isWellRested(
   }
 
   const requiredXP =
-    prestigeMode && prestigeProgression.level >= wellRestedLevels
-      ? xpRequiredForLevel(0, prestigeProgressionDef) * wellRestedLevels
-      : xpTotalRequiredForLevel(seasonPassLevel, seasonProgressionDef, wellRestedLevels);
+    (prestigeMode && prestigeProgression.level >= wellRestedLevels
+      ? xpRequiredForLevel(0, prestigeProgressionDef)
+      : xpRequiredForLevel(seasonPassLevel, seasonProgressionDef)) * wellRestedLevels;
 
   // Have you gained XP equal to three full levels worth of XP?
   return {
@@ -74,18 +74,6 @@ export function isWellRested(
  * How much XP was required to achieve the given level?
  */
 function xpRequiredForLevel(level: number, progressDef: DestinyProgressionDefinition) {
-  const stepIndex = clamp(level, 1, progressDef.steps.length - 1);
+  const stepIndex = clamp(level, 0, progressDef.steps.length - 1);
   return progressDef.steps[stepIndex].progressTotal;
-}
-
-function xpTotalRequiredForLevel(
-  totalLevel: number,
-  seasonProgressDef: DestinyProgressionDefinition,
-  WELL_RESTED_LEVELS: number,
-) {
-  let totalXP = 0;
-  for (let i = 0; i < WELL_RESTED_LEVELS; i++) {
-    totalXP += xpRequiredForLevel(totalLevel - i, seasonProgressDef);
-  }
-  return totalXP;
 }


### PR DESCRIPTION
Changelog: fixes well rested xp for levels below 5 showing the wrong required xp amount.

fixes #11471

OLD
<img width="795" height="233" alt="image" src="https://github.com/user-attachments/assets/6d7b667a-2edd-4aa8-acfd-ae99b15f3b73" />

NEW
<img width="919" height="275" alt="image" src="https://github.com/user-attachments/assets/8d9a37e2-bfcc-4dae-a519-d67b6edb6c2f" />
