### PR TITLE
Update Item header with new icons

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -120,10 +120,8 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
       ? itemConstants.masterworkExoticOverlayPath
       : itemConstants.masterworkOverlayPath);
 
-  //  Backdrop for season/featured icon is also shown at much lower opacity in game than the images Bungie
-  // gave us. These are aligned with the border, not the image.
-  const halfOpacitySeasonOverlay =
-    item.iconDef?.secondaryBackground && itemConstants.watermarkDropShadowPath;
+  // These are aligned with the border, not the image.
+  const seasonBanner = item.iconDef?.secondaryBackground && itemConstants.watermarkDropShadowPath;
 
   const craftedOverlays = compact([
     // The crafted/enhanced icon
@@ -136,7 +134,7 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
     item.crafted ? itemConstants.craftedBackgroundPath : undefined,
   ]);
   // These are aligned with the border, not the image
-  const fullOpacitySeasonOverlays = compact([
+  const seasonAndPips = compact([
     // Featured flags
     item.featured ? itemConstants.featuredItemFlagPath : undefined,
     // Tier pips
@@ -163,20 +161,14 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
             <div style={bungieBackgroundStyle(masterworkGlow)} className={styles.adjustOpacity} />
           )}
           {foreground && <div style={bungieBackgroundStyle(foreground)} />}
-          {halfOpacitySeasonOverlay && (
-            <div
-              style={bungieBackgroundStyle(halfOpacitySeasonOverlay)}
-              className={styles.shiftedLayer}
-            />
+          {seasonBanner && (
+            <div style={bungieBackgroundStyle(seasonBanner)} className={styles.shiftedLayer} />
           )}
           {craftedOverlays.length > 0 && (
             <div style={bungieBackgroundStyles(craftedOverlays)} className={styles.craftedLayer} />
           )}
-          {fullOpacitySeasonOverlays.length > 0 && (
-            <div
-              style={bungieBackgroundStyles(fullOpacitySeasonOverlays)}
-              className={styles.shiftedLayer}
-            />
+          {seasonAndPips.length > 0 && (
+            <div style={bungieBackgroundStyles(seasonAndPips)} className={styles.shiftedLayer} />
           )}
           {seasonIcon && (
             <div style={bungieBackgroundStyle(seasonIcon)} className={styles.seasonIcon} />

--- a/src/app/item-popup/ItemPopupHeader.m.scss
+++ b/src/app/item-popup/ItemPopupHeader.m.scss
@@ -1,7 +1,7 @@
 @use '../variables.scss' as *;
 @use 'sass:math';
 
-$iconOverlayScale: math.div(65, 92);
+$iconOverlayScale: math.div(65, 96);
 
 .header {
   composes: resetButton from 'app/dim-ui/common.m.scss';
@@ -17,7 +17,7 @@ $iconOverlayScale: math.div(65, 92);
   color: #eee;
 
   &:has(.iconOverlay) {
-    padding-left: 5px + 24px * $iconOverlayScale;
+    padding-left: 5px + 28px * $iconOverlayScale;
   }
 }
 
@@ -140,23 +140,16 @@ $iconOverlayScale: math.div(65, 92);
   position: absolute;
   box-sizing: border-box;
   align-items: center;
-  gap: 7%;
   top: 0;
   left: 0;
-  width: 24px * $iconOverlayScale;
-  height: 96px * $iconOverlayScale;
+  width: round(28px * $iconOverlayScale);
+  height: round(96px * $iconOverlayScale);
   background-size: cover;
-  background-position: -2px * $iconOverlayScale -2px * $iconOverlayScale;
   background-repeat: no-repeat;
   pointer-events: none;
-  padding-top: 30px * $iconOverlayScale;
-  font-size: 12px;
-}
+  padding-top: round(3px * $iconOverlayScale);
 
-.tierPip {
-  display: block;
-  height: 4px;
-  aspect-ratio: 1;
-  background: #fffd;
-  rotate: 45deg;
+  > img {
+    width: round(22px * $iconOverlayScale);
+  }
 }

--- a/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
+++ b/src/app/item-popup/ItemPopupHeader.m.scss.d.ts
@@ -15,7 +15,6 @@ interface CssExports {
   'pursuit': string;
   'rare': string;
   'subtitle': string;
-  'tierPip': string;
   'title': string;
   'type': string;
   'uncommon': string;

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -1,10 +1,12 @@
 import ArmorySheet from 'app/armory/ArmorySheet';
-import { bungieBackgroundStyle } from 'app/dim-ui/BungieImage';
+import { itemConstants } from 'app/destiny2/d2-definitions';
+import BungieImage, { bungieBackgroundStyles } from 'app/dim-ui/BungieImage';
 import ElementIcon from 'app/dim-ui/ElementIcon';
 import RichDestinyText from 'app/dim-ui/destiny-symbols/RichDestinyText';
 import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
 import type { ItemRarityName } from 'app/search/d2-known-values';
+import { compact } from 'app/utils/collections';
 import { itemTypeName } from 'app/utils/item-utils';
 import { LookupTable } from 'app/utils/util-types';
 import clsx from 'clsx';
@@ -84,22 +86,33 @@ export default function ItemPopupHeader({
           )}
         </div>
       </div>
-      {item.iconOverlay && (
-        <div className={styles.iconOverlay} style={bungieBackgroundStyle(item.iconOverlay)}>
-          {item.tier !== 0 ? (
-            <>
-              {Array(item.tier)
-                .fill(0)
-                .map((_, i) => (
-                  <div key={i} className={styles.tierPip} />
-                ))}
-            </>
-          ) : null}
-        </div>
-      )}
+      {item.iconDef?.secondaryBackground && <SeasonTierBanner item={item} />}
       {showArmory && linkToArmory && (
         <ArmorySheet onClose={() => setShowArmory(false)} item={item} />
       )}
     </button>
+  );
+}
+
+function SeasonTierBanner({ item }: { item: DimItem }) {
+  if (!item.iconDef || !itemConstants) {
+    return null;
+  }
+  const seasonIcon = item.iconDef.secondaryBackground;
+  const backgrounds = compact([
+    // Featured flags
+    item.featured ? itemConstants.featuredItemFlagPath : undefined,
+    // Tier pips
+    item.tier > 0 && itemConstants.gearTierOverlayImagePaths[item.tier - 1],
+    // Black stripe
+    item.iconDef.secondaryBackground && itemConstants.watermarkDropShadowPath,
+  ]);
+  if (!seasonIcon && backgrounds.length === 0) {
+    return null;
+  }
+  return (
+    <div className={styles.iconOverlay} style={bungieBackgroundStyles(backgrounds)}>
+      {seasonIcon && <BungieImage src={seasonIcon} />}
+    </div>
   );
 }


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Same assets we're using on the icon, just resized:

<img width="423" height="117" alt="Screenshot 2025-09-18 at 11 42 04 PM" src="https://github.com/user-attachments/assets/b5612c7d-d9e3-45c2-8b36-dfa0fa79c7cb" />
