### PR TITLE
Feature: MVP allow FOTL helmets to satisfy LO set bonus reqs

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -664,6 +664,7 @@
     "MwExotic": "Exotic",
     "ExcludeVendors": "Search \"not:vendor\" to exclude vendor items from Loadout Optimizer.",
     "ExistingLoadout": "Existing Loadout",
+    "FOTLWildcardWarning": "This set contains a Festival of the Lost mask. Manually apply the correct mod to activate desired set bonuses.",
     "ExoticClassItemPerks": "If you want specific perks, use searches like exactperk:\"spirit of verity\". Click perks in the Optimizer results to add or remove them from the item filter.",
     "ExoticSpecialCategory": "Special",
     "Filter": "Settings",

--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -4,6 +4,7 @@ import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-ty
 import { DimStore, statSourceOrder } from 'app/inventory/store-types';
 import { getSetBonusStatus } from 'app/item-popup/SetBonus';
 import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
+import { fotlWildcardHashes } from 'app/loadout/known-values';
 import { Loadout } from 'app/loadout/loadout-types';
 import { fitMostMods } from 'app/loadout/mod-assignment-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
@@ -172,6 +173,7 @@ export default memo(function GeneratedSet({
         existingLoadoutName={overlappingLoadout?.name}
         equippedHashes={equippedHashes}
         setBonusStatus={setBonusStatus}
+        fotlWarning={set.armor.some((i) => fotlWildcardHashes.has(i.hash))}
       />
       <div className={styles.build}>
         <div className={styles.items}>

--- a/src/app/loadout-builder/generated-sets/SetStats.m.scss
+++ b/src/app/loadout-builder/generated-sets/SetStats.m.scss
@@ -86,3 +86,7 @@
 .boostedValue {
   color: $stat-modded;
 }
+
+.statBarWarningIcon {
+  font-size: 20px;
+}

--- a/src/app/loadout-builder/generated-sets/SetStats.m.scss.d.ts
+++ b/src/app/loadout-builder/generated-sets/SetStats.m.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'light': string;
   'loadoutName': string;
   'nonActiveStat': string;
+  'statBarWarningIcon': string;
   'statIcon': string;
   'statSegment': string;
   'tier': string;

--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -1,3 +1,4 @@
+import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import BungieImage from 'app/dim-ui/BungieImage';
 import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
@@ -34,6 +35,7 @@ export function TierlessSetStats({
   existingLoadoutName,
   equippedHashes,
   setBonusStatus,
+  fotlWarning,
 }: {
   stats: ArmorStats;
   getStatsBreakdown: () => ModStatChanges;
@@ -44,6 +46,7 @@ export function TierlessSetStats({
   existingLoadoutName?: string;
   equippedHashes: Set<number>;
   setBonusStatus: ActiveSetBonusInfo;
+  fotlWarning?: boolean;
 }) {
   const defs = useD2Definitions()!;
   const totalStats = sum(Object.values(stats));
@@ -92,6 +95,11 @@ export function TierlessSetStats({
         {maxPower}
       </span>
       <SetBonusesStatus setBonusStatus={setBonusStatus} />
+      {fotlWarning && (
+        <PressTip tooltip={t('LoadoutBuilder.FOTLWildcardWarning')}>
+          <AlertIcon className={styles.statBarWarningIcon} />
+        </PressTip>
+      )}
       {existingLoadoutName ? (
         <span className={styles.existingLoadout}>
           {t('LoadoutBuilder.ExistingLoadout')}:{' '}

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -3,6 +3,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { DimItem, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
 import { calculateAssumedMasterworkStats } from 'app/loadout-drawer/loadout-utils';
 import { calculateAssumedItemEnergy } from 'app/loadout/armor-upgrade-utils';
+import { fotlWildcardHashes } from 'app/loadout/known-values';
 import { ModMap, assignBucketSpecificMods } from 'app/loadout/mod-assignment-utils';
 import { armorStats } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
@@ -192,7 +193,9 @@ export function filterItems({
     // If every non-exotic requires set bonuses...
     if (includeOnlySetBonusHashes && !lockedExoticApplicable) {
       firstPassFilteredItems = firstPassFilteredItems.filter(
-        (item) => item.setBonus && includeOnlySetBonusHashes.includes(item.setBonus.hash),
+        (item) =>
+          (item.setBonus && includeOnlySetBonusHashes.includes(item.setBonus.hash)) ||
+          fotlWildcardHashes.has(item.hash),
       );
     }
 

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -1,5 +1,5 @@
 import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
-import { MAX_STAT } from 'app/loadout/known-values';
+import { fotlWildcardHashes, MAX_STAT } from 'app/loadout/known-values';
 import { compact, filterMap } from 'app/utils/collections';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { sum } from 'es-toolkit';
@@ -180,7 +180,7 @@ export async function process(
   const hasMods = Boolean(activityMods.length || generalMods.length);
 
   const setBonusHashes = Object.keys(setBonuses).map((h) => Number(h));
-  const setBonusCounts = Object.values(setBonuses);
+  const setBonusCounts = Object.values(setBonuses) as number[]; // TS won't figure this out itself?
 
   interface Scheduler {
     scheduler?: { yield: () => Promise<void> };
@@ -243,17 +243,27 @@ export async function process(
             }
 
             // Check set bonus requirements
+            let wildcardAvailable = true;
             for (let i = 0; i < setBonusHashes.length; i++) {
               const setHash = setBonusHashes[i];
+              const setNeededCount = setBonusCounts[i];
               const setCount =
                 Number(helm.setBonus === setHash) +
                 Number(gaunt.setBonus === setHash) +
                 Number(chest.setBonus === setHash) +
                 Number(leg.setBonus === setHash) +
                 Number(classItem.setBonus === setHash);
-              if (setCount < setBonusCounts[i]) {
-                setStatistics.skipReasons.insufficientSetBonus += 1;
-                continue innerloop;
+              if (setCount < setNeededCount) {
+                if (
+                  wildcardAvailable &&
+                  fotlWildcardHashes.has(helm.hash!) &&
+                  setCount + 1 === setNeededCount
+                ) {
+                  wildcardAvailable = false;
+                } else {
+                  setStatistics.skipReasons.insufficientSetBonus += 1;
+                  continue innerloop;
+                }
               }
             }
 

--- a/src/app/loadout/known-values.ts
+++ b/src/app/loadout/known-values.ts
@@ -46,3 +46,6 @@ export const edgeOfFateReleased = D2CalculatedSeason >= 27;
 // MAX_STAT (which is the Edge of Fate value) to allow folks to theorycraft a
 // bit before it releases. Afterwards they will be the same.
 export const EFFECTIVE_MAX_STAT = edgeOfFateReleased ? MAX_STAT : 10 * MAX_TIER;
+
+/** These 3 helmets can be configured to contribute to any set bonus */
+export const fotlWildcardHashes = new Set([4095816113, 2462335932, 2390807586]);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -705,6 +705,7 @@
     "Exotic": "Exotic Armor",
     "ExoticClassItemPerks": "If you want specific perks, use searches like exactperk:\"spirit of verity\". Click perks in the Optimizer results to add or remove them from the item filter.",
     "ExoticSpecialCategory": "Special",
+    "FOTLWildcardWarning": "This set contains a Festival of the Lost mask. Manually apply the correct mod to activate desired set bonuses.",
     "Filter": "Settings",
     "IgnoreStat": "If unchecked, Loadout Optimizer will pretend this stat doesn't exist when building sets",
     "IncreaseStatPriority": "Increase stat priority",


### PR DESCRIPTION
New FOTL helmets are configurable to count as any one set bonus.

This PR allows FOTL helmets past the LO set bonus filter, and to satisfy one set bonus that the 5 pieces would otherwise fall short of.

Places a general warning in LO results if a FOTL helmet is included.

Changelog: Loadout Optimizer allows Festival of the Lost masks to complete a set bonus. You'll still need to plug the right mod in.