### PR TITLE
Remove max light loadout from loadouts page

### DIFF
--- a/src/app/loadout/Loadouts.tsx
+++ b/src/app/loadout/Loadouts.tsx
@@ -9,17 +9,12 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { VirtualListRef, WindowVirtualList } from 'app/dim-ui/VirtualList';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { t, tl } from 'app/i18next-t';
-import {
-  allItemsSelector,
-  artifactUnlocksSelector,
-  sortedStoresSelector,
-} from 'app/inventory/selectors';
+import { artifactUnlocksSelector, sortedStoresSelector } from 'app/inventory/selectors';
 import { useLoadStores } from 'app/inventory/store/hooks';
 import {
   MakeLoadoutAnalysisAvailable,
   useUpdateLoadoutAnalysisContext,
 } from 'app/loadout-analyzer/hooks';
-import { maxLightLoadout } from 'app/loadout-drawer/auto-loadouts';
 import { editLoadout } from 'app/loadout-drawer/loadout-events';
 import {
   getLoadoutSeason,
@@ -124,12 +119,6 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     [artifactUnlocks, selectedStore],
   );
 
-  const allItems = useSelector(allItemsSelector);
-  const maxLight = useMemo(
-    () => maxLightLoadout(allItems, selectedStore),
-    [allItems, selectedStore],
-  );
-
   useUpdateLoadoutAnalysisContext(selectedStore.id);
 
   const [showSnapshot, setShowSnapshot] = useState(false);
@@ -169,7 +158,6 @@ function Loadouts({ account }: { account: DestinyAccount }) {
     loadoutSort,
   );
   if (!filteringLoadouts) {
-    loadouts.unshift(maxLight);
     loadouts.unshift(currentLoadout);
   }
 


### PR DESCRIPTION
Changelog: Removed max light loadout from the Loadouts page because some folks are bothered by it.

Fixes #11531