### PR TITLE
Remove energy capacity from polaroid

### DIFF
--- a/src/app/inventory/BadgeInfo.m.scss
+++ b/src/app/inventory/BadgeInfo.m.scss
@@ -69,12 +69,6 @@
   padding: 0 1px;
 }
 
-.energyCapacity {
-  font-weight: bold;
-  font-size: calc(#{dim-item-px(9)}); // 9px at default 50px item size
-  margin-right: auto;
-}
-
 /* some elements icons (arc / void / strand) don't show up well on polaroid white. we darken these. */
 .fixContrast {
   filter: brightness(var(--theme-item-polaroid-element-adjust-brightness)) saturate(2.5);

--- a/src/app/inventory/BadgeInfo.m.scss.d.ts
+++ b/src/app/inventory/BadgeInfo.m.scss.d.ts
@@ -5,7 +5,6 @@ interface CssExports {
   'badgeContent': string;
   'capped': string;
   'deepsight': string;
-  'energyCapacity': string;
   'engram': string;
   'fixContrast': string;
   'fullstack': string;

--- a/src/app/inventory/BadgeInfo.tsx
+++ b/src/app/inventory/BadgeInfo.tsx
@@ -94,18 +94,14 @@ export default function BadgeInfo({ item, isCapped, wishlistRoll }: Props) {
         </div>
       )}
       {summaryIcon}
-      {item.energy ? (
-        <span className={styles.energyCapacity}>{item.energy.energyCapacity}</span>
-      ) : (
-        item.element &&
+      {item.element &&
         !(item.bucket.inWeapons && item.element.enumValue === DamageType.Kinetic) && (
           <ElementIcon
             element={item.element}
             className={clsx({ [styles.fixContrast]: fixContrast })}
             d1Badge={item.destinyVersion === 1}
           />
-        )
-      )}
+        )}
       <span className={styles.badgeContent}>{badgeContent}</span>
     </div>
   );


### PR DESCRIPTION
Changelog: Remove armor energy capacity from the item tile. It's just not that interesting these days.