### PR TITLE
Fix: normalize enhancedness for dupe perk comparison

### DIFF
--- a/src/app/search/items/search-filters/perks-set.ts
+++ b/src/app/search/items/search-filters/perks-set.ts
@@ -1,4 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
+import { normalizeEnhancedness } from 'app/utils/perk-utils';
 import { getSocketsByType } from 'app/utils/socket-utils';
 
 type PerkType = Parameters<typeof getSocketsByType>[1];
@@ -49,6 +50,6 @@ export class PerksSet {
 
 function makePerksSet(item: DimItem, perkType?: PerkType) {
   return getSocketsByType(item, perkType).map(
-    (s) => new Set(s.plugOptions.map((p) => p.plugDef.hash)),
+    (s) => new Set(s.plugOptions.map((p) => normalizeEnhancedness(p.plugDef.hash))),
   );
 }

--- a/src/app/utils/perk-utils.ts
+++ b/src/app/utils/perk-utils.ts
@@ -1,0 +1,6 @@
+import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
+
+/** Convert a perk hash to its enhanced version, if possible, else returns it unchanged (maybe it was already enhanced?) */
+export function normalizeEnhancedness(perkHash: number) {
+  return perkToEnhanced[perkHash] ?? perkHash;
+}


### PR DESCRIPTION
The utils file seems silly, but I have other things in other branches that I need to move/consolidate there.

Changelog: `dupe:perks` and `dupe:traits` will compare across enhanced and non-enhanced perks.