### PR TITLE
feat: Add keyboard shortcut (d) to toggle farming mode

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -446,6 +446,7 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "Enter": "ENTER",
+    "FarmingMode": "Toggle farming mode",
     "ItemPopupTab": "Switch item details tab",
     "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+* Added keyboard shortcut (d) to toggle farming mode on/off for the most recently played character.
+
 ## 8.114.0 <span class="changelog-date">(2026-03-01)</span>
 
 ## 8.113.0 <span class="changelog-date">(2026-02-22)</span>

--- a/src/app/farming/Farming.tsx
+++ b/src/app/farming/Farming.tsx
@@ -1,11 +1,14 @@
 import { settingSelector } from 'app/dim-api/selectors';
+import { useHotkey } from 'app/hotkeys/useHotkey';
 import { t } from 'app/i18next-t';
+import { storesSelector } from 'app/inventory/selectors';
+import { getCurrentStore } from 'app/inventory/stores-helpers';
 import { useSetting } from 'app/settings/hooks';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { AnimatePresence, Transition, Variants, motion } from 'motion/react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { stopFarming } from './actions';
+import { startFarming, stopFarming } from './actions';
 import * as styles from './Farming.m.scss';
 import { farmingStoreSelector } from './selectors';
 
@@ -18,8 +21,22 @@ const animateTransition: Transition<number> = { type: 'spring', duration: 0.3, b
 export default function Farming() {
   const dispatch = useThunkDispatch();
   const store = useSelector(farmingStoreSelector);
+  const stores = useSelector(storesSelector);
   const [makeRoomForItems, setMakeRoomForItems] = useSetting('farmingMakeRoomForItems');
   const inventoryClearSpaces = useSelector(settingSelector('inventoryClearSpaces'));
+
+  const toggleFarming = useCallback(() => {
+    if (store) {
+      dispatch(stopFarming());
+    } else {
+      const currentStore = getCurrentStore(stores);
+      if (currentStore) {
+        dispatch(startFarming(currentStore.id));
+      }
+    }
+  }, [dispatch, store, stores]);
+
+  useHotkey('d', t('Hotkey.FarmingMode'), toggleFarming);
 
   const makeRoomForItemsChanged = (e: React.ChangeEvent<HTMLInputElement>) =>
     setMakeRoomForItems(e.currentTarget.checked);

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -434,6 +434,7 @@
     "ClearDialog": "Dismiss dialog",
     "ClearNewItems": "Clear new items",
     "Enter": "ENTER",
+    "FarmingMode": "Toggle farming mode",
     "ItemPopupTab": "Switch item details tab",
     "LockUnlock": "Lock or unlock an item",
     "MarkItemAs": "Mark item as '{{tag}}'",


### PR DESCRIPTION
Fixes #11396

Adds a global keyboard shortcut d to toggle farming mode on/off. When pressed:

If farming is inactive: starts farming for the most recently played character
If farming is active: stops farming
The shortcut appears automatically in the ? hotkey cheat sheet. It follows the same pattern as all other existing hotkeys ([useHotkey](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook) and is blocked inside text inputs per standard DIM behavior.
