### PR TITLE
Show FOTL masks in organizer

### DIFF
--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -858,7 +858,11 @@ function getItemCategoryHashes(itemDef: DestinyInventoryItemDefinition): ItemCat
 
     // Masks are helmets too
     if (additionalICH === ItemCategoryHashes.Mask) {
-      itemCategoryHashes = [...itemCategoryHashes, ItemCategoryHashes.Helmets];
+      itemCategoryHashes = [
+        ...itemCategoryHashes,
+        ItemCategoryHashes.Helmets,
+        ItemCategoryHashes.Armor,
+      ];
     }
   }
 


### PR DESCRIPTION
Masks were being given the "Helmet" ICH, but not the "Armor" ICH which the Organizer was also using to filter.

Changelog: Festival masks will now show up in the Organizer.