### PR TITLE
Add `tunedstat:unfocused` filter

### DIFF
--- a/src/app/search/__snapshots__/autocomplete.test.ts.snap
+++ b/src/app/search/__snapshots__/autocomplete.test.ts.snap
@@ -378,6 +378,7 @@ exports[`filterComplete autocomplete terms for |stat| 1`] = `
   "tunedstat:primary",
   "tunedstat:secondary",
   "tunedstat:tertiary",
+  "tunedstat:unfocused",
   "stat:rpm:",
   "stat:rof:",
   "stat:charge:",

--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -181,24 +181,19 @@ const statFilters: ItemFilterDefinition[] = [
       const isUnfocused = filterValue === 'unfocused';
       return (item) => {
         const tunedStat = getArmor3TuningStat(item);
-
         if (tunedStat === undefined) {
           return false;
         }
-
-        // Standard tunedstat:super handling
+        // Standard tunedstat:statname handling
         if (!isUnfocused && ordinalIdx === undefined) {
           const expectedStat = realD2ArmorStatHashByName[filterValue];
           return expectedStat !== null && tunedStat === expectedStat;
         }
-
         const statFocus = getArmor3StatFocus(item);
-
         // Looking for tunedstat:unfocused
         if (isUnfocused) {
           return !statFocus.includes(tunedStat);
         }
-
         // Looking for tunedstat: 'primary', 'secondary', or 'tertiary'
         const expectedStat = statFocus?.[ordinalIdx!] ?? null;
         return expectedStat !== null && tunedStat === expectedStat;

--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -178,6 +178,7 @@ const statFilters: ItemFilterDefinition[] = [
       }
       // Check if we are looking for generic 'primary', 'secondary', or 'tertiary'
       const ordinalIdx = armor3OrdinalIndexByName[filterValue];
+      const realArmorStatHash = realD2ArmorStatHashByName[filterValue];
       const isUnfocused = filterValue === 'unfocused';
       return (item) => {
         const tunedStat = getArmor3TuningStat(item);
@@ -186,7 +187,7 @@ const statFilters: ItemFilterDefinition[] = [
         }
         // Standard tunedstat:statname handling
         if (!isUnfocused && ordinalIdx === undefined) {
-          const expectedStat = realD2ArmorStatHashByName[filterValue];
+          const expectedStat = realArmorStatHash;
           return expectedStat !== null && tunedStat === expectedStat;
         }
         const statFocus = getArmor3StatFocus(item);

--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -178,7 +178,7 @@ const statFilters: ItemFilterDefinition[] = [
       }
       // Check if we are looking for generic 'primary', 'secondary', or 'tertiary'
       const ordinalIdx = armor3OrdinalIndexByName[filterValue];
-      const realArmorStatHash = realD2ArmorStatHashByName[filterValue];
+      const armorStatHash = realD2ArmorStatHashByName[filterValue];
       const isUnfocused = filterValue === 'unfocused';
       return (item) => {
         const tunedStat = getArmor3TuningStat(item);
@@ -187,8 +187,7 @@ const statFilters: ItemFilterDefinition[] = [
         }
         // Standard tunedstat:statname handling
         if (!isUnfocused && ordinalIdx === undefined) {
-          const expectedStat = realArmorStatHash;
-          return expectedStat !== null && tunedStat === expectedStat;
+          return armorStatHash !== null && tunedStat === armorStatHash;
         }
         const statFocus = getArmor3StatFocus(item);
         // Looking for tunedstat:unfocused

--- a/src/app/search/items/search-filters/stats.ts
+++ b/src/app/search/items/search-filters/stats.ts
@@ -178,17 +178,29 @@ const statFilters: ItemFilterDefinition[] = [
       }
       // Check if we are looking for generic 'primary', 'secondary', or 'tertiary'
       const ordinalIdx = armor3OrdinalIndexByName[filterValue];
-      const constantExpected =
-        ordinalIdx === undefined ? realD2ArmorStatHashByName[filterValue] : undefined;
+      const isUnfocused = filterValue === 'unfocused';
       return (item) => {
         const tunedStat = getArmor3TuningStat(item);
+
         if (tunedStat === undefined) {
           return false;
         }
-        const expectedStat =
-          ordinalIdx === undefined
-            ? constantExpected
-            : (getArmor3StatFocus(item)?.[ordinalIdx] ?? null);
+
+        // Standard tunedstat:super handling
+        if (!isUnfocused && ordinalIdx === undefined) {
+          const expectedStat = realD2ArmorStatHashByName[filterValue];
+          return expectedStat !== null && tunedStat === expectedStat;
+        }
+
+        const statFocus = getArmor3StatFocus(item);
+
+        // Looking for tunedstat:unfocused
+        if (isUnfocused) {
+          return !statFocus.includes(tunedStat);
+        }
+
+        // Looking for tunedstat: 'primary', 'secondary', or 'tertiary'
+        const expectedStat = statFocus?.[ordinalIdx!] ?? null;
         return expectedStat !== null && tunedStat === expectedStat;
       };
     },

--- a/src/app/search/search-filter-values.ts
+++ b/src/app/search/search-filter-values.ts
@@ -58,6 +58,7 @@ export const armor3OrdinalIndexByName: StringLookup<number> = {
 export const searchableD2Armor3StatNames = [
   ...Object.keys(realD2ArmorStatHashByName),
   ...Object.keys(armor3OrdinalIndexByName),
+  'unfocused',
 ];
 
 /** stat hashes to calculate max values for */


### PR DESCRIPTION
Changelog: Added `tunedstat:unfocused` filter to match items whose tuning stat is not one of the focused stats.

After testing all tunedstat: filters appear to be working properly.

Resolves #11542

<img width="747" height="775" alt="image" src="https://github.com/user-attachments/assets/15d49610-d68e-4773-9612-9a01cd8592bf" />
