### PR TITLE
Ignore pointerenter events with type touch

### DIFF
--- a/src/app/dim-ui/PressTip.tsx
+++ b/src/app/dim-ui/PressTip.tsx
@@ -319,8 +319,16 @@ export function PressTip(props: Props) {
 
   // Fires on both pointerenter and pointerdown - does double duty for handling both hover tips and press tips
   const hover = useCallback((e: React.PointerEvent) => {
-    if (e.type === 'pointerenter' && e.buttons !== 0) {
+    if (
+      e.type === 'pointerenter' &&
       // Ignore hover events when the mouse is down
+      (e.buttons !== 0 ||
+        // Safari on iOS 26+ fires pointerenter with type 'touch' sometimes
+        // when showing elements. This causes PressTips to be shown initially
+        // and get stuck open, and pointereenter doesn't make much sense for
+        // touch anyway.
+        e.pointerType === 'touch')
+    ) {
       return;
     }
     e.preventDefault();


### PR DESCRIPTION
Changelog: Fixed tooltips showing unnecessarily due to a bug in iOS 26.

Fixes https://github.com/DestinyItemManager/DIM/issues/11687