### PR TITLE
Switch from terser to swc-minify

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -176,10 +176,14 @@ export default (env: Env) => {
       },
       minimizer: [
         new TerserPlugin({
+          minify: TerserPlugin.swcMinify,
           parallel: true,
           terserOptions: {
             ecma: 2020,
             module: true,
+            format: {
+              comments: false,
+            },
             compress: {
               passes: 3,
               toplevel: true,
@@ -201,6 +205,7 @@ export default (env: Env) => {
             },
             mangle: { toplevel: true },
           },
+          extractComments: false,
         }),
       ],
     },

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@eslint/compat": "^2.0.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.2",
     "@svgr/webpack": "^8.1.0",
+    "@swc/core": "^1.15.3",
     "@testing-library/react": "^16.3.0",
     "@types/dom-chromium-installation-events": "^101.0.4",
     "@types/dom-screen-wake-lock": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ devDependencies:
   '@svgr/webpack':
     specifier: ^8.1.0
     version: 8.1.0(typescript@5.9.3)
+  '@swc/core':
+    specifier: ^1.15.3
+    version: 1.15.3
   '@testing-library/react':
     specifier: ^16.3.0
     version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.0)(react@19.2.0)
@@ -228,7 +231,7 @@ devDependencies:
     version: 1.0.3
   '@types/generate-json-webpack-plugin':
     specifier: ^0.3.8
-    version: 0.3.8(webpack-cli@6.0.1)
+    version: 0.3.8(@swc/core@1.15.3)(webpack-cli@6.0.1)
   '@types/jest':
     specifier: ^30.0.0
     version: 30.0.0
@@ -255,7 +258,7 @@ devDependencies:
     version: 1.0.2
   '@types/webpack':
     specifier: ^5.28.5
-    version: 5.28.5(webpack-cli@6.0.1)
+    version: 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
   '@types/webpack-env':
     specifier: ^1.18.8
     version: 1.18.8
@@ -453,7 +456,7 @@ devDependencies:
     version: 4.0.0
   terser-webpack-plugin:
     specifier: ^5.3.14
-    version: 5.3.14(webpack@5.103.0)
+    version: 5.3.14(@swc/core@1.15.3)(webpack@5.103.0)
   ts-jest:
     specifier: ^29.4.6
     version: 29.4.6(@babel/core@7.28.5)(babel-jest@30.2.0)(jest@30.2.0)(typescript@5.9.3)
@@ -474,7 +477,7 @@ devDependencies:
     version: 8.48.0(eslint@9.19.0)(typescript@5.9.3)
   webpack:
     specifier: ^5.103.0
-    version: 5.103.0(webpack-cli@6.0.1)
+    version: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
   webpack-cli:
     specifier: ^6.0.1
     version: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
@@ -3134,7 +3137,7 @@ packages:
       webpack-plugin-serve:
         optional: true
     dependencies:
-      '@types/webpack': 5.28.5(webpack-cli@6.0.1)
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
       anser: 2.3.3
       core-js-pure: 3.47.0
       error-stack-parser: 2.1.4
@@ -3142,7 +3145,7 @@ packages:
       react-refresh: 0.18.0
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.103.0)
     dev: true
 
@@ -4947,11 +4950,136 @@ packages:
       - typescript
     dev: true
 
