### PR TITLE
Fix sizing of stat bars when icon is large

### DIFF
--- a/src/app/compare/CompareColumns.m.scss
+++ b/src/app/compare/CompareColumns.m.scss
@@ -42,10 +42,8 @@
 }
 
 .stat {
-  // the goal width is 64px at normal item tile size (50px)
-  // but allow the stat bars to shrink to account for bigger tiles,
-  // so that this doesn't blow out the overall compare width
-  max-width: calc(50px + 64px + 4px - var(--item-size));
+  margin-right: calc(4px + var(--item-size));
+  max-width: 68px;
 }
 
 .noWrap {
@@ -55,7 +53,6 @@
 .archetype {
   --item-size-mod: calc(#{dim-item-px(24)});
   composes: noWrap;
-  height: var(--item-size-mod) !important;
   padding-top: 4px;
   padding-bottom: 4px;
 }


### PR DESCRIPTION
Changelog: Fixed stat bars in Compare getting squished when the icon size setting is large.

Fixes #11519
