### PR TITLE
Reduce peak memory while loading the D2 manifest

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -9,11 +9,12 @@ import { t } from 'app/i18next-t';
 import { inGameLoadoutLoaded } from 'app/loadout/ingame/actions';
 import { processInGameLoadouts } from 'app/loadout/loadout-type-converters';
 import { loadCoreSettings } from 'app/manifest/actions';
-import { checkForNewManifest } from 'app/manifest/manifest-service-json';
+import { checkForNewManifest, reloadToUpdateManifest } from 'app/manifest/manifest-service-json';
 import { d2ManifestSelector, manifestSelector } from 'app/manifest/selectors';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { get, set } from 'app/storage/idb-keyval';
 import { ThunkResult } from 'app/store/types';
+import { isMobileBrowser } from 'app/utils/browsers';
 import { DimError } from 'app/utils/dim-error';
 import { convertToError, errorMessage } from 'app/utils/errors';
 import { errorLog, infoLog, timer, warnLog } from 'app/utils/log';
@@ -394,11 +395,18 @@ function loadStoresData(
             // immediately try again.
             if (
               stores.some((s) => s.hadErrors) &&
-              lastCheckedManifest - Date.now() > 5 * 60 * 1000
+              Date.now() - lastCheckedManifest > 5 * 60 * 1000
             ) {
               lastCheckedManifest = Date.now();
 
               if (await checkForNewManifest()) {
+                // On mobile, downloading the new manifest while the old one is
+                // still in memory can get the page killed for using too much
+                // memory - reload the app instead, so the new manifest is
+                // downloaded on a fresh boot.
+                if (isMobileBrowser() && (await reloadToUpdateManifest())) {
+                  return;
+                }
                 defs = await dispatch(getDefinitions(true));
                 continue; // go back to the top of the loop with the new defs
               }

--- a/src/app/manifest/json-batch-stream.test.ts
+++ b/src/app/manifest/json-batch-stream.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { batchJsonEntries } from './json-batch-stream';
+
+/** Stream a string as UTF-8 bytes in chunks of chunkSize bytes. */
+function streamOf(text: string, chunkSize: number): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close();
+      } else {
+        controller.enqueue(bytes.subarray(offset, offset + chunkSize));
+        offset += chunkSize;
+      }
+    },
+  });
+}
+
+async function parseViaBatches(obj: object, chunkSize: number, batchSizeBytes: number) {
+  const result: Record<string, unknown> = {};
+  let batches = 0;
+  for await (const batch of batchJsonEntries(
+    streamOf(JSON.stringify(obj), chunkSize),
+    batchSizeBytes,
+  )) {
+    batches++;
+    Object.assign(result, JSON.parse(batch));
+  }
+  return { result, batches };
+}
+
+// Entries designed to confuse a naive splitter: braces, commas, quotes and
+// escapes inside strings, nested arrays/objects, multi-byte characters.
+const trickyTable = {
+  '1': { name: 'simple', value: 1 },
+  '2': { name: 'br,ace }{ in string', arr: [1, 2, { deep: '],}' }] },
+  '3': { name: 'escaped quote \\" and backslash \\\\', other: '"' },
+  '4': { name: '日本語のテキスト🎉', desc: 'emoji 🦄 and accents éàü' },
+  '5': { nested: { a: { b: { c: [{ d: 'x,y' }] } } } },
+  '6': { empty: {}, emptyArr: [], nul: null, bool: false },
+  '74624: 39': { 'weird: key, with "stuff"': '}{,' },
+};
+
+describe('batchJsonEntries', () => {
+  test.each([1, 3, 7, 64, 1024])('round-trips with chunk size %d', async (chunkSize) => {
+    const { result } = await parseViaBatches(trickyTable, chunkSize, 16);
+    expect(result).toEqual(trickyTable);
+  });
+
+  test('splits into multiple batches when entries exceed the batch size', async () => {
+    const { result, batches } = await parseViaBatches(trickyTable, 8, 32);
+    expect(result).toEqual(trickyTable);
+    expect(batches).toBeGreaterThan(1);
+  });
+
+  test('one giant batch size yields a single batch', async () => {
+    const { result, batches } = await parseViaBatches(trickyTable, 16, 1024 * 1024);
+    expect(result).toEqual(trickyTable);
+    expect(batches).toBe(1);
+  });
+
+  test('empty table', async () => {
+    const { result } = await parseViaBatches({}, 1, 16);
+    expect(result).toEqual({});
+  });
+
+  test('single entry larger than the batch size', async () => {
+    const table = { '99': { blob: 'x'.repeat(500) } };
+    const { result } = await parseViaBatches(table, 13, 16);
+    expect(result).toEqual(table);
+  });
+
+  test('many entries, realistic shape', async () => {
+    const table: Record<string, unknown> = {};
+    for (let i = 0; i < 500; i++) {
+      table[`${i * 31 + 7}`] = {
+        hash: i,
+        displayProperties: { name: `Item ${i}`, description: `Description, with "comma" ${i}` },
+        sockets: { socketEntries: [{ plugItems: [i, i + 1] }] },
+      };
+    }
+    const { result, batches } = await parseViaBatches(table, 256, 1024);
+    expect(result).toEqual(table);
+    expect(batches).toBeGreaterThan(5);
+  });
+});

