### PR TITLE
Feature: Armor archetype inventory sorting

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -1213,6 +1213,7 @@
   },
   "Settings": {
     "Appearance": "Appearance",
+    "ArmorArchetypeModslot": "Armor Archetype / Modslot",
     "AutoLockTagged": "Sync item lock state with tag",
     "AutoLockTaggedExplanation": "DIM will automatically lock and unlock items to match their tag. Crafted items will remain unlocked to allow reshaping. When this setting is enabled, the lock icon will not be shown on the item tile for tagged items.",
     "BadgePostmaster": "Show the number of postmaster items for the current character on app icon",

--- a/src/app/settings/SettingsPage.tsx
+++ b/src/app/settings/SettingsPage.tsx
@@ -184,6 +184,7 @@ export default function SettingsPage() {
     deepsight: t('Settings.SortByDeepsight'),
     featured: t('Settings.SortByFeatured'),
     tier: t('Settings.SortByTier'),
+    armorArchetype: t('Settings.ArmorArchetypeModslot'),
   };
 
   const vaultWeaponGroupingOptions = mapToOptions({

--- a/src/app/shell/item-comparators.ts
+++ b/src/app/shell/item-comparators.ts
@@ -3,7 +3,13 @@ import { getSeason } from 'app/inventory/store/season';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import { ItemRarityMap } from 'app/search/d2-known-values';
 import { ItemSortSettings } from 'app/settings/item-sort';
-import { isD1Item } from 'app/utils/item-utils';
+import {
+  getArmor3StatFocus,
+  getSpecialtySocketMetadata,
+  isArmor3,
+  isArtifice,
+  isD1Item,
+} from 'app/utils/item-utils';
 import { DestinyAmmunitionType, DestinyDamageTypeDefinition } from 'bungie-api-ts/destiny2';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import { TagValue, tagConfig, vaultGroupTagOrder } from '../inventory/dim-item-info';
@@ -286,6 +292,23 @@ const ITEM_COMPARATORS: {
   featured: compareBy((item) => (item.featured ? 0 : 1)),
   // high -> low
   tier: reverseComparator(compareBy((item) => item.tier)),
+  // armor 3 archetypes -> artifice -> old specialty modslots -> nada
+  armorArchetype: compareBy((item) => {
+    if (!item.bucket.inArmor) {
+      return '0';
+    }
+    if (isArmor3(item)) {
+      return `1 ${getArmor3StatFocus(item)?.[0]}`;
+    }
+    if (isArtifice(item)) {
+      return '2';
+    }
+    const specialtySocket = getSpecialtySocketMetadata(item)?.slotTag;
+    if (specialtySocket) {
+      return `3 ${specialtySocket}`;
+    }
+    return '4';
+  }),
   default: () => 0,
 };
 

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1197,6 +1197,7 @@
   },
   "Settings": {
     "Appearance": "Appearance",
+    "ArmorArchetypeModslot": "Armor Archetype / Modslot",
     "AutoLockTagged": "Sync item lock state with tag",
     "AutoLockTaggedExplanation": "DIM will automatically lock and unlock items to match their tag. Crafted items will remain unlocked to allow reshaping. When this setting is enabled, the lock icon will not be shown on the item tile for tagged items.",
     "BadgePostmaster": "Show the number of postmaster items for the current character on app icon",


### PR DESCRIPTION
Changelog: Added inventory sorting by armor archetype or special modslot.

armor 3 archetypes -> artifice -> old specialty modslots -> nada

<img width="1249" height="616" alt="image" src="https://github.com/user-attachments/assets/ca051f69-0a36-44d9-a3df-de9ca9189df2" />
