### PR TITLE
Fix ItemPowerSet images, un-nest GearPower styles

### DIFF
--- a/src/app/gear-power/GearPower.m.scss
+++ b/src/app/gear-power/GearPower.m.scss
@@ -1,179 +1,186 @@
 @use '../variables.scss' as *;
+
+.sheetContents {
+  composes: flexColumn from '../dim-ui/common.m.scss';
+  align-items: center;
+}
+
 .gearPowerSheet {
   width: 100%;
-  max-width: fit-content;
+  max-width: 360px;
   margin: 0 auto;
 
   @include phone-portrait {
     max-width: unset;
   }
+}
 
-  .gearPowerSheetContent {
-    margin: 0 20px 20px;
-    width: min-content;
-    white-space: pre-wrap;
-  }
+.gearPowerSheetContent {
+  margin: 0 20px 20px;
+  white-space: pre-wrap;
+}
 
-  .gearPowerHeader {
-    display: flex;
+.gearPowerHeader {
+  display: flex;
+  margin-right: 10px;
+  align-items: center;
+
+  > img {
     margin-right: 10px;
-    align-items: center;
-
-    > img {
-      margin-right: 10px;
-      height: 48px;
-      width: 48px;
-    }
-
-    h1:first-child {
-      margin-bottom: 4px;
-    }
-    h1:last-child {
-      margin-bottom: 0;
-    }
+    height: 48px;
+    width: 48px;
   }
 
-  .powerLevel {
-    color: $power;
-    font-size: 1.4em;
-    :global(.app-icon) {
-      font-size: 60%;
-      vertical-align: 45%;
-      margin-right: 2px;
-    }
-    img {
-      height: 1.2em;
-      width: auto;
-      margin: 0;
-      vertical-align: text-bottom;
-      filter: none !important;
-      display: inline-block;
-    }
+  h1:first-child {
+    margin-bottom: 4px;
   }
-  :global(.selected) {
-    .powerLevel {
-      color: black;
-    }
+  h1:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.powerLevel {
+  color: $power;
+  font-size: 1.4em;
+  :global(.app-icon) {
+    font-size: 60%;
+    vertical-align: 45%;
+    margin-right: 2px;
+  }
+  img {
+    height: 1.2em;
+    width: auto;
+    margin: 0;
+    vertical-align: text-bottom;
+    filter: none !important;
+    display: inline-block;
+  }
+  :global(.selected) & {
+    color: black;
+  }
+}
+
+.toggle {
+  padding: 10px 10px 15px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.powerToggleButton {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.gearGrid {
+  width: max-content;
+  margin: 10px auto;
+  display: grid;
+  gap: 4px 10px;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(10, 1fr);
+}
+
+.kinetic,
+.energy,
+.power {
+  grid-column-start: 1;
+}
+
+.helmet,
+.gauntlets,
+.chest,
+.leg,
+.classItem {
+  grid-column-start: 2;
+
+  &.gearItem,
+  .gearItemInfo > div {
+    flex-direction: row-reverse;
+  }
+}
+
+.kinetic {
+  grid-row-start: 3;
+}
+.energy {
+  grid-row-start: 5;
+}
+.power {
+  grid-row-start: 7;
+}
+.helmet {
+  grid-row-start: 1;
+}
+.gauntlets {
+  grid-row-start: 3;
+}
+.chest {
+  grid-row-start: 5;
+}
+.leg {
+  grid-row-start: 7;
+}
+.classItem {
+  grid-row-start: 9;
+}
+
+.gearItem {
+  grid-row-end: span 2;
+  display: flex;
+}
+
+.itemImage {
+  height: 40px;
+  width: 40px;
+  margin: 0 5px;
+  border: 1px solid #ddd;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.gearItemInfo {
+  display: flex;
+  flex-direction: column;
+
+  .power {
+    font-size: 16px;
+    line-height: 1;
+  }
+  .statMeta {
+    font-size: 24px;
+    line-height: 26px;
   }
 
-  .toggle {
-    margin: 10px 10px 15px;
-  }
-
-  .powerToggleButton {
+  /* stylelint-disable-next-line no-descending-specificity */
+  & > div {
     display: flex;
-    flex-direction: column;
-    align-items: center;
   }
+}
 
-  .gearGrid {
-    width: max-content;
-    margin: 10px auto;
-    display: grid;
-    gap: 4px 10px;
-    grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(10, 1fr);
+.bucketImage {
+  height: 22px;
+  width: 22px;
+  margin-top: 2px;
+  opacity: 0.6;
+}
+.neutral {
+  opacity: 0.6;
+}
+.positive {
+  color: $green;
+}
+.negative {
+  color: $red;
+}
+.neutral,
+.positive,
+.negative {
+  margin: 0 3px;
+}
 
-    .kinetic,
-    .energy,
-    .power {
-      grid-column-start: 1;
-    }
-
-    .helmet,
-    .gauntlets,
-    .chest,
-    .leg,
-    .classItem {
-      grid-column-start: 2;
-
-      &.gearItem,
-      .gearItemInfo > div {
-        flex-direction: row-reverse;
-      }
-    }
-
-    .kinetic {
-      grid-row-start: 3;
-    }
-    .energy {
-      grid-row-start: 5;
-    }
-    .power {
-      grid-row-start: 7;
-    }
-    .helmet {
-      grid-row-start: 1;
-    }
-    .gauntlets {
-      grid-row-start: 3;
-    }
-    .chest {
-      grid-row-start: 5;
-    }
-    .leg {
-      grid-row-start: 7;
-    }
-    .classItem {
-      grid-row-start: 9;
-    }
-
-    .gearItem {
-      grid-row-end: span 2;
-      display: flex;
-
-      .itemImage {
-        height: 40px;
-        width: 40px;
-        margin: 0 5px;
-        border: 1px solid #ddd;
-        cursor: pointer;
-        pointer-events: auto;
-      }
-      .gearItemInfo {
-        display: flex;
-        flex-direction: column;
-
-        .power {
-          font-size: 16px;
-          line-height: 1;
-        }
-        .statMeta {
-          font-size: 24px;
-          line-height: 26px;
-        }
-
-        & > div {
-          display: flex;
-        }
-      }
-
-      .bucketImage {
-        height: 22px;
-        width: 22px;
-        margin-top: 2px;
-        opacity: 0.6;
-      }
-      .neutral {
-        opacity: 0.6;
-      }
-      .positive {
-        color: $green;
-      }
-      .negative {
-        color: $red;
-      }
-      .neutral,
-      .positive,
-      .negative {
-        margin: 0 3px;
-      }
-    }
-  }
-
-  .footNote {
-    margin: 10px auto 0;
-    color: #999;
-    max-width: 400px;
-  }
+.footNote {
+  margin: 10px auto 0;
+  color: #999;
+  max-width: 400px;
 }

--- a/src/app/gear-power/GearPower.m.scss.d.ts
+++ b/src/app/gear-power/GearPower.m.scss.d.ts
@@ -23,6 +23,7 @@ interface CssExports {
   'power': string;
   'powerLevel': string;
   'powerToggleButton': string;
+  'sheetContents': string;
   'statMeta': string;
   'toggle': string;
 }

--- a/src/app/gear-power/GearPower.tsx
+++ b/src/app/gear-power/GearPower.tsx
@@ -61,77 +61,79 @@ export default function GearPower() {
     whichGear === 'drop' ? powerLevel.dropCalcItems : powerLevel.maxEquippablePowerItems;
   return (
     <Sheet onClose={reset} header={header} sheetClassName={styles.gearPowerSheet}>
-      <RadioButtons
-        className={styles.toggle}
-        value={whichGear}
-        onChange={setWhichGear}
-        options={[
-          {
-            label: (
-              <div className={styles.powerToggleButton}>
-                <span>{t('Stats.EquippableGear')}</span>
-                <span className={styles.powerLevel}>
-                  <AppIcon icon={powerActionIcon} />
-                  <FractionalPowerLevel power={powerLevel.maxEquippableGearPower} />
-                </span>
-              </div>
-            ),
-            tooltip: t('Stats.MaxGearPowerOneExoticRule'),
-            value: 'equip',
-          },
-          {
-            label: (
-              <div className={styles.powerToggleButton}>
-                <span>{t('Stats.DropLevel')}</span>
-                <span className={styles.powerLevel}>
-                  <BungieImage src={rarityIcons.Legendary} />
-                  <FractionalPowerLevel power={powerLevel.dropPower} />
-                </span>
-              </div>
-            ),
-            tooltip: t('Stats.DropLevelExplanation1'),
-            value: 'drop',
-          },
-        ]}
-      />
-      <div className={styles.gearPowerSheetContent}>
-        <div className={styles.gearGrid}>
-          {items.map((i) => {
-            const powerDiff = (powerFloor - i.power) * -1;
-            const diffSymbol = powerDiff >= 0 ? '+' : '';
-            const diffClass =
-              powerDiff > 0 ? styles.positive : powerDiff < 0 ? styles.negative : styles.neutral;
-            return (
-              <div
-                key={i.id}
-                className={clsx(bucketClassNames[i.bucket.hash as BucketHashes], styles.gearItem)}
-              >
-                <div onClick={() => locateItem(i)}>
-                  <BungieImage src={i.icon} className={styles.itemImage} />
+      <div className={styles.sheetContents}>
+        <RadioButtons
+          className={styles.toggle}
+          value={whichGear}
+          onChange={setWhichGear}
+          options={[
+            {
+              label: (
+                <div className={styles.powerToggleButton}>
+                  <span>{t('Stats.EquippableGear')}</span>
+                  <span className={styles.powerLevel}>
+                    <AppIcon icon={powerActionIcon} />
+                    <FractionalPowerLevel power={powerLevel.maxEquippableGearPower} />
+                  </span>
                 </div>
-                <div className={styles.gearItemInfo}>
-                  <div className={styles.power}>{i.power}</div>
-                  <div className={styles.statMeta}>
-                    <BucketIcon className={styles.bucketImage} bucketHash={i.bucket.hash} />
-                    <div className={diffClass}>
-                      {diffSymbol}
-                      {powerDiff}
+              ),
+              tooltip: t('Stats.MaxGearPowerOneExoticRule'),
+              value: 'equip',
+            },
+            {
+              label: (
+                <div className={styles.powerToggleButton}>
+                  <span>{t('Stats.DropLevel')}</span>
+                  <span className={styles.powerLevel}>
+                    <BungieImage src={rarityIcons.Legendary} />
+                    <FractionalPowerLevel power={powerLevel.dropPower} />
+                  </span>
+                </div>
+              ),
+              tooltip: t('Stats.DropLevelExplanation1'),
+              value: 'drop',
+            },
+          ]}
+        />
+        <div className={styles.gearPowerSheetContent}>
+          <div className={styles.gearGrid}>
+            {items.map((i) => {
+              const powerDiff = (powerFloor - i.power) * -1;
+              const diffSymbol = powerDiff >= 0 ? '+' : '';
+              const diffClass =
+                powerDiff > 0 ? styles.positive : powerDiff < 0 ? styles.negative : styles.neutral;
+              return (
+                <div
+                  key={i.id}
+                  className={clsx(bucketClassNames[i.bucket.hash as BucketHashes], styles.gearItem)}
+                >
+                  <div onClick={() => locateItem(i)}>
+                    <BungieImage src={i.icon} className={styles.itemImage} />
+                  </div>
+                  <div className={styles.gearItemInfo}>
+                    <div className={styles.power}>{i.power}</div>
+                    <div className={styles.statMeta}>
+                      <BucketIcon className={styles.bucketImage} bucketHash={i.bucket.hash} />
+                      <div className={diffClass}>
+                        {diffSymbol}
+                        {powerDiff}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            );
-          })}
-        </div>
-        <div className={styles.footNote}>
-          {whichGear === 'equip' ? (
-            t('Stats.MaxGearPowerOneExoticRule')
-          ) : (
-            <>
-              <p>{t('Stats.DropLevelExplanation1')}</p>
-              <p>{t('Stats.DropLevelExplanation2')}</p>
-            </>
-          )}
+              );
+            })}
+          </div>
+          <div className={styles.footNote}>
+            {whichGear === 'equip' ? (
+              t('Stats.MaxGearPowerOneExoticRule')
+            ) : (
+              <>
+                <p>{t('Stats.DropLevelExplanation1')}</p>
+                <p>{t('Stats.DropLevelExplanation2')}</p>
+              </>
+            )}
+          </div>
         </div>
       </div>
     </Sheet>

--- a/src/app/inventory/ItemPowerSet.m.scss
+++ b/src/app/inventory/ItemPowerSet.m.scss
@@ -8,7 +8,8 @@
   gap: 1px 6px;
   align-items: center;
 
-  img {
+  img,
+  svg {
     height: 20px;
     width: 20px;
   }


### PR DESCRIPTION
Changelog: Fixed icons displaying too large on the gear power tooltip.

Before/after:

<img width="367" height="302" alt="Screenshot 2025-09-14 at 12 55 31 PM" src="https://github.com/user-attachments/assets/d9ccffa9-f7dd-42d5-96ed-34d6182402a6" />
<img width="340" height="329" alt="Screenshot 2025-09-14 at 12 55 35 PM" src="https://github.com/user-attachments/assets/33a0dd40-c899-4926-95aa-92448c0628f7" />
<img width="338" height="525" alt="Screenshot 2025-09-14 at 12 55 45 PM" src="https://github.com/user-attachments/assets/b31aa81c-88be-49b4-9d6a-0a76b32fcdb1" />
<img width="379" height="480" alt="Screenshot 2025-09-14 at 12 55 40 PM" src="https://github.com/user-attachments/assets/4f201ed7-28d3-4e7e-a7cf-a5993e3f0704" />
<img width="207" height="291" alt="Screenshot 2025-09-14 at 12 55 50 PM" src="https://github.com/user-attachments/assets/8045b666-ac26-41af-9018-75a225fb2755" />
<img width="208" height="252" alt="Screenshot 2025-09-14 at 12 55 56 PM" src="https://github.com/user-attachments/assets/4a2ad0e2-51c1-46c0-8689-f2e59d95b3d5" />