--- a/src/app/manifest/json-batch-stream.test.ts
+++ b/src/app/manifest/json-batch-stream.test.ts
@@ -42,6 +42,11 @@ const trickyTable = {
   '5': { nested: { a: { b: { c: [{ d: 'x,y' }] } } } },
   '6': { empty: {}, emptyArr: [], nul: null, bool: false },
   '74624: 39': { 'weird: key, with "stuff"': '}{,' },
+  '8': {
+    s: 'backslash runs \\ \\\\ \\\\\\ before quotes',
+    t: '\\\\',
+    u: 'ends in backslashes \\\\\\',
+  },
 };
 
 describe('batchJsonEntries', () => {

--- a/src/app/manifest/json-batch-stream.ts
+++ b/src/app/manifest/json-batch-stream.ts
@@ -1,0 +1,83 @@
+const QUOTE = 0x22; // "
+const COMMA = 0x2c; // ,
+const BACKSLASH = 0x5c; // \
+const SQUARE_OPEN = 0x5b; // [
+const SQUARE_CLOSE = 0x5d; // ]
+const CURLY_OPEN = 0x7b; // {
+const CURLY_CLOSE = 0x7d; // }
+
+/**
+ * Incrementally consume a streamed JSON object of the shape
+ * `{ "key": {...}, "key": {...}, ... }` (e.g. a Destiny manifest table),
+ * yielding JSON strings that each contain a batch of top-level entries and
+ * can be JSON.parsed independently.
+ *
+ * This exists so we can parse (and trim) a huge table a slice at a time
+ * instead of materializing the entire parsed table at once - JSON.parse of
+ * the whole DestinyInventoryItemDefinition table peaks at hundreds of MB,
+ * which gets the page killed on iOS Safari.
+ */
+export async function* batchJsonEntries(
+  stream: ReadableStream<Uint8Array>,
+  batchSizeBytes = 4 * 1024 * 1024,
+): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+
+  let buf = new Uint8Array(0);
+  let pos = 0; // how far into buf we've scanned
+  let depth = 0; // brace/bracket nesting depth
+  let inString = false;
+  let escaped = false;
+  let firstBatch = true;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      const newBuf = new Uint8Array(buf.length + value.length);
+      newBuf.set(buf);
+      newBuf.set(value, buf.length);
+      buf = newBuf;
+
+      while (pos < buf.length) {
+        const c = buf[pos];
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (c === BACKSLASH) {
+            escaped = true;
+          } else if (c === QUOTE) {
+            inString = false;
+          }
+        } else if (c === QUOTE) {
+          inString = true;
+        } else if (c === CURLY_OPEN || c === SQUARE_OPEN) {
+          depth++;
+        } else if (c === CURLY_CLOSE || c === SQUARE_CLOSE) {
+          depth--;
+        } else if (c === COMMA && depth === 1 && pos >= batchSizeBytes) {
+          // A comma between top-level entries, and we have enough bytes for a
+          // batch: emit everything before the comma as its own JSON object.
+          // The first batch begins with the table's opening brace; later
+          // batches need one prepended.
+          yield `${firstBatch ? '' : '{'}${decoder.decode(buf.subarray(0, pos))}}`;
+          firstBatch = false;
+          buf = buf.slice(pos + 1);
+          pos = 0;
+          continue;
+        }
+        pos++;
+      }
+    }
+
+    // Whatever remains is the last batch, already terminated by the table's
+    // closing brace.
+    yield `${firstBatch ? '' : '{'}${decoder.decode(buf)}`;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/src/app/manifest/json-batch-stream.ts
+++ b/src/app/manifest/json-batch-stream.ts
@@ -16,20 +16,48 @@ const CURLY_CLOSE = 0x7d; // }
  * instead of materializing the entire parsed table at once - JSON.parse of
  * the whole DestinyInventoryItemDefinition table peaks at hundreds of MB,
  * which gets the page killed on iOS Safari.
