### PR TITLE
is:artifice filter

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -220,6 +220,7 @@
     "AmmoType": "Shows items based on their ammo type.",
     "ArmorCategory": "Shows armors based on their category.",
     "ArmorIntrinsic": "Shows legendary armor which has an intrinsic perk, such as Artifice Armor.",
+    "Artifice": "Shows Artifice armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Unascended": "Shows items that have an ascend node which have not been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type. breaker:instrinsic shows items with intrinsic breaker ability.",

--- a/src/app/compare/reducer.ts
+++ b/src/app/compare/reducer.ts
@@ -175,10 +175,7 @@ function initialCompareQuery(item: DimItem) {
       factors.push(`exactperk:${quoteFilterString(intrinsicName)}`);
     }
 
-    let modSlotMetadata = getSpecialtySocketMetadata(item);
-    if (modSlotMetadata?.slotTag === 'artifice') {
-      modSlotMetadata = undefined;
-    }
+    const modSlotMetadata = getSpecialtySocketMetadata(item);
 
     if (modSlotMetadata) {
       factors.push(`modslot:${modSlotMetadata.slotTag}`);

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -15,9 +15,6 @@ import styles from './SpecialtyModSlotIcon.m.scss';
 export function SpecialtyModSlotIcon({ item, className }: { item: DimItem; className?: string }) {
   const defs = useD2Definitions()!;
   const modMetadata = isArtifice(item) ? artificeDisplayStub : getSpecialtySocketMetadata(item);
-  if (item.id === '6917529983910005561') {
-    console.log('isartifice', isArtifice(item), 'modMetadata', modMetadata);
-  }
   if (!modMetadata) {
     return null;
   }

--- a/src/app/dim-ui/SpecialtyModSlotIcon.tsx
+++ b/src/app/dim-ui/SpecialtyModSlotIcon.tsx
@@ -1,7 +1,8 @@
 import { bungieBackgroundStyle } from 'app/dim-ui/BungieImage';
 import { DimItem } from 'app/inventory/item-types';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { getSpecialtySocketMetadata } from 'app/utils/item-utils';
+import { artificeDisplayStub } from 'app/search/specialty-modslots';
+import { getSpecialtySocketMetadata, isArtifice } from 'app/utils/item-utils';
 import clsx from 'clsx';
 import { PressTip } from './PressTip';
 import styles from './SpecialtyModSlotIcon.m.scss';
@@ -13,8 +14,10 @@ import styles from './SpecialtyModSlotIcon.m.scss';
  */
 export function SpecialtyModSlotIcon({ item, className }: { item: DimItem; className?: string }) {
   const defs = useD2Definitions()!;
-  const modMetadata = getSpecialtySocketMetadata(item);
-
+  const modMetadata = isArtifice(item) ? artificeDisplayStub : getSpecialtySocketMetadata(item);
+  if (item.id === '6917529983910005561') {
+    console.log('isartifice', isArtifice(item), 'modMetadata', modMetadata);
+  }
   if (!modMetadata) {
     return null;
   }

--- a/src/app/inventory/InventoryItem.tsx
+++ b/src/app/inventory/InventoryItem.tsx
@@ -6,6 +6,7 @@ import {
   getArmor3StatFocus,
   getSpecialtySocketMetadata,
   isArmor3,
+  isArtifice,
   nonPullablePostmasterItem,
 } from 'app/utils/item-utils';
 import clsx from 'clsx';
@@ -86,7 +87,8 @@ export default function InventoryItem({
 
   const statFocusHash =
     item.bucket.inArmor && isArmor3(item) ? getArmor3StatFocus(item)?.[0] : undefined;
-  const hasInterestingModSlots = item.bucket.inArmor && getSpecialtySocketMetadata(item);
+  const hasInterestingModSlots =
+    item.bucket.inArmor && (getSpecialtySocketMetadata(item) || isArtifice(item));
 
   // Memoize the contents of the item - most of the time if this is re-rendering it's for a search, or a new item
   const contents = useMemo(() => {

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -90,7 +90,7 @@ export function mapDimItemToProcessItems({
     power,
     stats,
     remainingEnergyCapacity: capacity - modsCost,
-    compatibleActivityMod: compatibleActivityMod === 'artifice' ? undefined : compatibleActivityMod,
+    compatibleActivityMod: compatibleActivityMod,
     setBonus: setBonus?.hash,
   };
 

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -521,7 +521,8 @@ export function getColumns(
         header: t('Organizer.Columns.ModSlot'),
         className: styles.modslot,
         // TODO: only show if there are mod slots
-        value: (item) => getSpecialtySocketMetadata(item)?.slotTag,
+        value: (item) =>
+          isArtifice(item) ? 'artifice' : getSpecialtySocketMetadata(item)?.slotTag,
         cell: (value, item) =>
           value && <SpecialtyModSlotIcon className={styles.modslotIcon} item={item} />,
         filter: (value) => (value !== undefined ? `modslot:${value}` : ''),

--- a/src/app/search/__snapshots__/search-config.test.ts.snap
+++ b/src/app/search/__snapshots__/search-config.test.ts.snap
@@ -11,6 +11,7 @@ exports[`buildSearchConfig generates a reasonable filter map: is filters 1`] = `
   "armor3.0",
   "armorintrinsic",
   "armormod",
+  "artifice",
   "autorifle",
   "blue",
   "bow",

--- a/src/app/search/items/search-filters/sockets.ts
+++ b/src/app/search/items/search-filters/sockets.ts
@@ -7,7 +7,7 @@ import {
   emptySocketHashes,
 } from 'app/search/d2-known-values';
 import { plainString } from 'app/search/text-utils';
-import { getSpecialtySocketMetadata, modSlotTags } from 'app/utils/item-utils';
+import { getSpecialtySocketMetadata, isArtifice, modSlotTags } from 'app/utils/item-utils';
 import { enhancedVersion } from 'app/utils/perk-utils';
 import {
   countEnhancedPerks,
@@ -35,10 +35,7 @@ export const modslotFilter = {
   filter:
     ({ filterValue }) =>
     (item) => {
-      let modSocketTag = getSpecialtySocketMetadata(item)?.slotTag;
-      if (modSocketTag === 'artifice') {
-        modSocketTag = undefined;
-      }
+      const modSocketTag = getSpecialtySocketMetadata(item)?.slotTag;
 
       return Boolean(
         (filterValue === 'none' && !modSocketTag) ||
@@ -54,6 +51,12 @@ export const modslotFilter = {
 
 const socketFilters: ItemFilterDefinition[] = [
   modslotFilter,
+  {
+    keywords: 'artifice',
+    description: tl('Filter.Artifice'),
+    destinyVersion: 2,
+    filter: () => (item) => isArtifice(item),
+  },
   {
     keywords: 'randomroll',
     description: tl('Filter.RandomRoll'),

--- a/src/app/search/specialty-modslots.ts
+++ b/src/app/search/specialty-modslots.ts
@@ -46,7 +46,7 @@ export const modTypeTagByPlugCategoryHash: LookupTable<PlugCategoryHashes, strin
   [PlugCategoryHashes.EnhancementsRaidV800]: 'salvationsedge',
 };
 
-const modSocketMetadata: ModSocketMetadata[] = [
+export const modSocketMetadata: ModSocketMetadata[] = [
   {
     slotTag: 'lastwish',
     socketTypeHashes: [1444083081],
@@ -117,13 +117,9 @@ const modSocketMetadata: ModSocketMetadata[] = [
     emptyModSocketHash: 1180997867,
     activityModeHash: 332181804,
   },
-  {
-    slotTag: 'artifice',
-    socketTypeHashes: [1719555937, 2770223926, 3642670483, 2831858578, 4096670123, 3136585661],
-    compatiblePlugCategoryHashes: [PlugCategoryHashes.EnhancementsArtifice],
-    emptyModSocketHash: 4173924323,
-    iconHash: 3727270518,
-  },
 ];
 
-export default modSocketMetadata;
+export const artificeDisplayStub = {
+  emptyModSocketHash: 4173924323,
+  iconHash: 3727270518,
+} as ModSocketMetadata;

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -20,7 +20,8 @@ import {
   tuningModToTunedStathash,
 } from 'app/search/d2-known-values';
 import { damageNamesByEnum } from 'app/search/search-filter-values';
-import modSocketMetadata, {
+import {
+  modSocketMetadata,
   ModSocketMetadata,
   modTypeTagByPlugCategoryHash,
 } from 'app/search/specialty-modslots';
@@ -80,7 +81,11 @@ const getSpecialtySocket = (item?: DimItem): DimSocket | undefined => {
   }
 };
 
-/** returns ModMetadatas if the item has one or more specialty mod slots */
+/**
+ * Returns ModMetadatas if the item has one or more specialty mod slots.
+ *
+ * This no longer includes artifice. Use isArtifice function for that.
+ */
 export const getSpecialtySocketMetadata = (item?: DimItem): ModSocketMetadata | undefined => {
   const specialtySocket = getSpecialtySocket(item);
   if (!specialtySocket) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -210,6 +210,7 @@
     "Armor3": "Shows items that use the Armor 3.0 stat system introduced in Edge of Fate.",
     "ArmorCategory": "Shows armors based on their category.",
     "ArmorIntrinsic": "Shows legendary armor which has an intrinsic perk, such as Artifice Armor.",
+    "Artifice": "Shows Artifice armor.",
     "Ascended": "Shows items that have an ascend node which have been ascended.",
     "Breaker": "Filter by breaker type or corresponding champion type. breaker:instrinsic shows items with intrinsic breaker ability.",
     "BulkClear_one": "Removed tag from 1 item.",


### PR DESCRIPTION
Changelog: Added `is:artifice` filter to find Artifice armor.

`modslot:artifice` was not even working anymore, and it's time this was separated from seasonal/specialty modslots.