### PR TITLE
Don't block on DIM API

### DIFF
--- a/src/app/dim-api/basic-actions.ts
+++ b/src/app/dim-api/basic-actions.ts
@@ -28,7 +28,7 @@ export const profileLoadError = createAction('dim-api/PROFILE_ERROR')<Error>();
 
 export type ProfileIndexedDBState = Pick<
   DimApiState,
-  'settings' | 'profiles' | 'itemHashTags' | 'searches' | 'updateQueue'
+  'settings' | 'profiles' | 'itemHashTags' | 'searches' | 'updateQueue' | 'globalSettings'
 >;
 export const profileLoadedFromIDB = createAction('dim-api/LOADED_PROFILE_FROM_IDB')<
   ProfileIndexedDBState | undefined

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -17,7 +17,7 @@ import { Dispatch } from 'redux';
 import { loadDimApiData } from './actions';
 import { profileLoadedFromIDB } from './basic-actions';
 import { importData } from './dim-api';
-import type { DimApiState } from './reducer';
+import { type DimApiState } from './reducer';
 import { makeProfileKey } from './selectors';
 
 const TAG = 'importData';
@@ -68,7 +68,7 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
 }
 
 function importBackupIntoLocalState(data: ExportResponse, silent = false): ThunkResult {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     const settings = data.settings;
     const loadouts = extractLoadouts(data);
     const tags = extractItemAnnotations(data);
@@ -152,6 +152,7 @@ function importBackupIntoLocalState(data: ExportResponse, silent = false): Thunk
         itemHashTags: keyBy(itemHashTags, (t) => t.hash),
         searches,
         updateQueue: [],
+        globalSettings: getState().dimApi.globalSettings,
       }),
     );
 

--- a/src/app/dim-api/reducer.ts
+++ b/src/app/dim-api/reducer.ts
@@ -222,6 +222,7 @@ export const dimApi = (
               ...state.searches,
               ...action.payload.searches,
             },
+            globalSettings: state.globalSettings,
           })
         : {
             ...state,


### PR DESCRIPTION
Fixes #11572

This should help in the case where the DIM API is down or slow - DIM will keep loading and get the live data in the background. This is how it always should have been, but not having the ability to change language reactively meant I had twisted things into knots trying to make sure we have the right language at load. That's no longer a constraint.

Changelog: DIM should load faster even when it is having trouble loading DIM API data.