### PR TITLE
Fix: new armor masterwork socket not displaying correctly

### DIFF
--- a/src/app/inventory/ItemIcon.tsx
+++ b/src/app/inventory/ItemIcon.tsx
@@ -261,7 +261,9 @@ export function DefItemIcon({
     itemDef.plug && strandWrongColorPlugCategoryHashes.includes(itemDef.plug.plugCategoryHash);
 
   const isMasterworkMod =
-    isPluggableItem(itemDef) && itemDef.plug.plugCategoryIdentifier.includes('.masterworks.stat.');
+    isPluggableItem(itemDef) &&
+    (itemDef.plug.plugCategoryIdentifier.includes('.masterworks.stat.') ||
+      itemDef.itemCategoryHashes?.includes(ItemCategoryHashes.MasterworksMods));
 
   const itemImageStyles = clsx(
     'item-img',


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Fix masterwork socket on newer armor not displaying correctly

<details>
<summary>Screenshots</summary>

Old:
<img width="310" height="206" alt="Screenshot 2026-05-07 at 10 17 13 PM" src="https://github.com/user-attachments/assets/a44915fd-8637-496a-a527-9c40900cb520" />

New:
<img width="310" height="195" alt="Screenshot 2026-05-07 at 10 16 25 PM" src="https://github.com/user-attachments/assets/a1b5ccc6-01f2-4a24-a022-33936745d8ed" />


</details>