### PR TITLE
Fix weapons csv download

### DIFF
--- a/src/app/inventory/spreadsheets.ts
+++ b/src/app/inventory/spreadsheets.ts
@@ -84,6 +84,8 @@ export const csvStatNamesForDestinyVersion = (destinyVersion: DestinyVersion) =>
     [StatHashes.ShieldDuration, 'Shield Duration'],
     [StatHashes.AirborneEffectiveness, 'Airborne Effectiveness'],
     [StatHashes.AmmoGeneration, 'Ammo Generation'],
+    [StatHashes.HeatGenerated, 'Heat Generated'],
+    [StatHashes.CoolingEfficiency, 'Cooling Efficiency'],
     [StatHashes.Weapons, destinyVersion === 2 ? 'Weapons' : 'Mobility'],
     [StatHashes.Health, destinyVersion === 2 ? 'Health' : 'Resilience'],
     [StatHashes.Class, destinyVersion === 2 ? 'Class' : 'Recovery'],


### PR DESCRIPTION
### Issue
Getting an 'Error: missing-column-order' when trying to download the weapons csv file.


### Fix
Added `HeatGenerated` & `CoolingEfficiency` to the csv stat names map.