### PR TITLE
Consolidate enhanced/unenhanced plug hash handling

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -38,7 +38,9 @@
     }
   ],
   "allowCompoundWords": true,
-  "flagWords": ["langauge"],
+  "flagWords": [
+    "langauge"
+  ],
   "ignorePaths": [
     ".vscode/extensions.json",
     ".github/workflows/**",
@@ -75,5 +77,8 @@
     ".gitignore",
     "webpack-stats.json",
     ".stylelintrc"
+  ],
+  "words": [
+    "unenhanced"
   ]
 }

--- a/src/app/armory/AllWishlistRolls.tsx
+++ b/src/app/armory/AllWishlistRolls.tsx
@@ -7,17 +7,14 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { faExclamationTriangle } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
 import { compareBy } from 'app/utils/comparators';
+import { isEnhancedPerkHash } from 'app/utils/perk-utils';
 import { wishListInfosSelector, wishListRollsForItemHashSelector } from 'app/wishlists/selectors';
 import { WishListRoll } from 'app/wishlists/types';
 import { partition } from 'es-toolkit';
 import { useSelector } from 'react-redux';
 import styles from './AllWishlistRolls.m.scss';
 import { getCraftingTemplate } from './crafting-utils';
-import {
-  consolidateRollsForOneWeapon,
-  consolidateSecondaryPerks,
-  enhancedToPerk,
-} from './wishlist-collapser';
+import { consolidateRollsForOneWeapon, consolidateSecondaryPerks } from './wishlist-collapser';
 
 /**
  * List out all the known wishlist rolls for a given item.
@@ -159,7 +156,7 @@ function WishlistRolls({
                 const primaryBundles = cr.rolls[0].primarySocketIndices.map((socketIndex) =>
                   primariesGroupedByColumn[socketIndex ?? -1].sort(
                     // establish a consistent base -> enhanced perk order
-                    compareBy((h) => (h in enhancedToPerk ? 1 : 0)),
+                    compareBy((h) => Number(isEnhancedPerkHash(h))),
                   ),
                 );
 

--- a/src/app/armory/wishlist-collapser.ts
+++ b/src/app/armory/wishlist-collapser.ts
@@ -1,14 +1,11 @@
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem } from 'app/inventory/item-types';
-import { invert } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
+import { enhancedVersion, unenhancedVersion } from 'app/utils/perk-utils';
 import { WishListRoll } from 'app/wishlists/types';
 import { DestinyInventoryItemDefinition, TierType } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes } from 'data/d2/generated-enums';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { partition } from 'es-toolkit';
-
-export const enhancedToPerk = invert(perkToEnhanced, Number);
 
 interface Roll {
   /** rampage, outlaw, etc. */
