### PR TITLE
Don't send API key for unauthed Bungie APIs

### DIFF
--- a/src/app/bungie-api/bungie-service-helper.ts
+++ b/src/app/bungie-api/bungie-service-helper.ts
@@ -63,7 +63,7 @@ export const authenticatedHttpClient = dimErrorHandledHttpClient(
 /** used to get manifest and global alerts */
 export const unauthenticatedHttpClient = dimErrorHandledHttpClient(
   responsivelyThrottleHttpClient(
-    createHttpClient(createFetchWithNonStoppingTimeout(fetch, TIMEOUT, notifyTimeout), API_KEY),
+    createHttpClient(createFetchWithNonStoppingTimeout(fetch, TIMEOUT, notifyTimeout)),
     logThrottle,
   ),
 );

--- a/src/app/bungie-api/http-client.ts
+++ b/src/app/bungie-api/http-client.ts
@@ -125,7 +125,7 @@ export function createFetchWithNonStoppingTimeout(
 // HTTPCLIENT UTILS
 //
 
-export function createHttpClient(fetchFunction: typeof fetch, apiKey: string): HttpClient {
+export function createHttpClient(fetchFunction: typeof fetch, apiKey?: string): HttpClient {
   return async <T>(config: HttpClientConfig) => {
     let url = config.url;
     if (config.params) {
@@ -136,7 +136,7 @@ export function createHttpClient(fetchFunction: typeof fetch, apiKey: string): H
       method: config.method,
       body: config.body ? JSON.stringify(config.body) : undefined,
       headers: {
-        'X-API-Key': apiKey,
+        ...(apiKey ? { 'X-API-Key': apiKey } : undefined),
         ...(config.body ? { 'Content-Type': 'application/json' } : undefined),
       },
       credentials: 'omit',


### PR DESCRIPTION
This stops sending our API key for APIs that should be unauthenticated. I thought this might avoids a CORS preflight in some cases, but these are only gets. It should allow for better caching on Bungie's part though. I had held onto this because I seemed to remember cases where Bungie failed to return manifest data when the API key wasn't present, but I think that might have been another issue.