### PR TITLE
Remove legacy destinytracker and banshee-44 URL support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+* Add support for importing wish lists in Little Light JSON format.
+* Improved wish list matching to correctly handle multiple perk combinations (Cartesian product) from imported lists.
+
 ## 8.115.0 <span class="changelog-date">(2026-03-08)</span>
 
 ## 8.114.0 <span class="changelog-date">(2026-03-01)</span>

--- a/src/app/compare/compare-buttons.tsx
+++ b/src/app/compare/compare-buttons.tsx
@@ -71,7 +71,6 @@ export function findSimilarArmors(exampleItem: DimItem): CompareButton[] {
             <BungieImage key="1" src={intrinsic.icon} />,
             intrinsic.name,
             exampleItem.rarity === 'Legendary' ? (
-              // eslint-disable-next-line @eslint-react/no-duplicate-key
               <BungieImage key="rarity" src={rarityIcons.Legendary} className="dontInvert" />
             ) : null,
             <ArmorSlotIcon key="slot" item={exampleItem} className={styles.svgIcon} />,

--- a/src/app/wishlists/types.ts
+++ b/src/app/wishlists/types.ts
@@ -4,8 +4,7 @@ export const enum DimWishList {
 
 /**
  * Interface for translating lists of wish list rolls to a format we can use.
- * Initially, support for translating banshee-44.com -> this has been built,
- * but this is here so that we can plug in support for anyone else that can
+ * This is here so that we can plug in support for anyone that can
  * get us this information.
  */
 export interface WishListRoll {
@@ -21,8 +20,6 @@ export interface WishListRoll {
   recommendedPerks: Set<number>;
   /**
    * Is this an expert mode recommendation?
-   * With B-44 rolls, we make sure that most every perk asked for exists
-   * on the item. (It does discard masterwork and some other odds and ends).
    * With expert rolls, you can be as vague or specific as you want, so we make
    * sure that at least every perk asked for is there.
    */

--- a/src/app/wishlists/wishlist-file.test.ts
+++ b/src/app/wishlists/wishlist-file.test.ts
@@ -1,50 +1,62 @@
 import { WishListRoll } from './types';
 import { toWishList } from './wishlist-file';
 
-const cases: [wishlist: string, result: WishListRoll][] = [
+const cases: [wishlist: string, results: WishListRoll[]][] = [
   [
     'dimwishlist:item=-69420&perks=2682205016,2402480669#notes:Enh Over, Enh FocuFury',
-    {
-      itemHash: -69420,
-      recommendedPerks: new Set([2682205016, 2402480669]),
-      notes: 'Enh Over, Enh FocuFury',
-      isExpertMode: true,
-      isUndesirable: false,
-      description: undefined,
-      sourceWishListIndex: 0,
-      title: undefined,
-    },
+    [
+      {
+        itemHash: -69420,
+        recommendedPerks: new Set([2682205016, 2402480669]),
+        notes: 'Enh Over, Enh FocuFury',
+        isExpertMode: true,
+        isUndesirable: false,
+        description: undefined,
+        sourceWishListIndex: 0,
+        title: undefined,
+      },
+    ],
   ],
   [
-    `
-//notes:Example1 with\\nline break working
-dimwishlist:item=-69420&perks=2682205016,2402480669`,
-    {
-      itemHash: -69420,
-      recommendedPerks: new Set([2682205016, 2402480669]),
-      notes: 'Example1 with\nline break working',
-      isExpertMode: true,
-      isUndesirable: false,
-      description: undefined,
-      sourceWishListIndex: 0,
-      title: undefined,
-    },
-  ],
-  [
-    `dimwishlist:item=-69420&perks=2682205016,2402480669#notes:Example2 with\\nline break working`,
-    {
-      itemHash: -69420,
-      recommendedPerks: new Set([2682205016, 2402480669]),
-      notes: 'Example2 with\nline break working',
-      isExpertMode: true,
-      isUndesirable: false,
-      description: undefined,
-      sourceWishListIndex: 0,
-      title: undefined,
-    },
+    JSON.stringify({
+      name: "Aegis's endgame rolls and rankings",
+      description: "Recommendations from Aegis's endgame analysis spreadsheet.",
+      data: [
+        {
+          hash: 4164201232,
+          plugs: [[29505215], [3400784728], [3523296417, 2610012052]],
+          tags: ['PVE'],
+          description: 'F-Tier\nTT but no usable damage perk',
+        },
+      ],
+    }),
+    [
+      {
+        itemHash: 4164201232,
+        recommendedPerks: new Set([3400784728, 3523296417]),
+        notes: 'Tags: PVE | Notes: F-Tier\nTT but no usable damage perk',
+        isExpertMode: true,
+        description: "Recommendations from Aegis's endgame analysis spreadsheet.",
+        sourceWishListIndex: 0,
+        title: "Aegis's endgame rolls and rankings",
+      },
+      {
+        itemHash: 4164201232,
+        recommendedPerks: new Set([3400784728, 2610012052]),
+        notes: 'Tags: PVE | Notes: F-Tier\nTT but no usable damage perk',
+        isExpertMode: true,
+        description: "Recommendations from Aegis's endgame analysis spreadsheet.",
+        sourceWishListIndex: 0,
+        title: "Aegis's endgame rolls and rankings",
+      },
+    ],
   ],
 ];
 
-test.each(cases)('parse wishlist line: %s', (wishlist, result) => {
-  expect(toWishList([[undefined, wishlist]]).wishListRolls[0]).toStrictEqual(result);
+test.each(cases)('parse wishlist line: %s', (wishlist, results) => {
+  const parsed = toWishList([[undefined, wishlist]]).wishListRolls;
+  expect(parsed).toHaveLength(results.length);
+  for (const [i, expected] of results.entries()) {
+    expect(parsed[i]).toStrictEqual(expected);
+  }
 });

--- a/src/app/wishlists/wishlist-file.test.ts
+++ b/src/app/wishlists/wishlist-file.test.ts
@@ -53,10 +53,24 @@ const cases: [wishlist: string, results: WishListRoll[]][] = [
   ],
 ];
 
-test.each(cases)('parse wishlist line: %s', (wishlist, results) => {
-  const parsed = toWishList([[undefined, wishlist]]).wishListRolls;
-  expect(parsed).toHaveLength(results.length);
-  for (const [i, expected] of results.entries()) {
-    expect(parsed[i]).toStrictEqual(expected);
-  }
+describe('toWishList', () => {
+  test.each(cases)('parse wishlist line: %s', (wishlist, results) => {
+    const parsed = toWishList([[undefined, wishlist]]).wishListRolls;
+    expect(parsed).toHaveLength(results.length);
+    for (const [i, expected] of results.entries()) {
+      expect(parsed[i]).toStrictEqual(expected);
+    }
+  });
+
+  test('does not parse destinytracker URLs', () => {
+    const dtrUrl = 'https://destinytracker.com/destiny-2/db/items/12345?perks=1,2,3#notes:test';
+    const result = toWishList([[undefined, dtrUrl]]);
+    expect(result.wishListRolls).toHaveLength(0);
+  });
+
+  test('does not parse banshee-44 URLs', () => {
+    const bansheeUrl = 'https://banshee-44.com/?weapon=12345&socketEntries=1,2,3#notes:test';
+    const result = toWishList([[undefined, bansheeUrl]]);
+    expect(result.wishListRolls).toHaveLength(0);
+  });
 });

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -20,6 +20,25 @@ const descriptionLabel = /^@?description:(.+)$/;
 const notesLabel = '//notes:';
 
 /**
+ * Little Light uses this hash to mean "Any Perk" in a slot.
+ */
+const LITTLE_LIGHT_ANY_PERK = 29505215;
+
+export interface LittleLightRoll {
+  hash: number;
+  plugs: number[][];
+  tags?: string[];
+  description?: string;
+  name?: string;
+}
+
+export interface LittleLightWishList {
+  name?: string;
+  description?: string;
+  data: LittleLightRoll[];
+}
+
+/**
  * Extracts rolls, title, and description from the meat of
  * one or more wish list text files, deduplicating within
  * and between lists.
@@ -42,6 +61,46 @@ export function toWishList(files: [url: string | undefined, contents: string][])
         numRolls: 0,
         dupeRolls: 0,
       };
+
+      const trimmedText = fileText.trim();
+      if (trimmedText.startsWith('{') || trimmedText.startsWith('[')) {
+        try {
+          const json = JSON.parse(trimmedText) as LittleLightWishList;
+          if (json.data && Array.isArray(json.data)) {
+            info.title = json.name;
+            info.description = json.description;
+
+            for (const llRoll of json.data) {
+              const rolls = parseLittleLightWishListRoll(llRoll);
+              for (const roll of rolls) {
+                const rollHash = `${roll.itemHash};${roll.isExpertMode};${sortedSetToString(
+                  roll.recommendedPerks,
+                )}`;
+
+                if (!seen.has(rollHash)) {
+                  seen.add(rollHash);
+                  wishList.wishListRolls.push(roll);
+                  info.numRolls++;
+                } else {
+                  info.dupeRolls++;
+                }
+                roll.sourceWishListIndex = wishList.infos.length;
+                roll.title = info.title;
+                roll.description = info.description;
+              }
+            }
+
+            if (info.dupeRolls > 0) {
+              warnLog(TAG, 'Discarded', info.dupeRolls, 'duplicate rolls from wish list', url);
+            }
+            wishList.infos.push(info);
+            continue;
+          }
+        } catch (e) {
+          warnLog(TAG, 'Failed to parse wishlist as JSON', e);
+        }
+      }
+
       let blockNotes: string | undefined = undefined;
       let title: string | undefined = undefined;
       let description: string | undefined = undefined;
@@ -98,6 +157,64 @@ export function toWishList(files: [url: string | undefined, contents: string][])
   }
 }
 
+/**
+ * Little Light wish lists specify rolls as a list of columns, each containing a list of perks.
+ * To match DIM's current engine, we must expand these into all possible combinations
+ * and treat them as "expert" rolls (where all specified perks must be present).
+ */
+function parseLittleLightWishListRoll(llRoll: LittleLightRoll): WishListRoll[] {
+  if (!llRoll.hash || !llRoll.plugs || llRoll.plugs.length === 0) {
+    return [];
+  }
+
+  // Filter out empty columns, non-positive perk hashes, and the Little Light "Any" placeholder
+  const columns = llRoll.plugs
+    .map((column) =>
+      column.filter((perkHash) => perkHash > 0 && perkHash !== LITTLE_LIGHT_ANY_PERK),
+    )
+    .filter((column) => column.length > 0);
+
+  if (columns.length === 0) {
+    return [];
+  }
+
+  const notesParts: string[] = [];
+  if (llRoll.tags && llRoll.tags.length > 0) {
+    notesParts.push(`Tags: ${llRoll.tags.join(', ')}`);
+  }
+  if (llRoll.name) {
+    notesParts.push(`Name: ${llRoll.name}`);
+  }
+  if (llRoll.description) {
+    notesParts.push(`Notes: ${llRoll.description}`);
+  }
+  const notes = notesParts.length > 0 ? notesParts.join(' | ') : undefined;
+
+  // Generate Cartesian product of all columns
+  let combinations: number[][] = [[]];
+  for (const column of columns) {
+    const nextCombinations: number[][] = [];
+    for (const combination of combinations) {
+      for (const perkHash of column) {
+        nextCombinations.push([...combination, perkHash]);
+      }
+    }
+    combinations = nextCombinations;
+
+    // Safety break to prevent exponential explosion if a list is crazy
+    if (combinations.length > 500) {
+      break;
+    }
+  }
+
+  return combinations.map((perks) => ({
+    itemHash: llRoll.hash,
+    recommendedPerks: new Set(perks),
+    isExpertMode: true,
+    notes,
+  }));
+}
+
 function expectedMatchResultsLength(matchResults: RegExpMatchArray): boolean {
   return matchResults.length === 4;
 }
@@ -120,7 +237,7 @@ function getPerks(matchResults: RegExpMatchArray): Set<number> {
   const s = new Set<number>();
   for (const perkHash of split) {
     const n = Number(perkHash);
-    if (n > 0) {
+    if (n > 0 && n !== LITTLE_LIGHT_ANY_PERK) {
       s.add(n);
     }
   }

--- a/src/app/wishlists/wishlist-file.ts
+++ b/src/app/wishlists/wishlist-file.ts
@@ -123,10 +123,7 @@ export function toWishList(files: [url: string | undefined, contents: string][])
             info.description = description;
           }
         } else {
-          const roll =
-            toDimWishListRoll(line, blockNotes) ||
-            toBansheeWishListRoll(line, blockNotes) ||
-            toDtrWishListRoll(line, blockNotes);
+          const roll = toDimWishListRoll(line, blockNotes);
 
           if (roll) {
             const rollHash = `${roll.itemHash};${roll.isExpertMode};${sortedSetToString(
@@ -259,50 +256,6 @@ function getItemHash(matchResults: RegExpMatchArray): number {
   }
 
   return Number(matchResults.groups.itemHash);
-}
-
-const dtrTextLineRegex =
-  /^https:\/\/destinytracker\.com\/destiny-2\/db\/items\/(?<itemHash>\d+)\D*perks=(?<itemPerks>[\d,]*)(?:#notes:)?(?<wishListNotes>[^|]*)/;
-function toDtrWishListRoll(dtrTextLine: string, blockNotes?: string): WishListRoll | null {
-  const matchResults = dtrTextLineRegex.exec(dtrTextLine);
-
-  if (!matchResults || !expectedMatchResultsLength(matchResults)) {
-    return null;
-  }
-
-  const itemHash = getItemHash(matchResults);
-  const recommendedPerks = getPerks(matchResults);
-  const notes = getNotes(matchResults, blockNotes);
-
-  return {
-    itemHash,
-    recommendedPerks,
-    isExpertMode: false,
-    notes,
-  };
-}
-
-const bansheeTextLineRegex =
-  /^https:\/\/banshee-44\.com\/\?weapon=(?<itemHash>\d.+)&socketEntries=(?<itemPerks>[\d,]*)(?:#notes:)?(?<wishListNotes>[^|]*)/;
-
-/** Translate a single banshee-44.com URL -> WishListRoll. */
-function toBansheeWishListRoll(bansheeTextLine: string, blockNotes?: string): WishListRoll | null {
-  const matchResults = bansheeTextLineRegex.exec(bansheeTextLine);
-
-  if (!matchResults || !expectedMatchResultsLength(matchResults)) {
-    return null;
-  }
-
-  const itemHash = getItemHash(matchResults);
-  const recommendedPerks = getPerks(matchResults);
-  const notes = getNotes(matchResults, blockNotes);
-
-  return {
-    itemHash,
-    recommendedPerks,
-    isExpertMode: false,
-    notes,
-  };
 }
 
 const textLineRegex =


### PR DESCRIPTION
This PR removes support for parsing legacy destinytracker.com and banshee-44.com URLs in wishlists. These formats are outdated and no longer used in favor of the 'dimwishlist:' format and the recently added Little Light JSON format.

Changes:
- Removed 	oDtrWishListRoll and 	oBansheeWishListRoll from wishlist-file.ts.
- Cleaned up regexes and helper functions in wishlist-file.ts.
- Updated comments in 	ypes.ts.
- Added negative test cases to wishlist-file.test.ts to ensure these URLs are no longer parsed.

This addresses the removal of  destinytracker and banshee-44 URL support from wishlist mentioned in https://github.com/DestinyItemManager/DIM/issues/10313.