### PR TITLE
Stable assignment for tuning mods

### DIFF
--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -451,6 +451,12 @@ export async function process(
 
             // Add on any tuning mods that were preset on the items.
             mods.push(
+              // It's important that we keep the order of these tuning mods in
+              // the order of the armor (even when we assign mods dynamically,
+              // later), so that when we assign them in fitMostMods they get
+              // assigned to the same item. Otherwise, we could end up swapping
+              // between one balanced mod and one tuning mod, and the balanced
+              // mod's stat bonuses could be slightly different.
               ...compact([
                 helm.includedTuningMod,
                 gaunt.includedTuningMod,


### PR DESCRIPTION
Changelog: Fixed an issue where loadouts might assign tuning mods in a different order than they were shown in Loadout Optimizer, resulting in different stats.

This sacrifices our mod assignment function's preference for leaving mods in place, in favor of assigning tuning mods exactly as they were chosen by LO. This *should* fix the issue where a set is found and then later when it is equipped, the stats are slightly different (due to balanced tuning landing on different items).
