### PR TITLE
Fix: Lore book titles not aligned properly on Records page

### DIFF
--- a/src/app/records/PresentationNode.m.scss
+++ b/src/app/records/PresentationNode.m.scss
@@ -23,6 +23,15 @@
   min-height: 34px;
   text-transform: uppercase;
   font-size: 14px;
+
+  > span {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: 1;
+    gap: 6px;
+    min-width: 0;
+  }
 }
 
 .onlyChild {

--- a/src/app/records/PresentationNode.tsx
+++ b/src/app/records/PresentationNode.tsx
@@ -142,7 +142,7 @@ export default function PresentationNode({
             [styles.completed]: completed,
           })}
         >
-          {title}
+          <span>{title}</span>
           {nodeProgress}
         </h4>
       ) : (


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Changelog: Fix Lore book title position on the Records page

<details>
<summary>Screenshots</summary>
Old:
<img width="1446" height="94" alt="Screenshot 2026-05-10 at 5 48 58 PM" src="https://github.com/user-attachments/assets/0a04b6fa-c0fe-4611-9d4a-152624e985bf" />

New:
<img width="1441" height="97" alt="Screenshot 2026-05-10 at 5 48 37 PM" src="https://github.com/user-attachments/assets/038a2b7c-63b2-4cbc-9db1-eb60aa775d53" />

</details>