### PR TITLE
Fix: Loadout names properly overridden to text-transform:none

### DIFF
--- a/src/app/loadout/LoadoutView.m.scss
+++ b/src/app/loadout/LoadoutView.m.scss
@@ -28,8 +28,8 @@
     gap: 8px;
     margin: 0 !important;
     font-size: 18px;
-    text-transform: none;
-    letter-spacing: normal;
+    text-transform: none !important;
+    letter-spacing: normal !important;
   }
 }
 

--- a/src/app/loadout/Loadouts.m.scss
+++ b/src/app/loadout/Loadouts.m.scss
@@ -29,8 +29,8 @@
 }
 
 .menuLoadout > span:not(.app-icon) {
-  text-transform: none;
-  letter-spacing: normal;
+  text-transform: none !important;
+  letter-spacing: normal !important;
 }
 
 .hashtagTip {


### PR DESCRIPTION
Changelog: Fix Loadout names being forced to uppercase.