### PR TITLE
Feature: Show active set bonuses for LO result sets

### DIFF
--- a/src/app/item-popup/SetBonus.m.scss
+++ b/src/app/item-popup/SetBonus.m.scss
@@ -52,3 +52,10 @@
 .unsatisfied {
   opacity: 0.4;
 }
+
+.setBonusesStatus {
+  display: flex;
+  & > div {
+    display: flex;
+  }
+}

--- a/src/app/item-popup/SetBonus.m.scss.d.ts
+++ b/src/app/item-popup/SetBonus.m.scss.d.ts
@@ -8,6 +8,7 @@ interface CssExports {
   'perk': string;
   'perkIcon': string;
   'setBonus': string;
+  'setBonusesStatus': string;
   'unsatisfied': string;
 }
 export const cssExports: CssExports;

--- a/src/app/item-popup/SetBonus.tsx
+++ b/src/app/item-popup/SetBonus.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import styles from './SetBonus.m.scss';
 
 /** Information about set bonuses currently/hypothetically provided by  a collection of armor pieces. */
-interface ActiveSetBonusInfo {
+export interface ActiveSetBonusInfo {
   // Returned as a convenience for downstream display, to avoid repeat filtering and sorting armor.
   equippedArmor: DimItem[];
   possibleBonusSets: Record<number, DimItem[]>;
@@ -91,7 +91,7 @@ export function SetBonusesStatus({
   store?: DimStore;
 }) {
   return (
-    <div>
+    <div className={styles.setBonusesStatus}>
       {Object.values(setBonusStatus.activeSetBonuses).map((sb) => (
         <PressTip
           key={sb!.setBonus.hash}
@@ -103,10 +103,14 @@ export function SetBonusesStatus({
                   <strong>{`${t('Item.SetBonus.NPiece', { count: p.requirement })} | ${p.def.displayProperties.name}`}</strong>
                   <br />
                   {p.def.displayProperties.description}
-                  <hr />
                 </React.Fragment>
               ))}
-              {store && <ContributingArmor store={store} setBonus={sb!.setBonus} />}
+              {store && (
+                <>
+                  <hr />
+                  <ContributingArmor store={store} setBonus={sb!.setBonus} />
+                </>
+              )}
             </>
           }
           placement="top"

--- a/src/app/item-popup/SetBonus.tsx
+++ b/src/app/item-popup/SetBonus.tsx
@@ -98,8 +98,9 @@ export function SetBonusesStatus({
           tooltip={
             <>
               <Tooltip.Header text={sb!.setBonus.displayProperties.name} />
-              {Object.values(sb!.activePerks).map((p) => (
+              {Object.values(sb!.activePerks).map((p, i) => (
                 <React.Fragment key={p.def.hash}>
+                  {i !== 0 && <hr />}
                   <strong>{`${t('Item.SetBonus.NPiece', { count: p.requirement })} | ${p.def.displayProperties.name}`}</strong>
                   <br />
                   {p.def.displayProperties.description}

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -2,6 +2,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { t } from 'app/i18next-t';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { DimStore, statSourceOrder } from 'app/inventory/store-types';
+import { getSetBonusStatus } from 'app/item-popup/SetBonus';
 import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
 import { Loadout } from 'app/loadout/loadout-types';
 import { fitMostMods } from 'app/loadout/mod-assignment-utils';
@@ -158,6 +159,7 @@ export default memo(function GeneratedSet({
   });
 
   const canCompareLoadouts = loadouts.length > 0;
+  const setBonusStatus = getSetBonusStatus(defs, set.armor);
 
   return (
     <>
@@ -169,6 +171,7 @@ export default memo(function GeneratedSet({
         boostedStats={boostedStats}
         existingLoadoutName={overlappingLoadout?.name}
         equippedHashes={equippedHashes}
+        setBonusStatus={setBonusStatus}
       />
       <div className={styles.build}>
         <div className={styles.items}>

--- a/src/app/loadout-builder/generated-sets/SetStats.m.scss
+++ b/src/app/loadout-builder/generated-sets/SetStats.m.scss
@@ -29,6 +29,7 @@
 .light {
   color: $gold;
   white-space: nowrap;
+  margin-right: 0.5em;
 
   :global(.app-icon) {
     vertical-align: 3px;

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -1,6 +1,7 @@
 import BungieImage from 'app/dim-ui/BungieImage';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
+import { ActiveSetBonusInfo, SetBonusesStatus } from 'app/item-popup/SetBonus';
 import { MAX_STAT } from 'app/loadout/known-values';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { AppIcon, powerIndicatorIcon } from 'app/shell/icons';
@@ -32,6 +33,7 @@ export function TierlessSetStats({
   className,
   existingLoadoutName,
   equippedHashes,
+  setBonusStatus,
 }: {
   stats: ArmorStats;
   getStatsBreakdown: () => ModStatChanges;
@@ -41,6 +43,7 @@ export function TierlessSetStats({
   className?: string;
   existingLoadoutName?: string;
   equippedHashes: Set<number>;
+  setBonusStatus: ActiveSetBonusInfo;
 }) {
   const defs = useD2Definitions()!;
   const totalStats = sum(Object.values(stats));
@@ -88,6 +91,7 @@ export function TierlessSetStats({
         <AppIcon icon={powerIndicatorIcon} />
         {maxPower}
       </span>
+      <SetBonusesStatus setBonusStatus={setBonusStatus} />
       {existingLoadoutName ? (
         <span className={styles.existingLoadout}>
           {t('LoadoutBuilder.ExistingLoadout')}:{' '}

--- a/src/app/store-stats/StoreStats.m.scss
+++ b/src/app/store-stats/StoreStats.m.scss
@@ -90,10 +90,4 @@
   display: flex;
   flex-direction: row-reverse;
   gap: 4px;
-  & > div {
-    display: flex;
-    & > div {
-      display: flex;
-    }
-  }
 }


### PR DESCRIPTION
Changelog: Loadout Optimizer result sets now show which set bonuses they activate.

<img width="1630" height="1194" alt="image" src="https://github.com/user-attachments/assets/2f14a8c4-e14e-4357-8f91-24b4942eaa51" />