+ *
+ * Each incoming chunk is scanned exactly once, with string contents skipped
+ * at native speed via indexOf; chunks are accumulated in a list and only
+ * copied once per emitted batch.
  */
 export async function* batchJsonEntries(
   stream: ReadableStream<Uint8Array>,
   batchSizeBytes = 4 * 1024 * 1024,
 ): AsyncGenerator<string> {
   const reader = stream.getReader();
+  // A single sequential decoder (stream: true) handles multi-byte characters
+  // that span chunk boundaries. Batch boundaries are always at structural
+  // ASCII bytes, so the decoder state is empty between batches.
   const decoder = new TextDecoder();
 
-  let buf = new Uint8Array(0);
-  let pos = 0; // how far into buf we've scanned
+  // Bytes accumulated since the last emitted batch.
+  let chunks: Uint8Array[] = [];
+  let pendingBytes = 0;
+
   let depth = 0; // brace/bracket nesting depth
   let inString = false;
-  let escaped = false;
+  // Length of the backslash run at the end of the last scanned chunk, for
+  // detecting escaped quotes that span chunk boundaries.
+  let carryBackslashes = 0;
   let firstBatch = true;
+
+  /** Copy the accumulated chunks (plus an optional final piece) into one buffer. */
+  const assemble = (last?: Uint8Array) => {
+    const total = pendingBytes + (last?.length ?? 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      out.set(c, offset);
+      offset += c.length;
+    }
+    if (last) {
+      out.set(last, offset);
+    }
+    chunks = [];
+    pendingBytes = 0;
+    return out;
+  };
 
   try {
     for (;;) {
@@ -38,45 +66,72 @@ export async function* batchJsonEntries(
         break;
       }
 
-      const newBuf = new Uint8Array(buf.length + value.length);
-      newBuf.set(buf);
-      newBuf.set(value, buf.length);
-      buf = newBuf;
-
-      while (pos < buf.length) {
-        const c = buf[pos];
+      let chunk = value;
+      let i = 0;
+      while (i < chunk.length) {
         if (inString) {
-          if (escaped) {
-            escaped = false;
-          } else if (c === BACKSLASH) {
-            escaped = true;
-          } else if (c === QUOTE) {
+          const q = chunk.indexOf(QUOTE, i);
+          if (q === -1) {
+            // The string continues into the next chunk. Carry over the length
+            // of any backslash run touching the chunk end, to resolve quote
+            // escaping across the boundary.
+            let k = chunk.length - 1;
+            while (k >= i && chunk[k] === BACKSLASH) {
+              k--;
+            }
+            const run = chunk.length - 1 - k;
+            carryBackslashes = k < i && i === 0 ? carryBackslashes + run : run;
+            i = chunk.length;
+            break;
+          }
+          // The quote is escaped iff the backslash run immediately before it
+          // has odd length.
+          let k = q - 1;
+          while (k >= i && chunk[k] === BACKSLASH) {
+            k--;
+          }
+          let run = q - 1 - k;
+          if (k < i && i === 0) {
+            run += carryBackslashes;
+          }
+          carryBackslashes = 0;
+          if (run % 2 === 0) {
             inString = false;
           }
-        } else if (c === QUOTE) {
+          i = q + 1;
+          continue;
+        }
+
+        const c = chunk[i];
+        if (c === QUOTE) {
           inString = true;
+          carryBackslashes = 0;
         } else if (c === CURLY_OPEN || c === SQUARE_OPEN) {
           depth++;
         } else if (c === CURLY_CLOSE || c === SQUARE_CLOSE) {
           depth--;
-        } else if (c === COMMA && depth === 1 && pos >= batchSizeBytes) {
+        } else if (c === COMMA && depth === 1 && pendingBytes + i >= batchSizeBytes) {
           // A comma between top-level entries, and we have enough bytes for a
           // batch: emit everything before the comma as its own JSON object.
           // The first batch begins with the table's opening brace; later
           // batches need one prepended.
-          yield `${firstBatch ? '' : '{'}${decoder.decode(buf.subarray(0, pos))}}`;
+          const text = decoder.decode(assemble(chunk.subarray(0, i)), { stream: true });
+          yield `${firstBatch ? '' : '{'}${text}}`;
           firstBatch = false;
-          buf = buf.slice(pos + 1);
-          pos = 0;
+          chunk = chunk.subarray(i + 1);
+          i = 0;
           continue;
         }
-        pos++;
+        i++;
       }
+
+      chunks.push(chunk);
+      pendingBytes += chunk.length;
     }
 
     // Whatever remains is the last batch, already terminated by the table's
     // closing brace.
-    yield `${firstBatch ? '' : '{'}${decoder.decode(buf)}`;
+    yield `${firstBatch ? '' : '{'}${decoder.decode(assemble())}`;
   } finally {
     reader.releaseLock();
   }

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -170,7 +170,7 @@ function doGetManifest(
       if (e.cause instanceof TypeError || e.cause instanceof HttpStatusError) {
       } else {
         // Something may be wrong with the manifest
-        deleteManifestFile();
+        deleteManifestCache();
       }
 
       errorLog(TAG, 'Manifest loading error', e);
@@ -371,7 +371,7 @@ export async function downloadManifestComponents(
   return manifest as AllDestinyManifestComponents;
 }
 
-async function deleteManifestFile() {
+export async function deleteManifestCache() {
   localStorage.removeItem(localStorageKey);
   await Promise.all(
     (await keys()).map(async (key) => {
@@ -380,6 +380,29 @@ async function deleteManifestFile() {
       }
     }),
   );
+}
+
+const autoReloadKey = 'd2-manifest-auto-reload';
+
+/**
+ * Delete the cached manifest and reload the app, so the new manifest is
+ * downloaded on a fresh boot with as little else in memory as possible.
+ * Downloading a new manifest while the old one is still in memory can get the
+ * page killed on mobile.
+ *
+ * Returns false (without reloading) if we already auto-reloaded recently, so
+ * a misbehaving manifest can't cause a reload loop - callers should fall back
+ * to downloading the manifest in place.
+ */
+export async function reloadToUpdateManifest(): Promise<boolean> {
+  const lastReload = parseInt(localStorage.getItem(autoReloadKey) ?? '0', 10);
+  if (Date.now() - lastReload < 15 * 60 * 1000) {
+    return false;
+  }
+  localStorage.setItem(autoReloadKey, Date.now().toString());
+  await deleteManifestCache();
+  window.location.reload();
+  return true;
 }
 
 /**
@@ -427,7 +450,7 @@ async function loadManifestFromCache(
     return manifest;
   } else {
     // Delete the existing manifest first, to make space
-    await deleteManifestFile();
+    await deleteManifestCache();
     throw new Error(`version mismatch: ${version} ${currentManifestVersion}`);
   }
 }

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -30,6 +30,7 @@ import { getManifest as d2GetManifest } from '../bungie-api/destiny2-api';
 import { showNotification } from '../notifications/notifications';
 import { settingsReady } from '../settings/settings';
 import { reportException } from '../utils/sentry';
+import { batchJsonEntries } from './json-batch-stream';
 
 const TAG = 'manifest';
 
@@ -41,88 +42,88 @@ const TAG = 'manifest';
 // Testing flags
 const alwaysLoadRemote = false;
 
-/** Functions that can reduce the size of a table after it's downloaded but before it's saved to cache. */
-const tableTrimmers: LookupTable<DestinyManifestComponentName, (table: any) => any> = {
-  DestinyInventoryItemDefinition: (table: { [hash: number]: DestinyInventoryItemDefinition }) => {
-    for (const key in table) {
-      const def = table[key] as Draft<DestinyInventoryItemDefinition>;
+/** Functions that can reduce the size of a definition after it's downloaded but before it's saved to cache. */
+const defTrimmers: LookupTable<DestinyManifestComponentName, (d: any) => void> = {
+  DestinyInventoryItemDefinition: (d) => {
+    const def = d as Draft<DestinyInventoryItemDefinition>;
 
-      // Deleting properties can actually make memory usage go up as V8 replaces some efficient
-      // structures from JSON parsing. Only replace objects with empties, and always test with the
-      // memory profiler. Don't assume that deleting something makes this smaller.
+    // Deleting properties can actually make memory usage go up as V8 replaces some efficient
+    // structures from JSON parsing. Only replace objects with empties, and always test with the
+    // memory profiler. Don't assume that deleting something makes this smaller.
 
-      def.action = emptyObject<Draft<DestinyItemActionBlockDefinition>>();
-      def.backgroundColor = emptyObject();
-      def.translationBlock = emptyObject<Draft<DestinyItemTranslationBlockDefinition>>();
-      if (def.equippingBlock?.displayStrings?.length) {
-        def.equippingBlock.displayStrings = emptyArray();
+    def.action = emptyObject<Draft<DestinyItemActionBlockDefinition>>();
+    def.backgroundColor = emptyObject();
+    def.translationBlock = emptyObject<Draft<DestinyItemTranslationBlockDefinition>>();
+    if (def.equippingBlock?.displayStrings?.length) {
+      def.equippingBlock.displayStrings = emptyArray();
+    }
+    if (def.preview) {
+      if (def.preview.derivedItemCategories?.length) {
+        def.preview.derivedItemCategories = emptyArray();
       }
-      if (def.preview) {
-        if (def.preview.derivedItemCategories?.length) {
-          def.preview.derivedItemCategories = emptyArray();
-        }
-        def.preview.screenStyle = '';
+      def.preview.screenStyle = '';
+    }
+    if (def.inventory) {
+      if (def.inventory.bucketTypeHash !== BucketHashes.Subclass) {
+        // The only useful bit about talent grids is for subclass damage types
+        def.talentGrid = emptyObject<Draft<DestinyItemTalentGridBlockDefinition>>();
       }
-      if (def.inventory) {
-        if (def.inventory.bucketTypeHash !== BucketHashes.Subclass) {
-          // The only useful bit about talent grids is for subclass damage types
-          def.talentGrid = emptyObject<Draft<DestinyItemTalentGridBlockDefinition>>();
-        }
-        def.inventory.tierTypeName = '';
-      }
+      def.inventory.tierTypeName = '';
+    }
 
-      if (def.sockets) {
-        def.sockets.intrinsicSockets = emptyArray();
-        for (const socket of def.sockets.socketEntries) {
-          if (socket.reusablePlugSetHash && socket.reusablePlugItems.length > 0) {
-            socket.reusablePlugItems = emptyArray();
-          }
+    if (def.sockets) {
+      def.sockets.intrinsicSockets = emptyArray();
+      for (const socket of def.sockets.socketEntries) {
+        if (socket.reusablePlugSetHash && socket.reusablePlugItems.length > 0) {
+          socket.reusablePlugItems = emptyArray();
         }
       }
-
-      // We never figured out anything to do with icon sequences on items
-      if (def.displayProperties.iconSequences) {
-        def.displayProperties.iconSequences = emptyArray();
-      }
-
-      // We don't use these
-      def.tooltipStyle = '';
-      def.itemTypeAndTierDisplayName = '';
     }
 
-    return table;
+    // We never figured out anything to do with icon sequences on items
+    if (def.displayProperties.iconSequences) {
+      def.displayProperties.iconSequences = emptyArray();
+    }
+
+    // We don't use these
+    def.tooltipStyle = '';
+    def.itemTypeAndTierDisplayName = '';
   },
-  DestinyObjectiveDefinition: (table: { [hash: number]: DestinyObjectiveDefinition }) => {
-    for (const key in table) {
-      const def = table[key] as Draft<DestinyObjectiveDefinition>;
+  DestinyObjectiveDefinition: (d) => {
+    const def = d as Draft<DestinyObjectiveDefinition>;
 
-      def.stats = emptyObject();
-      def.perks = emptyObject();
-      // Believe it or not we don't use these
-      def.displayProperties.description = '';
-      def.displayProperties.name = '';
-    }
-    return table;
+    def.stats = emptyObject();
+    def.perks = emptyObject();
+    // Believe it or not we don't use these
+    def.displayProperties.description = '';
+    def.displayProperties.name = '';
   },
-  DestinyCollectibleDefinition: (table: { [hash: number]: DestinyCollectibleDefinition }) => {
-    for (const key in table) {
-      const def = table[key] as Draft<DestinyCollectibleDefinition>;
+  DestinyCollectibleDefinition: (d) => {
+    const def = d as Draft<DestinyCollectibleDefinition>;
 
-      def.acquisitionInfo = emptyObject();
-      def.stateInfo = emptyObject();
-    }
-    return table;
+    def.acquisitionInfo = emptyObject();
+    def.stateInfo = emptyObject();
   },
-  DestinyRecordDefinition: (table: { [hash: number]: DestinyRecordDefinition }) => {
-    for (const key in table) {
-      const def = table[key] as Draft<DestinyRecordDefinition>;
+  DestinyRecordDefinition: (d) => {
+    const def = d as Draft<DestinyRecordDefinition>;
 
-      def.requirements = emptyObject();
-      def.expirationInfo = emptyObject();
-    }
-    return table;
+    def.requirements = emptyObject();
+    def.expirationInfo = emptyObject();
   },
 };
+
+function trimTable(
+  table: DestinyManifestComponentName,
+  records: AllDestinyManifestComponents[DestinyManifestComponentName],
+) {
+  const trimmer = defTrimmers[table];
+  if (trimmer) {
+    for (const key in records) {
+      trimmer(records[key as unknown as number]);
+    }
+  }
+  return records;
+}
 
 // Module-local state
 const localStorageKey = 'd2-manifest-version';
@@ -302,17 +303,37 @@ export async function downloadManifestComponents(
 
   const loadTable = async (tableShort: TableShortName) => {
     const table = `Destiny${tableShort}Definition` as DestinyManifestComponentName;
-    let response: Response;
     let error: Error | undefined;
-    let body = null;
+    let records: AllDestinyManifestComponents[DestinyManifestComponentName] | undefined;
 
     for (const query of cacheBusterStrings) {
       try {
-        response = await fetch(`https://www.bungie.net${components[table]}${query}`);
+        const response = await fetch(`https://www.bungie.net${components[table]}${query}`);
         if (response.ok) {
           // Sometimes the file is found, but isn't parseable as JSON
-          body =
-            (await response.json()) as AllDestinyManifestComponents[DestinyManifestComponentName];
+          // (the getReader check excludes test environments where the body
+          // is a Node stream rather than a web ReadableStream)
+          if (hugeTables.includes(tableShort) && typeof response.body?.getReader === 'function') {
+            // Parse and trim huge tables a batch of definitions at a time, so
+            // the untrimmed table never fully exists in memory. JSON.parse of
+            // the whole table peaks at hundreds of MB, which gets the page
+            // killed on iOS Safari.
+            const trimmer = defTrimmers[table];
+            const result: Record<string, unknown> = {};
+            for await (const batchText of batchJsonEntries(response.body)) {
+              const batch = JSON.parse(batchText) as Record<string, unknown>;
+              for (const key in batch) {
+                trimmer?.(batch[key]);
+                result[key] = batch[key];
+              }
+            }
+            records = result as AllDestinyManifestComponents[DestinyManifestComponentName];
+          } else {
+            records = trimTable(
+              table,
+              (await response.json()) as AllDestinyManifestComponents[DestinyManifestComponentName],
+            );
+          }
           break;
         }
         error ??= await toHttpStatusError(response);
@@ -320,13 +341,10 @@ export async function downloadManifestComponents(
         error ??= convertToError(e);
       }
     }
-    if (!body) {
+    if (!records) {
       handleErrors(error); // throws
     }
 
-    const records = (
-      table in tableTrimmers ? tableTrimmers[table]!(body) : body
-    ) as AllDestinyManifestComponents[DestinyManifestComponentName];
     (manifest as Record<string, unknown>)[table] = records;
     await onTableLoaded?.(tableShort, records);
   };

--- a/src/app/manifest/manifest-service-json.ts
+++ b/src/app/manifest/manifest-service-json.ts
@@ -218,7 +218,7 @@ function loadManifest(tableAllowList: TableShortName[]): ThunkResult<AllDestinyM
 }
 
 /**
- * Returns a promise for the manifest data as a Uint8Array. Will cache it on success.
+ * Downloads the manifest from Bungie.net, caching it in IndexedDB on success.
  */
 function loadManifestRemote(
   version: string,
@@ -230,10 +230,36 @@ function loadManifestRemote(
   return async (dispatch) => {
     dispatch(loadingStart(t('Manifest.Download')));
     try {
-      const manifest = await downloadManifestComponents(components, tableAllowList);
+      let saveError: Error | undefined;
+      // Save each table to IndexedDB as it arrives, and wait for those saves,
+      // so we never serialize the whole manifest at once and saving doesn't
+      // overlap with building stores. Peak memory matters a lot on iOS, where
+      // the OS will kill the page (black screen) if we use too much.
+      const manifest = await downloadManifestComponents(
+        components,
+        tableAllowList,
+        async (tableShort, records) => {
+          try {
+            await set(`${idbKey}-${tableShort}`, records);
+          } catch (e) {
+            saveError ??= convertToError(e);
+          }
+        },
+      );
 
-      // We intentionally don't wait on this promise
-      saveManifestToIndexedDB(manifest, version, tableAllowList);
+      if (saveError) {
+        errorLog(TAG, 'Error saving manifest file', saveError);
+        showNotification({
+          title: t('Help.NoStorage'),
+          body: t('Help.NoStorageMessage'),
+          type: 'error',
+        });
+      } else {
+        await del(idbKey); // the old storage location before per-table
+        infoLog(TAG, `Successfully stored manifest file.`);
+        localStorage.setItem(localStorageKey, version);
+        localStorage.setItem(`${localStorageKey}-whitelist`, JSON.stringify(tableAllowList));
+      }
       return manifest;
     } finally {
       dispatch(loadingEnd(t('Manifest.Download')));
@@ -241,11 +267,26 @@ function loadManifestRemote(
   };
 }
 
+/**
+ * Tables so large that parsing them concurrently with anything else risks
+ * running out of memory on iOS Safari. These are loaded one at a time, before
+ * the other tables, while the heap is at its smallest.
+ */
+const hugeTables: TableShortName[] = ['InventoryItem', 'Vendor'];
+
+/** How many of the remaining (smaller) tables to download and parse at once. */
+const maxConcurrency = 4;
+
 export async function downloadManifestComponents(
   components: {
     [key: string]: string;
   },
   tableAllowList: TableShortName[],
+  /** Called (and awaited) with each table's trimmed contents before the next table is loaded. */
+  onTableLoaded?: (
+    tableShort: TableShortName,
+    records: AllDestinyManifestComponents[DestinyManifestComponentName],
+  ) => Promise<void>,
 ) {
   // Adding a cache buster to work around bad cached CloudFlare data: https://github.com/DestinyItemManager/DIM/issues/5101
   // try canonical component URL which should likely be already cached,
@@ -259,69 +300,57 @@ export async function downloadManifestComponents(
 
   const manifest: Partial<AllDestinyManifestComponents> = {};
 
-  // Load the manifest tables we want table-by-table, in parallel. This is
-  // faster and downloads less data than the single huge file.
-  const futures = tableAllowList
-    .map((t) => `Destiny${t}Definition` as DestinyManifestComponentName)
-    .map(async (table) => {
-      let response: Response;
-      let error: Error | undefined;
-      let body = null;
+  const loadTable = async (tableShort: TableShortName) => {
+    const table = `Destiny${tableShort}Definition` as DestinyManifestComponentName;
+    let response: Response;
+    let error: Error | undefined;
+    let body = null;
 
-      for (const query of cacheBusterStrings) {
-        try {
-          response = await fetch(`https://www.bungie.net${components[table]}${query}`);
-          if (response.ok) {
-            // Sometimes the file is found, but isn't parseable as JSON
-            body =
-              (await response.json()) as AllDestinyManifestComponents[DestinyManifestComponentName];
-            break;
-          }
-          error ??= await toHttpStatusError(response);
-        } catch (e) {
-          error ??= convertToError(e);
+    for (const query of cacheBusterStrings) {
+      try {
+        response = await fetch(`https://www.bungie.net${components[table]}${query}`);
+        if (response.ok) {
+          // Sometimes the file is found, but isn't parseable as JSON
+          body =
+            (await response.json()) as AllDestinyManifestComponents[DestinyManifestComponentName];
+          break;
         }
+        error ??= await toHttpStatusError(response);
+      } catch (e) {
+        error ??= convertToError(e);
       }
-      if (!body) {
-        handleErrors(error); // throws
+    }
+    if (!body) {
+      handleErrors(error); // throws
+    }
+
+    const records = (
+      table in tableTrimmers ? tableTrimmers[table]!(body) : body
+    ) as AllDestinyManifestComponents[DestinyManifestComponentName];
+    (manifest as Record<string, unknown>)[table] = records;
+    await onTableLoaded?.(tableShort, records);
+  };
+
+  for (const tableShort of hugeTables) {
+    if (tableAllowList.includes(tableShort)) {
+      await loadTable(tableShort);
+    }
+  }
+
+  // Load the remaining tables with limited concurrency - parsing them all at
+  // once holds too many decoded bodies and parsed tables in memory
+  // simultaneously.
+  const queue = tableAllowList.filter((t) => !hugeTables.includes(t));
+  await Promise.all(
+    Array.from({ length: maxConcurrency }, async () => {
+      let tableShort: TableShortName | undefined;
+      while ((tableShort = queue.shift()) !== undefined) {
+        await loadTable(tableShort);
       }
-
-      // I couldn't figure out how to make these types work...
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      manifest[table] = table in tableTrimmers ? tableTrimmers[table]!(body) : body;
-    });
-
-  await Promise.all(futures);
+    }),
+  );
 
   return manifest as AllDestinyManifestComponents;
-}
-
-async function saveManifestToIndexedDB(
-  manifest: AllDestinyManifestComponents,
-  version: string,
-  tableAllowList: TableShortName[],
-) {
-  try {
-    await Promise.all([
-      ...tableAllowList.map(async (t) => {
-        const records = manifest[`Destiny${t}Definition`];
-        if (records) {
-          await set(`${idbKey}-${t}`, records);
-        }
-      }),
-      del(idbKey), // the old storage location before per-table
-    ]);
-    infoLog(TAG, `Successfully stored manifest file.`);
-    localStorage.setItem(localStorageKey, version);
-    localStorage.setItem(`${localStorageKey}-whitelist`, JSON.stringify(tableAllowList));
-  } catch (e) {
-    errorLog(TAG, 'Error saving manifest file', e);
-    showNotification({
-      title: t('Help.NoStorage'),
-      body: t('Help.NoStorageMessage'),
-      type: 'error',
-    });
-  }
 }
 
 async function deleteManifestFile() {
@@ -353,14 +382,28 @@ async function loadManifestFromCache(
   ) as string[];
   if (currentManifestVersion === version && deepEqual(currentAllowList, tableAllowList)) {
     const manifest = {} as AllDestinyManifestComponents;
+    const loadTable = async (t: TableShortName) => {
+      const records = await get<Record<number, any>>(`${idbKey}-${t}`);
+      const tableName = `Destiny${t}Definition` as DestinyManifestComponentName;
+      if (!records) {
+        throw new Error(`No cached contents for table ${tableName}`);
+      }
+      manifest[tableName] = records;
+    };
+    // Deserialize the huge tables one at a time to limit peak memory, which
+    // can get the page killed on iOS. See downloadManifestComponents.
+    for (const t of hugeTables) {
+      if (tableAllowList.includes(t)) {
+        await loadTable(t);
+      }
+    }
+    const queue = tableAllowList.filter((t) => !hugeTables.includes(t));
     await Promise.all(
-      tableAllowList.map(async (t) => {
-        const records = await get<Record<number, any>>(`${idbKey}-${t}`);
-        const tableName = `Destiny${t}Definition` as DestinyManifestComponentName;
-        if (!records) {
-          throw new Error(`No cached contents for table ${tableName}`);
+      Array.from({ length: maxConcurrency }, async () => {
+        let t: TableShortName | undefined;
+        while ((t = queue.shift()) !== undefined) {
+          await loadTable(t);
         }
-        manifest[tableName] = records;
       }),
     );
     return manifest;

--- a/src/app/settings/LanguageSetting.tsx
+++ b/src/app/settings/LanguageSetting.tsx
@@ -4,7 +4,9 @@ import { getDefinitions } from 'app/destiny2/d2-definitions';
 import { settingsSelector } from 'app/dim-api/selectors';
 import { t } from 'app/i18next-t';
 import { clearStores } from 'app/inventory/actions';
+import { reloadToUpdateManifest } from 'app/manifest/manifest-service-json';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { isMobileBrowser } from 'app/utils/browsers';
 import i18next from 'i18next';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -38,6 +40,13 @@ export default function LanguageSetting() {
     await i18next.changeLanguage(language);
     setSetting('language', language);
     if (currentAccount?.destinyVersion === 2) {
+      // On mobile, downloading the new manifest while the old one is still in
+      // memory can get the page killed for using too much memory - reload the
+      // app instead, so the new language's manifest is downloaded on a fresh
+      // boot. (The language setting is persisted to localStorage before this.)
+      if (isMobileBrowser() && (await reloadToUpdateManifest())) {
+        return;
+      }
       await dispatch(getDefinitions(true));
     } else if (currentAccount?.destinyVersion === 1) {
       await dispatch(getDefinitionsD1(false));

--- a/src/app/utils/browsers.ts
+++ b/src/app/utils/browsers.ts
@@ -36,6 +36,11 @@ const android = navigator.userAgent.includes('Android');
 export function isAndroid() {
   return android;
 }
+
+/** Is this a mobile browser (iOS or Android), where memory is tightly constrained? */
+export function isMobileBrowser() {
+  return iOS || android;
+}
 export const isNativeDragAndDropSupported = () => {
   // Chrome on Android should support native DnD, but React-DnD may not be able
   // to work around some quirk of it.


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Closes #11777 

Changelog: Greatly reduced memory usage while downloading a new Destiny 2 manifest, and DIM on mobile now reloads itself automatically to pick up manifest updates. This should fix black screens and crashes on iOS (and some Android devices) after Destiny 2 updates.