+  /@swc/core-darwin-arm64@1.15.3:
+    resolution: {integrity: sha512-AXfeQn0CvcQ4cndlIshETx6jrAM45oeUrK8YeEY6oUZU/qzz0Id0CyvlEywxkWVC81Ajpd8TQQ1fW5yx6zQWkQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64@1.15.3:
+    resolution: {integrity: sha512-p68OeCz1ui+MZYG4wmfJGvcsAcFYb6Sl25H9TxWl+GkBgmNimIiRdnypK9nBGlqMZAcxngNPtnG3kEMNnvoJ2A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf@1.15.3:
+    resolution: {integrity: sha512-Nuj5iF4JteFgwrai97mUX+xUOl+rQRHqTvnvHMATL/l9xE6/TJfPBpd3hk/PVpClMXG3Uvk1MxUFOEzM1JrMYg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.15.3:
+    resolution: {integrity: sha512-2Nc/s8jE6mW2EjXWxO/lyQuLKShcmTrym2LRf5Ayp3ICEMX6HwFqB1EzDhwoMa2DcUgmnZIalesq2lG3krrUNw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl@1.15.3:
+    resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.15.3:
+    resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl@1.15.3:
+    resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.15.3:
+    resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc@1.15.3:
+    resolution: {integrity: sha512-B8UtogMzErUPDWUoKONSVBdsgKYd58rRyv2sHJWKOIMCHfZ22FVXICR4O/VwIYtlnZ7ahERcjayBHDlBZpR0aw==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.15.3:
+    resolution: {integrity: sha512-SpZKMR9QBTecHeqpzJdYEfgw30Oo8b/Xl6rjSzBt1g0ZsXyy60KLXrp6IagQyfTYqNYE/caDvwtF2FPn7pomog==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core@1.15.3:
+    resolution: {integrity: sha512-Qd8eBPkUFL4eAONgGjycZXj1jFCBW8Fd+xF0PzdTlBCWQIV1xnUT7B93wUANtW3KGjl3TRcOyxwSx/u/jyKw/Q==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.25
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.3
+      '@swc/core-darwin-x64': 1.15.3
+      '@swc/core-linux-arm-gnueabihf': 1.15.3
+      '@swc/core-linux-arm64-gnu': 1.15.3
+      '@swc/core-linux-arm64-musl': 1.15.3
+      '@swc/core-linux-x64-gnu': 1.15.3
+      '@swc/core-linux-x64-musl': 1.15.3
+      '@swc/core-win32-arm64-msvc': 1.15.3
+      '@swc/core-win32-ia32-msvc': 1.15.3
+      '@swc/core-win32-x64-msvc': 1.15.3
+    dev: true
+
+  /@swc/counter@0.1.3:
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+    dev: true
+
   /@swc/helpers@0.5.17:
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
     dependencies:
       tslib: 2.8.1
     dev: false
+
+  /@swc/types@0.1.25:
+    resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: true
 
   /@tanstack/react-virtual@3.13.12(react-dom@19.2.0)(react@19.2.0):
     resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
@@ -5150,10 +5278,10 @@ packages:
       '@types/serve-static': 1.15.8
     dev: true
 
-  /@types/generate-json-webpack-plugin@0.3.8(webpack-cli@6.0.1):
+  /@types/generate-json-webpack-plugin@0.3.8(@swc/core@1.15.3)(webpack-cli@6.0.1):
     resolution: {integrity: sha512-yArZZaSLvRa5T4884KxyiWMaTAxrDECk18LCzRa5ZhQuyvL6tgCz6Im6KSAIP7VbaZEkuhRQ0IZeRiv9XXqSQw==}
     dependencies:
-      '@types/webpack': 5.28.5(webpack-cli@6.0.1)
+      '@types/webpack': 5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -5373,12 +5501,12 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /@types/webpack@5.28.5(webpack-cli@6.0.1):
+  /@types/webpack@5.28.5(@swc/core@1.15.3)(webpack-cli@6.0.1):
     resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
     dependencies:
       '@types/node': 22.0.2
       tapable: 2.2.1
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -5814,7 +5942,7 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
     dev: true
 
@@ -5825,7 +5953,7 @@ packages:
       webpack: ^5.82.0
       webpack-cli: 6.x.x
     dependencies:
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
     dev: true
 
@@ -5840,7 +5968,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
       webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.103.0)
     dev: true
@@ -6328,7 +6456,7 @@ packages:
     dependencies:
       '@babel/core': 7.28.5
       find-up: 5.0.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /babel-plugin-istanbul@7.0.1:
@@ -6758,7 +6886,7 @@ packages:
       webpack: '>=4.0.0 <6.0.0'
     dependencies:
       del: 4.1.1
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /cli-boxes@3.0.0:
@@ -6929,7 +7057,7 @@ packages:
     dependencies:
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /compression@1.8.0:
@@ -7023,7 +7151,7 @@ packages:
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       tinyglobby: 0.2.14
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /core-js-compat@3.46.0:
@@ -7142,7 +7270,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.1
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /css-select@4.3.0:
@@ -8834,7 +8962,7 @@ packages:
       semver: 7.7.1
       tapable: 2.2.1
       typescript: 5.9.3
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /forwarded@0.2.0:
@@ -9339,7 +9467,7 @@ packages:
     dependencies:
       html-minifier-terser: 7.2.0
       parse5: 7.2.1
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /html-minifier-terser@6.1.0:
@@ -9392,7 +9520,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.3.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /htmlparser2@6.1.0:
@@ -11135,7 +11263,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       marked: 4.3.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /marked@17.0.1:
@@ -11280,7 +11408,7 @@ packages:
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /mini-svg-data-uri@1.4.4:
@@ -11952,7 +12080,7 @@ packages:
       fancy-log: 1.3.3
       human-size: 1.1.0
       postcss: 8.5.6
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-sources: 2.3.1
     dev: true
 
@@ -12045,7 +12173,7 @@ packages:
       jiti: 2.5.1
       postcss: 8.5.6
       semver: 7.7.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -13083,7 +13211,7 @@ packages:
     dependencies:
       neo-async: 2.6.2
       sass: 1.94.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /sass@1.94.2:
@@ -13477,7 +13605,7 @@ packages:
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /source-map-support@0.5.13:
@@ -13795,7 +13923,7 @@ packages:
     peerDependencies:
       webpack: ^5.27.0
     dependencies:
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /stylehacks@7.0.7(postcss@8.5.6):
@@ -14106,7 +14234,7 @@ packages:
       unique-string: 2.0.0
     dev: true
 
-  /terser-webpack-plugin@5.3.14(webpack@5.103.0):
+  /terser-webpack-plugin@5.3.14(@swc/core@1.15.3)(webpack@5.103.0):
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -14123,11 +14251,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
+      '@swc/core': 1.15.3
       jest-worker: 27.5.1
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       terser: 5.39.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /terser@5.39.0:
@@ -14365,7 +14494,7 @@ packages:
       semver: 7.7.2
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /ts-pattern@5.9.0:
@@ -14898,7 +15027,7 @@ packages:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.103.0)
       webpack-merge: 6.0.1
     dev: true
@@ -14918,7 +15047,7 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.3.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
     dev: true
 
   /webpack-dev-server@5.2.2(webpack-cli@6.0.1)(webpack@5.103.0):
@@ -14960,7 +15089,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
       webpack-dev-middleware: 7.4.2(webpack@5.103.0)
       ws: 8.18.2
@@ -15004,7 +15133,7 @@ packages:
     resolution: {integrity: sha512-yUKYyy+e0iF/w31QdfioRKY+h3jDBRpthexBOWGKda99iu2l/wxYsI/XqdlP5IU58/0KB9CsJZgWNAl+/MPkRw==}
     dev: true
 
-  /webpack@5.103.0(webpack-cli@6.0.1):
+  /webpack@5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1):
     resolution: {integrity: sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -15036,7 +15165,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(webpack@5.103.0)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.15.3)(webpack@5.103.0)
       watchpack: 2.4.4
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.103.0)
       webpack-sources: 3.3.3
@@ -15334,7 +15463,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.103.0(webpack-cli@6.0.1)
+      webpack: 5.103.0(@swc/core@1.15.3)(webpack-cli@6.0.1)
       webpack-sources: 1.4.3
       workbox-build: 7.4.0
     transitivePeerDependencies:


### PR DESCRIPTION
swc-minify is a Rust-based minifier that is somewhat faster than Terser. I verified that it also produces smaller output. This should result in faster build times, but could result in issues - I haven't exhaustively tested every page.