### PR TITLE
handle unhandled promise in retry logic

### DIFF
--- a/src/app/dim-api/actions.ts
+++ b/src/app/dim-api/actions.ts
@@ -289,7 +289,9 @@ export function loadDimApiData(
         infoLog(TAG, 'Waiting', waitTime, 'ms before re-attempting profile fetch');
 
         // Wait, then retry. We don't await this here so we don't stop the finally block from running
-        delay(waitTime).then(() => dispatch(loadDimApiData(options)));
+        delay(waitTime)
+          .then(() => dispatch(loadDimApiData(options)))
+          .catch((e) => errorLog(TAG, 'Retry failed', e));
       }
     }
 

--- a/src/app/dim-api/import.ts
+++ b/src/app/dim-api/import.ts
@@ -49,7 +49,9 @@ export function importDataBackup(data: ExportResponse, silent = false): ThunkRes
         // dim-api can cache the data for up to 60 seconds. Reload from the
         // server after that so we don't use our faked import data too long. We
         // won't wait for this.
-        delay(60_000).then(() => dispatch(loadDimApiData({ forceLoad: true })));
+        delay(60_000)
+          .then(() => dispatch(loadDimApiData({ forceLoad: true })))
+          .catch((e) => errorLog(TAG, 'Retry failed', e));
         infoLog(TAG, 'Successfully imported data into DIM API', result);
         showImportSuccessNotification(result, true);
         return;


### PR DESCRIPTION
Add catch handler to retry delay promise to prevent potential unhandled promise rejections. No change to retry behavior.