### PR TITLE
Add a quick filter by frame+damage type while comparing weapon 

### DIFF
--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -280,6 +280,24 @@ export function findSimilarWeapons(exampleItem: DimItem): CompareButton[] {
       query: `is:${getItemDamageShortName(exampleItem)}`,
     },
 
+    // same waepon frame and also matching element
+    {
+      buttonLabel: [
+        intrinsicName,
+        <ElementIcon
+          key={exampleItem.id}
+          element={exampleItem.element}
+          className={clsx(styles.inlineImageIcon, 'dontInvert')}
+        />,
+        <WeaponTypeIcon key="type" item={exampleItem} className={styles.svgIcon} />,
+      ],
+      query: `(is:${getItemDamageShortName(exampleItem)} ${
+        exampleItem.destinyVersion === 2 && intrinsic
+          ? `exactperk:${quoteFilterString(intrinsic.displayProperties.name)}`
+          : `stat:rpm:${getRpm(exampleItem)}`
+      })`,
+    },
+
     // exact same weapon, judging by name. might span multiple expansions.
     {
       buttonLabel: [adeptStripped],


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

In weapon compare panel, add a quick filter button matching same elemental type and same weapon frame.

<img width="1233" height="494" alt="image" src="https://github.com/user-attachments/assets/d67eab08-de1a-4ce6-8a13-45a8926c71c9" />
