### PR TITLE
Remove new items

### DIFF
--- a/config/feature-flags.ts
+++ b/config/feature-flags.ts
@@ -56,7 +56,7 @@ export function makeFeatureFlags(env: {
     // Whether to sync DIM API data instead of loading everything
     dimApiSync: true,
     // Whether to show the "New Items" dot
-    newItems: env.release,
+    newItems: false,
   };
 }
 


### PR DESCRIPTION
Changelog: Removed the "new item" dot and tracking. This has been gone in Beta for a while now, and the recommendation is to use the Item Feed and tagging to keep tabs on your loot as it drops.
