### PR TITLE
remove unsafe non-null assertion in Links.tsx

### DIFF
--- a/src/app/armory/Links.tsx
+++ b/src/app/armory/Links.tsx
@@ -136,7 +136,7 @@ function getWeaponSocketInfo(item: DimItem): null | {
     const weaponModSocket = item.sockets.allSockets.find((s) =>
       s.plugged?.plugDef.itemCategoryHashes?.includes(ItemCategoryHashes.WeaponModsDamage),
     );
-    const weaponMod = weaponModSocket?.plugged!.plugDef.hash ?? 0;
+    const weaponMod = weaponModSocket?.plugged?.plugDef.hash ?? 0;
 
     const trackerSocket = item.sockets.allSockets.find(isKillTrackerSocket);
     const largePerks = getSocketsWithStyle(item.sockets, DestinySocketCategoryStyle.LargePerk)


### PR DESCRIPTION
replace non null assertion with optional chaining to align with nearby pattern and improve null safety. No behavior change.