@@ -156,7 +153,7 @@ export function consolidateRollsForOneWeapon(
   // roll doesn't specify them
   for (const roll of Object.values(rollsGroupedByPrimaryPerks)) {
     for (const perk of roll.commonPrimaryPerks) {
-      const enhancedPerk = perkToEnhanced[perk];
+      const enhancedPerk = enhancedVersion(perk);
       if (enhancedPerk && !roll.commonPrimaryPerks.includes(enhancedPerk)) {
         const socketIndex = socketIndexByPerkHash[perk];
         if (
@@ -260,17 +257,17 @@ interface PerkMeta {
 export type PerkColumnsMeta = PerkMeta[][];
 
 function getBaseEnhancedPerkPair(perkHash: number) {
-  let base = enhancedToPerk[perkHash];
-  let enhanced = perkToEnhanced[perkHash];
+  let base = unenhancedVersion(perkHash);
+  let enhanced = enhancedVersion(perkHash);
   if (!base && !enhanced) {
     return;
   }
 
   if (!enhanced) {
-    enhanced = perkToEnhanced[base]!;
+    enhanced = enhancedVersion(base!)!;
   }
   if (!base) {
-    base = enhancedToPerk[enhanced];
+    base = unenhancedVersion(enhanced)!;
   }
 
   return { base, enhanced };

--- a/src/app/inventory/store/override-sockets.ts
+++ b/src/app/inventory/store/override-sockets.ts
@@ -2,7 +2,7 @@ import { UNSET_PLUG_HASH } from 'app/loadout/known-values';
 import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { isEmpty } from 'app/utils/collections';
 import { errorLog } from 'app/utils/log';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
+import { enhancedVersion } from 'app/utils/perk-utils';
 import { produce } from 'immer';
 import { useCallback, useState } from 'react';
 import { DimItem, DimPlug, DimSocket } from '../item-types';
@@ -49,7 +49,7 @@ export function applySocketOverrides(
       if (s.isPerk) {
         newPlug =
           plugOptions.find((p) => p.plugDef.hash === override) ??
-          plugOptions.find((p) => perkToEnhanced[p.plugDef.hash] === override);
+          plugOptions.find((p) => enhancedVersion(p.plugDef.hash) === override);
         actuallyPlugged = plugOptions.find((p) => p.plugDef.hash === s.plugged?.plugDef.hash);
       } else {
         // This is likely a mod selection!

--- a/src/app/inventory/store/sockets.ts
+++ b/src/app/inventory/store/sockets.ts
@@ -4,9 +4,10 @@ import {
   GhostActivitySocketTypeHashes,
   weaponMasterworkY2SocketTypeHash,
 } from 'app/search/d2-known-values';
-import { filterMap, invert } from 'app/utils/collections';
+import { filterMap } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
+import { unenhancedVersion } from 'app/utils/perk-utils';
 import {
   eventArmorRerollSocketIdentifiers,
   isEnhancedPerk,
@@ -34,7 +35,6 @@ import {
   PlugCategoryHashes,
   SocketCategoryHashes,
 } from 'data/d2/generated-enums';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { partition } from 'es-toolkit';
 import {
   DimItem,
@@ -53,8 +53,6 @@ import { exoticClassItemPlugs } from './exotic-class-item';
 //
 // This is called from within d2-item-factory.service.ts
 //
-
-const enhancedToPerk = invert(perkToEnhanced, Number);
 
 /**
  * Calculate all the sockets we want to display (or make searchable). Sockets represent perks,
@@ -502,7 +500,7 @@ function buildPlug(
     : '';
 
   const enabled = destinyItemPlug ? plug.enabled : plug.isEnabled;
-  const unenhancedVersion = enhancedToPerk[plugDef.hash];
+  const unenhanced = unenhancedVersion(plugDef.hash);
   return {
     plugDef,
     enabled: enabled && (!destinyItemPlug || plug.canInsert),
@@ -511,7 +509,7 @@ function buildPlug(
     stats: null,
     cannotCurrentlyRoll:
       plugSet?.plugHashesThatCannotRoll.includes(plugDef.hash) &&
-      !plugSet?.plugHashesThatCanRoll.includes(unenhancedVersion),
+      (!unenhanced || !plugSet?.plugHashesThatCanRoll.includes(unenhanced)),
   };
 }
 

--- a/src/app/search/items/search-filters/perks-set.ts
+++ b/src/app/search/items/search-filters/perks-set.ts
@@ -1,5 +1,5 @@
 import { DimItem } from 'app/inventory/item-types';
-import { normalizeEnhancedness } from 'app/utils/perk-utils';
+import { normalizeToEnhanced } from 'app/utils/perk-utils';
 import { getSocketsByType } from 'app/utils/socket-utils';
 
 type PerkType = Parameters<typeof getSocketsByType>[1];
@@ -50,6 +50,6 @@ export class PerksSet {
 
 function makePerksSet(item: DimItem, perkType?: PerkType) {
   return getSocketsByType(item, perkType).map(
-    (s) => new Set(s.plugOptions.map((p) => normalizeEnhancedness(p.plugDef.hash))),
+    (s) => new Set(s.plugOptions.map((p) => normalizeToEnhanced(p.plugDef.hash))),
   );
 }

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -12,6 +12,7 @@ import {
   getSpecialtySocketMetadatas,
   modSlotTags,
 } from 'app/utils/item-utils';
+import { enhancedVersion } from 'app/utils/perk-utils';
 import {
   countEnhancedPerks,
   getIntrinsicArmorPerkSocket,
@@ -26,7 +27,6 @@ import {
   PlugCategoryHashes,
   SocketCategoryHashes,
 } from 'data/d2/generated-enums';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { ItemFilterDefinition } from '../item-filter-types';
 import { patternIsUnlocked } from './known-values';
 
@@ -322,7 +322,7 @@ const socketFilters: ItemFilterDefinition[] = [
       }
       if (item.crafted === 'crafted') {
         return item.sockets?.allSockets.some((s) => {
-          const enhancedPerk = perkToEnhanced[s.plugged?.plugDef.hash || 0] || 0;
+          const enhancedPerk = enhancedVersion(s.plugged?.plugDef.hash || 0) || 0;
           return (
             enhancedPerk &&
             s.plugSet?.plugHashesThatCanRoll.includes(enhancedPerk) &&

--- a/src/app/utils/perk-utils.ts
+++ b/src/app/utils/perk-utils.ts
@@ -1,6 +1,30 @@
 import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
+import { invert } from './collections';
+
+// map an enhanced perk hash to the unenhanced version.
+const enhancedToPerk = invert(perkToEnhanced, Number);
 
 /** Convert a perk hash to its enhanced version, if possible, else returns it unchanged (maybe it was already enhanced?) */
-export function normalizeEnhancedness(perkHash: number) {
+export function normalizeToEnhanced(perkHash: number) {
   return perkToEnhanced[perkHash] ?? perkHash;
+}
+
+/** Convert a perk hash to its un-enhanced version(s), if possible, else returns it unchanged (maybe it wasn't enhanced?) */
+export function normalizeToUnenhanced(perkHash: number) {
+  return enhancedToPerk[perkHash] ?? perkHash;
+}
+
+/** Return the hash of the enhanced version of this perk, assuming it is an un-enhanced perk. */
+export function enhancedVersion(perkHash: number): number | undefined {
+  return perkToEnhanced[perkHash];
+}
+
+/** Return the hash of the unenhanced version of this perk, assuming it is an enhanced perk. */
+export function unenhancedVersion(perkHash: number): number | undefined {
+  return enhancedToPerk[perkHash];
+}
+
+/** Is this hash one of our known enhanced versions of a regular perk? */
+export function isEnhancedPerkHash(perkHash: number) {
+  return perkHash in enhancedToPerk;
 }

--- a/src/app/utils/plug-descriptions.ts
+++ b/src/app/utils/plug-descriptions.ts
@@ -13,11 +13,10 @@ import { activityModPlugCategoryHashes } from 'app/loadout/known-values';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DestinyClass, ItemPerkVisibility } from 'bungie-api-ts/destiny2';
 import { ItemCategoryHashes, StatHashes, TraitHashes } from 'data/d2/generated-enums';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { useSelector } from 'react-redux';
 import modsWithoutDescription from '../../data/d2/mods-with-bad-descriptions.json';
-import { invert } from './collections';
 import { compareBy } from './comparators';
+import { unenhancedVersion } from './perk-utils';
 import { isArmorArchetypePlug } from './socket-utils';
 import { LookupTable } from './util-types';
 
@@ -40,8 +39,6 @@ const statNameAliases: LookupTable<StatHashes, string[]> = {
   [StatHashes.AmmoCapacity]: ['Magazine Stat'],
   [StatHashes.ReloadSpeed]: ['Reload'],
 };
-
-const enhancedPerkToRegularPerk = invert(perkToEnhanced, Number);
 
 export function usePlugDescriptions(
   plug?: PluggableInventoryItemDefinition,
@@ -103,7 +100,7 @@ export function usePlugDescriptions(
 
     // if we couldn't find a Clarity description for this perk, fall back to the non-enhanced perk variant
     if (!clarityPerk) {
-      const regularPerkHash = enhancedPerkToRegularPerk[plug.hash];
+      const regularPerkHash = unenhancedVersion(plug.hash);
       if (regularPerkHash) {
         clarityPerk = allClarityDescriptions[regularPerkHash];
       }

--- a/src/app/wishlists/wishlists.ts
+++ b/src/app/wishlists/wishlists.ts
@@ -1,6 +1,5 @@
-import { enhancedToPerk } from 'app/armory/wishlist-collapser';
+import { normalizeToUnenhanced } from 'app/utils/perk-utils';
 import { BucketHashes, ItemCategoryHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
-import perkToEnhanced from 'data/d2/trait-to-enhanced-trait.json';
 import { DimItem, DimPlug } from '../inventory/item-types';
 import { DimWishList, WishListRoll } from './types';
 
@@ -102,12 +101,7 @@ export function isWishListPlug(
     ('recommendedPerks' in wishListRoll
       ? wishListRoll.recommendedPerks
       : wishListRoll.wishListPerks);
-  return Boolean(
-    perks &&
-      (perks.has(plug.plugDef.hash) || // if this perk was recommended
-        // or this enhanced perk's base version was recommended
-        perks.has(enhancedToPerk[plug.plugDef.hash])),
-  );
+  return Boolean(perks?.has(normalizeToUnenhanced(plug.plugDef.hash)));
 }
 
 /** Get all of the plugs for this item that match the wish list roll. */
@@ -144,10 +138,7 @@ function allDesiredPerksExist(item: DimItem, wishListRoll: WishListRoll): boolea
       outer: for (const s of item.sockets!.allSockets) {
         if (s.plugOptions) {
           for (const plug of s.plugOptions) {
-            if (
-              plug.plugDef.hash === recommendedPerk ||
-              perkToEnhanced[recommendedPerk] === plug.plugDef.hash
-            ) {
+            if (normalizeToUnenhanced(plug.plugDef.hash) === recommendedPerk) {
               included = true;
               break outer;
             }


### PR DESCRIPTION
Changelog: Fixed some cases where the enhanced version of perks would not match wishlists that specified the unenhanced version.

This PR is actually mostly just code cleanup and avoiding having a bunch of different inverted copies of the trait to enhanced trait mapping.