### PR TITLE
Move crafting/kill tracker tooltip, show secondary kill trackers in tooltip

### DIFF
--- a/src/app/item-popup/WeaponCraftedInfo.tsx
+++ b/src/app/item-popup/WeaponCraftedInfo.tsx
@@ -1,9 +1,6 @@
-import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { DimItem } from 'app/inventory/item-types';
-import { getCraftedSocket } from 'app/inventory/store/crafted';
-import { KillTrackerInfo } from 'app/item-popup/KillTracker';
-import Objective, {
+import {
   ObjectiveDescription,
   ObjectiveProgress,
   ObjectiveProgressBar,
@@ -11,8 +8,6 @@ import Objective, {
 } from 'app/progress/Objective';
 import { percentWithSingleDecimal } from 'app/shell/formatters';
 import { AppIcon, enhancedIcon, shapedIcon } from 'app/shell/icons';
-import { filterMap } from 'app/utils/collections';
-import { isKillTrackerSocket, plugToKillTracker } from 'app/utils/item-utils';
 import * as styles from './WeaponCraftedInfo.m.scss';
 
 /**
@@ -42,39 +37,10 @@ export function WeaponCraftedInfo({ item, className }: { item: DimItem; classNam
 }
 
 function CraftedDataMedallion({ item }: { item: DimItem }) {
-  const killTrackers = filterMap(
-    item.sockets?.allSockets.find((s) => isKillTrackerSocket(s))?.plugOptions ?? [],
-    (p) => plugToKillTracker(p),
-  );
-  const shapedDateObjective = getCraftedSocket(item)?.plugged?.plugObjectives.find(
-    (o) => o.progress === item.craftedInfo?.craftedDate,
-  );
-
   return (
-    <PressTip
-      tooltip={
-        <>
-          {shapedDateObjective && (
-            <>
-              <Objective objective={shapedDateObjective} />
-              <hr />
-            </>
-          )}
-          {killTrackers.map((kt) => (
-            <KillTrackerInfo
-              key={kt?.trackerDef.hash}
-              tracker={kt}
-              showTextLabel
-              className="masterwork-progress"
-            />
-          ))}
-        </>
-      }
-    >
-      <AppIcon
-        className={styles.patternIcon}
-        icon={item.crafted === 'enhanced' ? enhancedIcon : shapedIcon}
-      />
-    </PressTip>
+    <AppIcon
+      className={styles.patternIcon}
+      icon={item.crafted === 'enhanced' ? enhancedIcon : shapedIcon}
+    />
   );
 }

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -49,7 +49,6 @@ import {
   getArmor3TuningStat,
   getItemCurrentKillTrackerInfo,
   getItemDamageShortName,
-  getItemKillTrackers,
   getItemYear,
   getMasterworkStatNames,
   getSpecialtySocketMetadata,
@@ -847,25 +846,11 @@ export function getColumns(
         },
         cell: (_val, item) => {
           const killTrackerInfo = getItemCurrentKillTrackerInfo(item);
-          const killTrackers = getItemKillTrackers(item);
+          // TODO add additional kill trackers to display if present
           return (
-            <>
-              {killTrackerInfo && (
-                <KillTrackerInfo tracker={killTrackerInfo} className={styles.locationCell} />
-              )}
-              {killTrackers &&
-                killTrackers.length > 1 &&
-                killTrackers.map((kt) => (
-                  <>
-                    <KillTrackerInfo
-                      tracker={kt}
-                      key={kt.trackerDef.hash}
-                      className={clsx(styles.locationCell)}
-                    />
-                    <br />
-                  </>
-                ))}
-            </>
+            killTrackerInfo && (
+              <KillTrackerInfo tracker={killTrackerInfo} className={styles.locationCell} />
+            )
           );
         },
         defaultSort: SortDirection.DESC,

--- a/src/app/organizer/Columns.tsx
+++ b/src/app/organizer/Columns.tsx
@@ -47,8 +47,9 @@ import { Comparator, compareBy, primitiveComparator } from 'app/utils/comparator
 import {
   getArmor3StatFocus,
   getArmor3TuningStat,
+  getItemCurrentKillTrackerInfo,
   getItemDamageShortName,
-  getItemKillTrackerInfo,
+  getItemKillTrackers,
   getItemYear,
   getMasterworkStatNames,
   getSpecialtySocketMetadata,
@@ -841,15 +842,30 @@ export function getColumns(
         id: 'killTracker',
         header: t('Organizer.Columns.KillTracker'),
         value: (item) => {
-          const killTrackerInfo = getItemKillTrackerInfo(item);
+          const killTrackerInfo = getItemCurrentKillTrackerInfo(item);
           return killTrackerInfo?.count;
         },
         cell: (_val, item) => {
-          const killTrackerInfo = getItemKillTrackerInfo(item);
+          const killTrackerInfo = getItemCurrentKillTrackerInfo(item);
+          const killTrackers = getItemKillTrackers(item);
           return (
-            killTrackerInfo && (
-              <KillTrackerInfo tracker={killTrackerInfo} className={styles.locationCell} />
-            )
+            <>
+              {killTrackerInfo && (
+                <KillTrackerInfo tracker={killTrackerInfo} className={styles.locationCell} />
+              )}
+              {killTrackers &&
+                killTrackers.length > 1 &&
+                killTrackers.map((kt) => (
+                  <>
+                    <KillTrackerInfo
+                      tracker={kt}
+                      key={kt.trackerDef.hash}
+                      className={clsx(styles.locationCell)}
+                    />
+                    <br />
+                  </>
+                ))}
+            </>
           );
         },
         defaultSort: SortDirection.DESC,

--- a/src/app/search/items/search-filters/range-numeric.ts
+++ b/src/app/search/items/search-filters/range-numeric.ts
@@ -1,5 +1,5 @@
 import { tl } from 'app/i18next-t';
-import { getItemKillTrackerInfo, getItemYear } from 'app/utils/item-utils';
+import { getItemCurrentKillTrackerInfo, getItemYear } from 'app/utils/item-utils';
 import { ItemFilterDefinition } from '../item-filter-types';
 
 const simpleRangeFilters: ItemFilterDefinition[] = [
@@ -41,7 +41,7 @@ const simpleRangeFilters: ItemFilterDefinition[] = [
     filter:
       ({ filterValue, compare }) =>
       (item) => {
-        const killTrackerInfo = getItemKillTrackerInfo(item);
+        const killTrackerInfo = getItemCurrentKillTrackerInfo(item);
         return Boolean(
           killTrackerInfo &&
           (!filterValue.length || filterValue === killTrackerInfo.type) &&

--- a/src/app/utils/item-utils.ts
+++ b/src/app/utils/item-utils.ts
@@ -34,7 +34,7 @@ import {
   PlugCategoryHashes,
   StatHashes,
 } from 'data/d2/generated-enums';
-import { objectifyArray } from './collections';
+import { filterMap, objectifyArray } from './collections';
 import { getArmor3TuningSocket } from './socket-utils';
 
 // damage is a mess!
@@ -215,8 +215,13 @@ export function plugToKillTracker(killTrackerPlug: DimPlug) {
 }
 
 /** returns an item's kill tracker info */
-export const getItemKillTrackerInfo = (item: DimItem): KillTracker | null | undefined =>
+export const getItemCurrentKillTrackerInfo = (item: DimItem): KillTracker | null | undefined =>
   getSocketKillTrackerInfo(getKillTrackerSocket(item));
+
+export const getItemKillTrackers = (item: DimItem): KillTracker[] =>
+  filterMap(item.sockets?.allSockets.find((s) => isKillTrackerSocket(s))?.plugOptions ?? [], (p) =>
+    plugToKillTracker(p),
+  );
 
 const d1YearSourceHashes = {
   //         tTK       Variks        CoE         FoTL    Kings Fall


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Display all secondary kill trackers on a weapon's kill tracker tooltip, if available

<details>
<summary>Screenshots</summary>

<img width="350" height="auto" alt="image" src="https://github.com/user-attachments/assets/5e4a9e84-847c-4f47-95c8-cc3f3082f214" />
<img width="328" height="243" alt="Screenshot 2026-01-19 at 5 39 38 AM" src="https://github.com/user-attachments/assets/eb84ace6-2b3a-4267-9b3c-d98126895752" />
<img width="331" height="260" alt="Screenshot 2026-01-19 at 5 45 03 AM" src="https://github.com/user-attachments/assets/eaa978b5-bae5-499d-b9d8-33fe5971966d" />
<img width="340" height="360" alt="Screenshot 2026-01-19 at 5 45 25 AM" src="https://github.com/user-attachments/assets/b67b21d0-fe2a-4a1b-9428-5b41d7e902d8" />


</details>