### PR TITLE
Set webpack client logging to 'none'

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -124,6 +124,7 @@ export default (env: Env) => {
           },
           client: {
             overlay: false,
+            logging: "none", // we don't need to see build errors in the console log
           },
           historyApiFallback: true,
           hot: 'only',


### PR DESCRIPTION
Disable logging of build errors in the console. I don't care about them.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
