### PR TITLE
Defer hydrating sets so they're always "live"

### DIFF
--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -23,10 +23,9 @@ import {
   getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadatas,
 } from '../../utils/item-utils';
-import { AutoModData, ProcessArmorSet, ProcessItem, ProcessMod } from '../process-worker/types';
+import { AutoModData, ProcessItem, ProcessMod } from '../process-worker/types';
 import {
   ArmorEnergyRules,
-  ArmorSet,
   artificeSocketReusablePlugSetHash,
   artificeStatBoost,
   AutoModDefs,
@@ -146,24 +145,6 @@ export function mapDimItemToProcessItem({
   }
 
   return [processItem];
-}
-
-export function hydrateArmorSet(
-  processed: ProcessArmorSet,
-  itemsById: Map<string, DimItem>,
-): ArmorSet {
-  const armor: DimItem[] = [];
-
-  for (const itemId of processed.armor) {
-    armor.push(itemsById.get(itemId)!);
-  }
-
-  return {
-    armor,
-    stats: processed.stats,
-    armorStats: processed.armorStats,
-    statMods: processed.statMods,
-  };
 }
 
 export function mapAutoMods(defs: AutoModDefs): AutoModData {

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -20,19 +20,13 @@ import {
 import {
   ArmorBucketHash,
   ArmorEnergyRules,
-  ArmorSet,
   AutoModDefs,
   DesiredStatRange,
   ItemsByBucket,
   ModStatChanges,
   StatRanges,
 } from '../types';
-import {
-  hydrateArmorSet,
-  mapArmor2ModToProcessMod,
-  mapAutoMods,
-  mapDimItemToProcessItem,
-} from './mappers';
+import { mapArmor2ModToProcessMod, mapAutoMods, mapDimItemToProcessItem } from './mappers';
 
 interface MappedItem {
   dimItem: DimItem;
@@ -56,7 +50,7 @@ function createWorker() {
 }
 
 export type RunProcessResult = Omit<ProcessResult, 'sets'> & {
-  sets: ArmorSet[];
+  sets: ProcessArmorSet[];
   processTime: number;
 };
 
@@ -112,8 +106,6 @@ export function runProcess({
     [BucketHashes.LegArmor]: [],
     [BucketHashes.ClassArmor]: [],
   };
-  const itemsById = new Map<string, DimItem>();
-
   for (const [bucketHashStr, items] of Object.entries(filteredItems)) {
     const bucketHash = parseInt(bucketHashStr, 10) as ArmorBucketHash;
     processItems[bucketHash] = [];
@@ -132,7 +124,6 @@ export function runProcess({
 
     for (const mappedItem of mappedItems) {
       processItems[bucketHash].push(mappedItem.processItem);
-      itemsById.set(mappedItem.dimItem.id, mappedItem.dimItem);
     }
   }
 
@@ -206,9 +197,8 @@ export function runProcess({
     input,
     resultPromise: Promise.all(workerPromises).then((results) => {
       const result = combineResults(results);
-      const hydratedSets = result.sets.map((set) => hydrateArmorSet(set, itemsById));
       const processTime = performance.now() - processStart;
-      return { ...result, sets: hydratedSets, processTime };
+      return { ...result, processTime };
     }),
   };
 }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -8,10 +8,9 @@ import { infoLog } from 'app/utils/log';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { ProcessInputs } from '../process-worker/process';
-import { ProcessStatistics } from '../process-worker/types';
+import { ProcessArmorSet, ProcessStatistics } from '../process-worker/types';
 import {
   ArmorEnergyRules,
-  ArmorSet,
   DesiredStatRange,
   ItemsByBucket,
   ModStatChanges,
@@ -24,7 +23,7 @@ interface ProcessState {
   processing: boolean;
   resultStoreId: string;
   result: {
-    sets: ArmorSet[];
+    sets: ProcessArmorSet[];
     /**
      * The mods and rules used to generate the sets above. The sets
      * are guaranteed (modulo bugs in worker) to fit these mods given


### PR DESCRIPTION
Changelog: Items in loadout optimizer sets will now reflect changes like lock/unlock or being masterworked in-game.

Fixes #11502