### PR TITLE
  Fix D1 loadout builder crash on frozen store items

### DIFF
--- a/src/app/destiny1/loadout-builder/utils.ts
+++ b/src/app/destiny1/loadout-builder/utils.ts
@@ -320,11 +320,13 @@ function getBuckets(items: D1Item[]): ItemBucket {
   };
 }
 
-function normalizeStats(item: D1ItemWithNormalStats) {
-  item.normalStats = {};
+function normalizeStats(item: D1ItemWithNormalStats): D1ItemWithNormalStats {
+  // Build the normalStats map locally and return a copy rather than mutating the
+  // item in place: items come from the (frozen) Redux store and are not extensible.
+  const normalStats: NonNullable<D1ItemWithNormalStats['normalStats']> = {};
   if (item.stats) {
     for (const stat of item.stats) {
-      item.normalStats[stat.statHash] = {
+      normalStats[stat.statHash] = {
         statHash: stat.statHash,
         base: stat.base,
         scaled: stat.scaled ? stat.scaled.min : 0,
@@ -334,5 +336,5 @@ function normalizeStats(item: D1ItemWithNormalStats) {
       };
     }
   }
-  return item;
+  return { ...item, normalStats };
 }


### PR DESCRIPTION
The D1 loadout builder crashes on render with TypeError: Attempting to define property on object that is not extensible (DIM-1YT3). normalizeStats writes normalStats straight onto each item, but items come out of the Redux store frozen, so the assignment throws the moment ArmorForClass tries to load a bucket.

  Build the normalStats map locally and return a shallow copy ({ ...item, normalStats }) instead of mutating in place. normalizeStats is only called inside getBuckets's .map, and everything downstream reads the returned items, so nothing relied on the original being mutated.
