### PR TITLE
Fix: Display 5 tier pips for (bugged?) T6 weapons

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -145,7 +145,9 @@ export default function ItemIcon({ item, className }: { item: DimItem; className
     // Featured flags
     item.featured ? itemConstants?.featuredItemFlagPath : undefined,
     // Tier pips
-    item.tier > 0 && !item.isEngram && itemConstants?.gearTierOverlayImagePaths[item.tier - 1],
+    item.tier > 0 &&
+      !item.isEngram &&
+      itemConstants?.gearTierOverlayImagePaths[Math.min(item.tier - 1, 4)],
   ]);
 
   if (craftedOverlays.length === 0 && seasonBanner) {

--- a/src/app/item-popup/ItemPopupHeader.tsx
+++ b/src/app/item-popup/ItemPopupHeader.tsx
@@ -103,7 +103,7 @@ function SeasonTierBanner({ item }: { item: DimItem }) {
     // Featured flags
     item.featured ? itemConstants.featuredItemFlagPath : undefined,
     // Tier pips
-    item.tier > 0 && itemConstants.gearTierOverlayImagePaths[item.tier - 1],
+    item.tier > 0 && itemConstants.gearTierOverlayImagePaths[Math.min(item.tier - 1, 4)],
     // Black stripe
     item.iconDef.secondaryBackground && itemConstants.watermarkDropShadowPath,
   ]);


### PR DESCRIPTION
Changelog: Display 5 tier pips (instead of none) for bugged Call to Arms Tier 6 holofoil weapons, so there are no misunderstandings.