### PR TITLE
Added check for untaggable items in `tag:none`

### DIFF
--- a/src/app/search/items/search-filters/item-infos.ts
+++ b/src/app/search/items/search-filters/item-infos.ts
@@ -20,7 +20,7 @@ const itemInfosFilters: ItemFilterDefinition[] = [
     filter:
       ({ filterValue, getTag }) =>
       (item) =>
-        (getTag(item) || (item.taggable ? 'none' : undefined)) === filterValue,
+       item.taggable && (getTag(item) || 'none') === filterValue,
   },
   {
     keywords: 'hasnotes',

--- a/src/app/search/items/search-filters/item-infos.ts
+++ b/src/app/search/items/search-filters/item-infos.ts
@@ -20,7 +20,7 @@ const itemInfosFilters: ItemFilterDefinition[] = [
     filter:
       ({ filterValue, getTag }) =>
       (item) =>
-       item.taggable && (getTag(item) || 'none') === filterValue,
+        item.taggable && (getTag(item) || 'none') === filterValue,
   },
   {
     keywords: 'hasnotes',

--- a/src/app/search/items/search-filters/item-infos.ts
+++ b/src/app/search/items/search-filters/item-infos.ts
@@ -20,7 +20,7 @@ const itemInfosFilters: ItemFilterDefinition[] = [
     filter:
       ({ filterValue, getTag }) =>
       (item) =>
-        (getTag(item) || 'none') === filterValue,
+        (getTag(item) || (item.taggable ? 'none' : undefined)) === filterValue,
   },
   {
     keywords: 'hasnotes',


### PR DESCRIPTION
Changelog: `tag:none` no longer selects untaggable objects like materials and abilities

resolves #11496 