### PR TITLE
Hide tuning hints on Organizer stat columns

### DIFF
--- a/src/app/compare/CompareColumns.tsx
+++ b/src/app/compare/CompareColumns.tsx
@@ -60,16 +60,12 @@ export function getColumns(
   const isGeneral = itemsType === 'general';
 
   const { statColumns, baseStatColumns, baseMasterworkStatColumns, d1ArmorQualityByStat } =
-    getStatColumns(
-      stats,
-      customStatDefs,
-      destinyVersion,
-      {
-        isArmor,
-        showStatLabel: true,
-      },
-      styles.stat,
-    );
+    getStatColumns(stats, customStatDefs, destinyVersion, {
+      isArmor,
+      showStatLabel: true,
+      extraStatInfo: true,
+      className: styles.stat,
+    });
 
   const preferredStatColumns =
     !isArmor || armorCompare === 'current'
@@ -78,13 +74,12 @@ export function getColumns(
         ? baseStatColumns
         : baseMasterworkStatColumns;
 
-  const customStatColumns = createCustomStatColumns(
-    customStatDefs,
-    styles.stat,
-    undefined, // `headerClassName` string
-    true, // `hideFormula` boolean
-    armorCompare === 'baseMasterwork', // `withMasterwork` boolean
-  );
+  const customStatColumns = createCustomStatColumns(customStatDefs, {
+    className: styles.stat,
+    hideFormula: true,
+    withMasterwork: armorCompare === 'baseMasterwork',
+    extraStatInfo: true,
+  });
 
   // TODO: maybe add destinyVersion / usecase to the ColumnDefinition type??
   const columns: ColumnDefinition[] = compact([

--- a/src/app/compare/CompareStat.tsx
+++ b/src/app/compare/CompareStat.tsx
@@ -16,6 +16,7 @@ export default function CompareStat({
   item,
   value,
   relevantStatHashes,
+  extraStatInfo = false,
 }: {
   stat?: DimStat | D1Stat;
   item: DimItem;
@@ -24,6 +25,8 @@ export default function CompareStat({
   max: number;
   /** If this represents a custom stat, these are the real stats that custom stat includes. */
   relevantStatHashes?: number[];
+  /** Whether to show extra stat info icons (e.g. that the total includes tuners, or that the stat is tuned) and stat bars. */
+  extraStatInfo?: boolean;
 }) {
   const isMasterworkStat = Boolean(
     item?.bucket.inWeapons &&
@@ -51,7 +54,7 @@ export default function CompareStat({
           [styles.noMinWidth]: !stat || stat.statHash === StatHashes.AnyEnergyTypeCost,
         })}
       />
-      {item.bucket.inArmor && (
+      {item.bucket.inArmor && extraStatInfo && (
         <span className={clsx(styles.statBarArea, showBar && styles.statBarContainer)}>
           {extraIcon && (
             <span

--- a/src/app/organizer/Columns.m.scss
+++ b/src/app/organizer/Columns.m.scss
@@ -46,12 +46,13 @@
 }
 
 .centered {
-  text-align: center !important;
+  text-align: center;
+  justify-content: center;
 }
 
 .dmg {
   composes: centered;
-  padding-top: calc(var(--item-size) * 0.75 * 0.5 - 2px) !important;
+  padding-top: calc(var(--item-size) * 0.75 * 0.5 - 2px);
 }
 .dmgHeader {
   composes: centered;
@@ -61,12 +62,12 @@
 .icon {
   --icon-item-size: calc(var(--item-size) * 0.75);
   composes: centered;
-  padding-top: 4px !important;
+  padding-top: 4px;
   min-width: calc(var(--item-size) * 0.75);
   left: calc(30px + env(safe-area-inset-left));
   position: sticky;
   top: calc(var(--header-height) + var(--table-header-height) + var(--item-table-toolbar-height));
-  z-index: table.$header-cells !important;
+  z-index: table.$header-cells;
   background: var(--org-row-bg);
   > :global(.item) {
     --item-size: var(--icon-item-size) !important;
@@ -108,7 +109,7 @@
 }
 
 .perkLike {
-  padding-top: calc(var(--item-size) * 0.5 * 0.5 - 5px) !important;
+  padding-top: calc(var(--item-size) * 0.5 * 0.5 - 5px);
   > *:nth-last-child(n + 2) {
     margin-bottom: 4px;
   }
@@ -182,7 +183,7 @@
 .perksGrid {
   --mod-size: calc(28 / 50 * var(--item-size));
   --perk-size: calc(28 / 50 * var(--item-size));
-  padding-top: 4px !important;
+  padding-top: 4px;
   padding-bottom: 4px;
 
   @include phone-portrait {
@@ -216,7 +217,12 @@ $modslotSize: 30px;
 
 .modslot {
   composes: centered;
-  padding-top: calc(4px + (var(--item-size) * 0.75 - #{$modslotSize}) / 2) !important;
+  padding-top: calc(4px + (var(--item-size) * 0.75 - #{$modslotSize}) / 2);
+}
+
+.loadouts {
+  flex-direction: column;
+  gap: 4px;
 }
 
 .loadout {

--- a/src/app/organizer/Columns.m.scss.d.ts
+++ b/src/app/organizer/Columns.m.scss.d.ts
@@ -14,6 +14,7 @@ interface CssExports {
   'inlineIcon': string;
   'isPerk': string;
   'loadout': string;
+  'loadouts': string;
   'locationCell': string;
   'miniPerkContainer': string;
   'modPerk': string;

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -935,6 +935,7 @@ export function getColumns(
     c({
       id: 'loadouts',
       header: t('Organizer.Columns.Loadouts'),
+      className: styles.loadouts,
       value: (item) => {
         const loadouts = loadoutsByItem[item.id];
         // The raw comparison value compares by number of loadouts first,

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -252,13 +252,16 @@ export function getColumns(
     {
       isArmor,
       isSpreadsheet,
+      className: styles.stats,
+      headerClassName: styles.statsHeader,
     },
-    styles.stats,
-    styles.statsHeader,
   );
   const customStats = isSpreadsheet
     ? []
-    : createCustomStatColumns(customStatDefs, styles.stats, styles.statsHeader);
+    : createCustomStatColumns(customStatDefs, {
+        className: styles.stats,
+        headerClassName: styles.statsHeader,
+      });
 
   const columns: ColumnDefinition[] = compact([
     !isSpreadsheet &&
@@ -1000,13 +1003,18 @@ export function getStatColumns(
     isArmor,
     isSpreadsheet = false,
     showStatLabel = false,
+    extraStatInfo = false,
+    className,
+    headerClassName,
   }: {
     isArmor: boolean;
     isSpreadsheet?: boolean;
     showStatLabel?: boolean;
+    /** Whether to show extra stat info icons (e.g. that the total includes tuners, or that the stat is tuned) and stat bars. */
+    extraStatInfo?: boolean;
+    className?: string;
+    headerClassName?: string;
   },
-  className?: string,
-  headerClassName?: string,
 ) {
   const customStatHashes = customStatDefs.map((c) => c.statHash);
   const statsGroup: ColumnGroup = {
@@ -1071,6 +1079,7 @@ export function getStatColumns(
             stat={stat}
             item={item}
             value={stat.value}
+            extraStatInfo={extraStatInfo}
           />
         );
       },
@@ -1140,6 +1149,7 @@ export function getStatColumns(
                 stat={stat}
                 item={item}
                 value={stat.base}
+                extraStatInfo={extraStatInfo}
               />
             );
           },
@@ -1179,6 +1189,7 @@ export function getStatColumns(
                 stat={stat}
                 item={item}
                 value={val}
+                extraStatInfo={extraStatInfo}
               />
             );
           },

--- a/src/app/organizer/CustomStatColumns.tsx
+++ b/src/app/organizer/CustomStatColumns.tsx
@@ -9,10 +9,20 @@ import { ColumnDefinition, SortDirection } from './table-types';
 
 export function createCustomStatColumns(
   customStatDefs: CustomStatDef[],
-  className?: string,
-  headerClassName?: string,
-  hideFormula = false,
-  withMasterwork = false,
+  {
+    hideFormula = false,
+    withMasterwork = false,
+    extraStatInfo = false,
+    className,
+    headerClassName,
+  }: {
+    hideFormula?: boolean;
+    withMasterwork?: boolean;
+    /** Whether to show extra stat info icons (e.g. that the total includes tuners, or that the stat is tuned) and stat bars. */
+    extraStatInfo?: boolean;
+    className?: string;
+    headerClassName?: string;
+  } = {},
 ): ColumnDefinition[] {
   return customStatDefs.map((c): ColumnDefinition => {
     const { class: guardianClass, label, shortLabel, statHash, weights } = c;
@@ -49,6 +59,7 @@ export function createCustomStatColumns(
             item={item}
             value={val}
             relevantStatHashes={relevantStatHashes}
+            extraStatInfo={extraStatInfo}
           />
         );
       },

--- a/src/app/organizer/ItemTable.m.scss
+++ b/src/app/organizer/ItemTable.m.scss
@@ -12,129 +12,134 @@ $content-cells: 5;
   --item-table-toolbar-height: 0;
 }
 
-.table {
-  display: grid;
-  margin: 8px 0 16px 0;
+// Put these on their own layer so they can be overridden easily
+@layer itemtable {
+  .table {
+    display: grid;
+    margin: 8px 0 16px 0;
 
-  [role='cell'] {
-    z-index: $content-cells;
-  }
-}
-
-.toolbar {
-  grid-column: 1 / -1;
-  z-index: $toolbar;
-  box-sizing: border-box;
-
-  top: var(--header-height);
-  padding: 8px 8px !important;
-  border-bottom: none !important;
-  background-color: var(--theme-organizer-row-odd-bg);
-
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  position: sticky;
-  left: env(safe-area-inset-left);
-  // Reserve space for always-on scrollbars :-(
-  width: calc(
-    100vw - var(--scrollbar-width) - env(safe-area-inset-left) - env(safe-area-inset-right)
-  );
-  gap: 4px;
-}
-
-.importButton {
-  @media (max-width: 1000px) {
-    display: none;
-  }
-}
-
-// Column headers
-.header {
-  vertical-align: bottom;
-  text-align: left;
-  border-bottom: 1px solid #ddd !important;
-  background: #313233;
-  padding: 4px 8px;
-  white-space: nowrap;
-  padding-top: 4px !important;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end !important;
-
-  img {
-    height: 16px;
-    width: 16px;
-    vertical-align: bottom;
-  }
-}
-
-.sorter {
-  margin-left: 2px;
-}
-
-.selection {
-  background-color: var(--org-row-bg);
-  padding-left: 8px !important;
-  padding-right: 2px !important;
-  min-width: 20px;
-  left: env(safe-area-inset-left);
-  position: sticky;
-  top: calc(var(--header-height) + var(--table-header-height) + var(--item-table-toolbar-height));
-  z-index: $header-cells !important;
-  &.header {
-    top: calc(var(--header-height) + var(--item-table-toolbar-height));
-  }
-}
-
-// Indicate cells that can be filtered on shift-click
-.shiftHeld {
-  .hasFilter {
-    @include interactive($hover: true) {
-      background-color: var(--theme-accent-primary) !important;
-      cursor: pointer;
+    // Lower specificity to allow overrides
+    :where([role='cell']) {
+      display: flex;
+      flex-direction: row;
+      z-index: $content-cells;
     }
   }
-}
 
-.noItems {
-  text-align: center;
-  grid-column: 1 / -1;
-  padding: 2em !important;
-}
+  .toolbar {
+    grid-column: 1 / -1;
+    z-index: $toolbar;
+    box-sizing: border-box;
 
-.row {
-  --org-row-bg: var(--theme-organizer-row-odd-bg);
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
-  background-color: var(--org-row-bg);
+    top: var(--header-height);
+    padding: 8px;
+    background-color: var(--theme-organizer-row-odd-bg);
 
-  > div {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    position: sticky;
+    left: env(safe-area-inset-left);
+    // Reserve space for always-on scrollbars :-(
+    width: calc(
+      100vw - var(--scrollbar-width) - env(safe-area-inset-left) - env(safe-area-inset-right)
+    );
+    gap: 4px;
+  }
+
+  .importButton {
+    @media (max-width: 1000px) {
+      display: none;
+    }
+  }
+
+  // Column headers
+  .header {
+    vertical-align: bottom;
+    text-align: left;
+    border-bottom: 1px solid #ddd !important;
+    background: #313233;
+    padding: 4px 8px;
+    white-space: nowrap;
+    padding-top: 4px !important;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end !important;
+
+    img {
+      height: 16px;
+      width: 16px;
+      vertical-align: bottom;
+    }
+  }
+
+  .sorter {
+    margin-left: 2px;
+  }
+
+  .selection {
+    background-color: var(--org-row-bg);
+    padding-left: 8px !important;
+    padding-right: 2px !important;
+    min-width: 20px;
+    left: env(safe-area-inset-left);
+    position: sticky;
+    top: calc(var(--header-height) + var(--table-header-height) + var(--item-table-toolbar-height));
+    z-index: $header-cells;
+    &.header {
+      top: calc(var(--header-height) + var(--item-table-toolbar-height));
+    }
+  }
+
+  // Indicate cells that can be filtered on shift-click
+  .shiftHeld {
+    .hasFilter {
+      @include interactive($hover: true) {
+        background-color: var(--theme-accent-primary) !important;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .noItems {
+    text-align: center;
+    grid-column: 1 / -1;
+    padding: 2em !important;
+  }
+
+  .row {
+    --org-row-bg: var(--theme-organizer-row-odd-bg);
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    background-color: var(--org-row-bg);
+
+    &:nth-of-type(2n) {
+      --org-row-bg: var(--theme-organizer-row-even-bg);
+    }
+
+    &:hover {
+      background-color: rgb(255, 255, 255, 0.1);
+    }
+  }
+  :where(.row > div) {
     padding: 4px 8px;
     padding-top: calc(var(--item-size) * 0.75 * 0.5 - 4px);
   }
-  &:nth-of-type(2n) {
-    --org-row-bg: var(--theme-organizer-row-even-bg);
-  }
 
-  &:hover {
-    background-color: rgb(255, 255, 255, 0.1);
-  }
-}
+  .headerRow {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    background: #313233;
+    position: sticky;
+    z-index: $header-cells + 1;
 
-.headerRow {
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
-  background: #313233;
-  position: sticky;
-  z-index: $header-cells + 1;
+    top: calc(var(--header-height) + var(--item-table-toolbar-height));
 
-  top: calc(var(--header-height) + var(--item-table-toolbar-height));
-
-  > * {
-    background-color: var(--theme-organizer-row-odd-bg);
+    > * {
+      background-color: var(--theme-organizer-row-odd-bg);
+    }
   }
 }


### PR DESCRIPTION
The Organizer already has dedicated columns for things like which is the tuning stat, and it's apparently distracting to have the icons. I wasn't sure if they should also be removed from custom stats, but it's easily changeable now.