### PR TITLE
Upgrade to pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@bundle-stats/plugin-webpack-filter": "^4.21.8",
     "@eslint-react/eslint-plugin": "^2.7.4",
     "@eslint/compat": "^2.0.1",
+    "@eslint/js": "^9.39.2",
     "@rspack/cli": "^1.7.3",
     "@rspack/core": "^1.7.3",
     "@rspack/plugin-react-refresh": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@eslint/compat':
         specifier: ^2.0.1
         version: 2.0.2(eslint@9.39.2)
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
       '@rspack/cli':
         specifier: ^1.7.3
         version: 1.7.4(@rspack/core@1.7.4(@swc/helpers@0.5.18))(@types/express@4.17.25)(tslib@2.8.1)(webpack@5.104.1)


### PR DESCRIPTION
This upgrades to pnpm 10, which among other things has protections against supply chain attacks that leverage npm install scripts.

Note: You may need to upgrade corepack in order to install this: `npm install -g corepack@latest`