### PR TITLE
Loadout analyzer shouldn't consider generic class stat constraints

### DIFF
--- a/src/app/loadout-analyzer/analysis.test.ts
+++ b/src/app/loadout-analyzer/analysis.test.ts
@@ -92,9 +92,6 @@ beforeAll(async () => {
       customStats: [],
       itemComponents: undefined,
     },
-    savedLoStatConstraintsByClass: {
-      [DestinyClass.Hunter]: armorStats.map((statHash) => ({ statHash })),
-    },
     autoModDefs: getAutoMods(defs, unlockedPlugs),
     unlockedPlugs,
     // No idea how to test this

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -60,7 +60,6 @@ export async function analyzeLoadout(
   {
     allItems,
     autoModDefs,
-    savedLoStatConstraintsByClass,
     itemCreationContext,
     unlockedPlugs,
     validateQuery,
@@ -85,10 +84,8 @@ export async function analyzeLoadout(
   const originalLoadoutMods = resolvedLoadout.resolvedMods;
   const originalModDefs = originalLoadoutMods.map((mod) => mod.resolvedMod);
 
-  const statOrderForClass = savedLoStatConstraintsByClass[classType];
   const loadoutParameters: LoadoutParameters = {
     ...defaultLoadoutParameters,
-    ...(statOrderForClass && { statConstraints: statOrderForClass }),
     ...loadout.parameters,
   };
 

--- a/src/app/loadout-analyzer/hooks.tsx
+++ b/src/app/loadout-analyzer/hooks.tsx
@@ -1,5 +1,4 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { savedLoStatConstraintsByClassSelector } from 'app/dim-api/selectors';
 import {
   allItemsSelector,
   createItemContextSelector,
@@ -44,7 +43,6 @@ const autoOptimizationContextSelector = currySelector(
   createSelector(
     createItemContextSelector,
     unlockedPlugSetItemsSelector.selector,
-    savedLoStatConstraintsByClassSelector,
     autoModSelector,
     allItemsSelector,
     loVendorItemsSelector.selector,
@@ -53,7 +51,6 @@ const autoOptimizationContextSelector = currySelector(
     (
       itemCreationContext,
       unlockedPlugs,
-      savedLoStatConstraintsByClass,
       autoModDefs,
       inventoryItems,
       vendorItems,
@@ -67,7 +64,6 @@ const autoOptimizationContextSelector = currySelector(
         ({
           itemCreationContext,
           unlockedPlugs,
-          savedLoStatConstraintsByClass,
           autoModDefs,
           allItems,
           filterFactory,

--- a/src/app/loadout-analyzer/types.ts
+++ b/src/app/loadout-analyzer/types.ts
@@ -1,4 +1,4 @@
-import { LoadoutParameters, Settings } from '@destinyitemmanager/dim-api-types';
+import { LoadoutParameters } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { AutoModDefs, ResolvedStatConstraint } from 'app/loadout-builder/types';
@@ -82,7 +82,6 @@ export const blockAnalysisFindings: LoadoutFinding[] = [
 export interface LoadoutAnalysisContext {
   unlockedPlugs: Set<number>;
   itemCreationContext: ItemCreationContext;
-  savedLoStatConstraintsByClass: Settings['loStatConstraintsByClass'];
   allItems: DimItem[];
   autoModDefs: AutoModDefs;
   validateQuery: (query: string) => { valid: boolean };

--- a/src/app/loadout-builder/loadout-params.test.ts
+++ b/src/app/loadout-builder/loadout-params.test.ts
@@ -32,6 +32,18 @@ describe('resolveStatConstraints', () => {
         { statHash: armorStats[5], minStat: 0, maxStat: MAX_STAT, ignored: true },
       ],
     },
+    {
+      name: 'fills in from an empty array',
+      before: [],
+      after: [
+        { statHash: armorStats[0], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[1], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[2], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[3], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[4], minStat: 0, maxStat: MAX_STAT, ignored: true },
+        { statHash: armorStats[5], minStat: 0, maxStat: MAX_STAT, ignored: true },
+      ],
+    },
   ];
 
   for (const { name, before, after } of cases) {


### PR DESCRIPTION
Changelog: Fixed "Wrong Stat Minimums" showing up on loadouts without stat constraints.

I noticed this while looking at the screenshot in https://github.com/DestinyItemManager/DIM/pull/11512 where even the "Equipped" loadout said it couldn't meet stat minimums. But there were no stat minimums?

It turns out we are considering the saved per-class loadout parameters when the loadout doesn't already include stat constraints, which I think is confusing/misleading.