### PR TITLE
cap t5 exotic energy at 10

### DIFF
--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -24,7 +24,9 @@ export const d2MissingIcon = '/img/misc/missing_icon_d2.png';
 //
 
 // In Edge of Fate, Tier 5 armor was introduced that has 11 energy instead of 10.
-export const maxEnergyCapacity = (item: DimItem): number => (item.tier === 5 ? 11 : 10);
+// Tier 5 Exotics are capped at 10.
+export const maxEnergyCapacity = (item: DimItem): number =>
+  item.tier === 5 && !item.isExotic ? 11 : 10;
 /**
  * @deprecated: use `maxEnergyCapacity` instead
  */


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Cap Tier 5 Exotics at 10 energy.

This may be a Bungie exotic upgrade problem tho, all the exotics pre-mot that were T3 are capped at 10, but all the post MoT are at 11.