### PR TITLE
Fix fake masterwork plug on crafted/enhanced items showing the number/border

### DIFF
--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -210,10 +210,13 @@ export const D2PlugCategoryByStatHash = new Map<StatHashes, PlugCategoryHashes>(
   [StatHashes.Impact, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDamage],
   [StatHashes.DrawTime, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatDrawTime],
   [StatHashes.Handling, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHandling],
+  [StatHashes.CoolingEfficiency, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatHeatEfficiency],
+  [StatHashes.Persistence, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatPersistence],
   [StatHashes.Range, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatRange],
   [StatHashes.ReloadSpeed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatReload],
   [StatHashes.Stability, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatStability],
   [StatHashes.Velocity, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatProjectileSpeed],
+  [StatHashes.VentSpeed, PlugCategoryHashes.V400PlugsWeaponsMasterworksStatVentSpeed],
   [StatHashes.ShieldDuration, PlugCategoryHashes.V600PlugsWeaponsMasterworksStatShieldDuration],
 ]);
 

--- a/src/app/utils/socket-utils.ts
+++ b/src/app/utils/socket-utils.ts
@@ -508,7 +508,7 @@ export function getWeaponSockets(
             ...fullMasterworkPlug.plugDef.displayProperties,
             iconHash: 0, // use legacy icon so we can remove the '10' on it
           },
-          iconWatermark: '', // remove the '10' in the top left of the icon
+          iconWatermark: '', // remove the '10' in the top right of the icon
           investmentStats: [], // remove the stats from the fake plug
         },
       };


### PR DESCRIPTION
Changelog: Fix the masterwork socket on crafted and enhanced weapons incorrectly showing a masterwork tier number

With the switch to iconDef, the presence of iconHash was causing the fake plug to show the number (mw level) and gold border where they shouldn't be shown (as in #10917 where we only want to show the mw stat icon in the fake socket)
Also updates the stat hash -> mw plug mapping for completeness (none of the items that have these MW stats are enhanceable)

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
<details>
<summary>Screenshots:</summary>

Bugged:
<img width="512" height="506" alt="Screenshot 2025-12-19 at 3 42 40 AM" src="https://github.com/user-attachments/assets/4dca852c-55da-488b-89c2-d9d6c05772fa" />

Fixed:
<img width="491" height="491" alt="Screenshot 2025-12-19 at 3 43 09 AM" src="https://github.com/user-attachments/assets/7bae2243-1508-4b1b-9dd6-18de5fc36850" />

Original impl from #10917:
<img width="525" alt="Screenshot 2025-01-29 at 5 49 45 AM" src="https://github.com/user-attachments/assets/c673db1d-a681-447b-9660-f34995ce6002" />

</details>
