### PR TITLE
Fix not being able to switch characters in LO

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -31,8 +31,10 @@ import { searchFilterSelector } from 'app/search/items/item-search-filter';
 import { useSetSetting } from 'app/settings/hooks';
 import { AppIcon, disabledIcon, redoIcon, refreshIcon, undoIcon } from 'app/shell/icons';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
+import { filterMap } from 'app/utils/collections';
 import { emptyObject } from 'app/utils/empty';
 import { isClassCompatible, itemCanBeEquippedBy } from 'app/utils/item-utils';
+import { errorLog } from 'app/utils/log';
 import { getMaxParallelCores } from 'app/utils/parallel-cores';
 import { timerDurationFromMs } from 'app/utils/time';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -306,7 +308,20 @@ export default memo(function LoadoutBuilder({
         statMods: processed.statMods,
       };
     }
-    return resultSets && sortGeneratedSets(resultSets.map(hydrateArmorSet), desiredStatRanges);
+    return (
+      resultSets &&
+      sortGeneratedSets(
+        filterMap(resultSets, (s) => {
+          try {
+            return hydrateArmorSet(s);
+          } catch (e) {
+            errorLog('loadout optimizer', 'Error hydrating armor set', e);
+            return undefined;
+          }
+        }),
+        desiredStatRanges,
+      )
+    );
   }, [desiredStatRanges, resultSets, armorItems]);
 
   useEffect(() => hideItemPicker(), [hideItemPicker, selectedStore.classType]);

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -74,7 +74,7 @@ export function useProcess({
   autoStatMods: boolean;
   strictUpgrades: boolean;
 }) {
-  const [{ result, processing, totalCombos, completedCombos, startTime }, setState] =
+  const [{ result, processing, totalCombos, completedCombos, startTime, resultStoreId }, setState] =
     useState<ProcessState>({
       processing: false,
       startTime: 0,
@@ -197,7 +197,13 @@ export function useProcess({
     firstTime,
   ]);
 
-  return { result, processing, startTime, totalCombos, completedCombos };
+  return {
+    result: resultStoreId === selectedStore.id ? result : null,
+    processing,
+    startTime,
+    totalCombos,
+    completedCombos,
+  };
 }
 
 /**


### PR DESCRIPTION
Not sure how long this has been broken, or how nobody noticed it, but we can't switch characters in LO because the old results can't be hydrated into the new set of items. This fixes that, and also the case where an item may have been deleted.

Changelog: Fix crash in loadout optimizer when changing characters.