### PR TITLE
Fix: Ignore quotes in strings when item name matching

### DIFF
--- a/src/app/search/items/search-filters/freeform.ts
+++ b/src/app/search/items/search-filters/freeform.ts
@@ -4,6 +4,7 @@ import { DimItem, DimPlug } from 'app/inventory/item-types';
 import { quoteFilterString } from 'app/search/query-parser';
 import {
   matchText,
+  normalizeItemName,
   plainString,
   startWordRegexp,
   testStringsFromDisplayProperties,
@@ -44,7 +45,7 @@ const getUniqueItemNamesFromManifest = memoizeOne(
 
         return isArmor || i.itemCategoryHashes.includes(ItemCategoryHashes.Weapon);
       })
-      .map((i) => i.displayProperties.name.toLowerCase());
+      .map((i) => i.displayProperties.name);
     return [...new Set(itemNames)];
   },
 );
@@ -60,12 +61,11 @@ const nameFilter = {
           (i) =>
             i.bucket.inWeapons || i.bucket.inArmor || i.bucket.inGeneral || i.bucket.inInventory,
         )
-        .map((i) => i.name.toLowerCase());
-      // favor items we actually own
+        .map((i) => i.name); // favor items we actually own
       const allItemNames = getUniqueItemNamesFromManifest(d2Definitions.InventoryItem.getAll());
       return Array.from(
         new Set([...myItemNames, ...allItemNames]),
-        (s) => `exactname:${quoteFilterString(s)}`,
+        (s) => `exactname:${quoteFilterString(normalizeItemName(s))}`,
       );
     }
   },
@@ -73,7 +73,7 @@ const nameFilter = {
     const test = matchText(filterValue, language, /* exact */ lhs === 'exactname');
     return (item) => test(item.name);
   },
-  fromItem: (item) => `exactname:${quoteFilterString(item.name)}`,
+  fromItem: (item) => `exactname:${quoteFilterString(normalizeItemName(item.name))}`,
 } satisfies ItemFilterDefinition;
 
 const freeformFilters: ItemFilterDefinition[] = [

--- a/src/app/search/query-parser.ts
+++ b/src/app/search/query-parser.ts
@@ -19,6 +19,7 @@
 */
 
 import { convertToError } from 'app/utils/errors';
+import { normalizeQuoteChars } from 'app/utils/strings';
 
 /* **** Parser **** */
 
@@ -353,10 +354,7 @@ export class QueryLexerOpenQuotesError extends QueryLexerError {
  */
 export function* lexer(query: string): Generator<Token> {
   query = query.toLowerCase();
-
-  // http://blog.tatedavies.com/2012/08/28/replace-microsoft-chars-in-javascript/
-  query = query.replace(/[\u2018-\u201A]/g, "'");
-  query = query.replace(/[\u201C-\u201E]/g, '"');
+  query = normalizeQuoteChars(query);
 
   let match: string | undefined;
   let i = 0;

--- a/src/app/search/text-utils.ts
+++ b/src/app/search/text-utils.ts
@@ -1,6 +1,7 @@
 /* Utilities for text matching in filters. */
 
 import { DIM_LANG_INFOS, DimLanguage } from 'app/i18n';
+import { normalizeQuoteChars } from 'app/utils/strings';
 
 /** global language bool. "latin" character sets are the main driver of string processing changes */
 const isLatinBased = (language: DimLanguage) => DIM_LANG_INFOS[language].latinBased;
@@ -25,17 +26,21 @@ export function startWordRegexp(s: string, language: DimLanguage) {
 export const plainString = (s: string, language: DimLanguage): string =>
   latinize(s, language).toLowerCase();
 
+export function normalizeItemName(str: string) {
+  return normalizeQuoteChars(str).toLowerCase().replace(/"/g, '');
+}
+
 /**
  * Create a case-/diacritic-insensitive matching predicate for name / perkname filters.
  * Requires an exact match if `exact`, otherwise partial.
  */
 export function matchText(value: string, language: DimLanguage, exact: boolean) {
-  const normalized = plainString(value, language);
+  const normalized = normalizeItemName(plainString(value, language));
   if (exact) {
-    return (s: string) => normalized === plainString(s, language);
+    return (s: string) => normalized === normalizeItemName(plainString(s, language));
   } else {
     const startWord = startWordRegexp(normalized, language);
-    return (s: string) => startWord.test(plainString(s, language));
+    return (s: string) => startWord.test(normalizeItemName(plainString(s, language)));
   }
 }
 

--- a/src/app/utils/strings.ts
+++ b/src/app/utils/strings.ts
@@ -1,0 +1,4 @@
+// http://blog.tatedavies.com/2012/08/28/replace-microsoft-chars-in-javascript/
+export function normalizeQuoteChars(str: string) {
+  return str.replace(/[\u2018-\u201A]/g, "'").replace(/[\u201C-\u201E]/g, '"');
+}


### PR DESCRIPTION
Fixes #11573 

Definitely a post-Sunday merge.

It was tempting to modify `plainString` but that's used a lot of places.

Item names can contain quote-like characters, at least in German.
This interferes with search filter and consequently with Compare buttons.
The PR strips quotes from generated suggestions, and compares item names (`name:` / `exactname:`) with quotes stripped.

