### PR TITLE
Add: Display Milestone quest steps in the Progress tab

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -11,7 +11,7 @@ import { t } from 'app/i18next-t';
 import ItemIcon, { DefItemIcon } from 'app/inventory/ItemIcon';
 import { DimItem } from 'app/inventory/item-types';
 import { allItemsSelector, createItemContextSelector } from 'app/inventory/selectors';
-import { makeFakeItem } from 'app/inventory/store/d2-item-factory';
+import { getQuestLineInfo, makeFakeItem } from 'app/inventory/store/d2-item-factory';
 import {
   SocketOverrides,
   applySocketOverrides,
@@ -236,6 +236,7 @@ export default function Armory({
           <div className={styles.list}>
             {alternates.map((alternate) => {
               const altSeasonNum = getSeason(alternate);
+              const questLine = getQuestLineInfo(alternate);
               return (
                 <div key={alternate.hash} className={styles.alternate}>
                   <button
@@ -247,6 +248,14 @@ export default function Armory({
                   </button>
                   <div>
                     <b>{alternate.displayProperties.name}</b>
+                    {questLine && (
+                      <div>
+                        {t('MovePopup.Subtitle.QuestProgress', {
+                          questStepNum: questLine.questStepNum,
+                          questStepsTotal: questLine.questStepsTotal ?? '?',
+                        })}
+                      </div>
+                    )}
                     {altSeasonNum >= 0 && (
                       <SeasonInfo defs={defs} item={alternate} seasonNum={altSeasonNum} />
                     )}
@@ -323,7 +332,9 @@ function getAlternateItems(
 
   alternates.sort(
     chainComparator(
-      reverseComparator(compareBy((i) => getSeason(i, defs) ?? 0)),
+      reverseComparator(
+        compareBy((i) => getQuestLineInfo(i)?.questStepNum ?? getSeason(i, defs) ?? 0),
+      ),
       compareBy((i) => i.displayProperties.name),
     ),
   );

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -791,7 +791,9 @@ function isLegendaryOrBetter(item: DimItem) {
   return item.rarity === 'Legendary' || item.rarity === 'Exotic';
 }
 
-function getQuestLineInfo(itemDef: DestinyInventoryItemDefinition): DimQuestLine | undefined {
+export function getQuestLineInfo(
+  itemDef: DestinyInventoryItemDefinition,
+): DimQuestLine | undefined {
   if (itemDef.inventory?.bucketTypeHash === BucketHashes.Quests && itemDef.setData?.itemList) {
     const thisStepIndex = itemDef.setData.itemList.findIndex((i) => i.itemHash === itemDef.hash);
     if (thisStepIndex !== -1) {

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -5,6 +5,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { DimStore } from 'app/inventory/store-types';
 import { findItemsByBucket } from 'app/inventory/stores-helpers';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { MILESTONE_QUEST_BUCKET } from 'app/search/d2-known-values';
 import { chainComparator, compareBy } from 'app/utils/comparators';
 import { BucketHashes, ItemCategoryHashes } from 'data/d2/generated-enums';
 import pursuitsInfoFile from 'data/d2/pursuits.json';
@@ -39,7 +40,9 @@ export default function Pursuits({ store }: { store: DimStore }) {
   // Get all items in this character's inventory that represent quests - some are actual items that take
   // up inventory space, others are in the "Progress" bucket and need to be separated from the quest items
   // that represent milestones.
-  const pursuits = Object.groupBy(findItemsByBucket(store, BucketHashes.Quests), (item) => {
+  const milestoneQuests = findItemsByBucket(store, MILESTONE_QUEST_BUCKET);
+  const quests = findItemsByBucket(store, BucketHashes.Quests);
+  const pursuits = Object.groupBy([...milestoneQuests, ...quests], (item) => {
     const itemDef = defs.InventoryItem.get(item.hash);
     if (!item.objectives || item.objectives.length === 0 || item.sockets) {
       return 'Items';

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -297,6 +297,12 @@ export const uniqueEquipBuckets = [
   BucketHashes.Finishers,
 ];
 
+/**
+ * Bucket for what appears to be milestone quest steps
+ * Matches the D1 quest bucket hash
+ */
+export const MILESTONE_QUEST_BUCKET = 1801258597;
+
 //
 // PRESENTATION NODE KNOWN VALUES
 //


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Add Territorial Profit quest and other milestone-based quest steps to Progress tab

Note that this also adds the Purification quest step here (it already exists in the Milestone section). That may need to be handled as its own special case.
<img width="1473" height="349" alt="Screenshot 2026-02-25 at 6 45 48 PM" src="https://github.com/user-attachments/assets/6cf3a3a9-32c5-4a03-a8c6-08ca32af651d" />
