### PR TITLE
engrams dont care about no stinking bucket

### DIFF
--- a/src/app/search/items/search-filters/known-values.ts
+++ b/src/app/search/items/search-filters/known-values.ts
@@ -198,6 +198,9 @@ export const itemTypeFilter = {
         break;
       }
     }
+    if (filterValue === 'engrams') {
+      return (item) => item.isEngram;
+    }
     return (item) => item.bucket.hash === bucketHash;
   },
   fromItem: (item) => `is:${bucketToType[item.bucket.hash as BucketHashes]}`,


### PR DESCRIPTION
Changelog: Tiered Engrams in postmaster will now match `is:engrams`
