### PR TITLE
Only report missing-def store errors after a manifest refresh

### DIFF
--- a/src/app/inventory/d2-stores.ts
+++ b/src/app/inventory/d2-stores.ts
@@ -366,7 +366,7 @@ function loadStoresData(
             return;
           }
 
-          for (let i = 0; i < 2; i++) {
+          for (let attempt = 0; attempt < 2; attempt++) {
             if (!defs || !profileInfo) {
               infoLog(TAG, 'No defs or profile info, skipping store load', {
                 defs: Boolean(defs),
@@ -381,12 +381,18 @@ function loadStoresData(
 
             const buckets = d2BucketsSelector(getState())!;
             const customStats = customStatsSelector(getState());
-            const stores = buildStores({
-              defs,
-              buckets,
-              customStats,
-              profileResponse,
-            });
+            const stores = buildStores(
+              {
+                defs,
+                buckets,
+                customStats,
+                profileResponse,
+              },
+              // Only report missing-def items on the second attempt: the loop only
+              // reaches attempt 1 after we've already refreshed the manifest below, so a
+              // def that's still missing here isn't just a stale manifest.
+              attempt === 1,
+            );
 
             // One reason stores could have errors is if the manifest was not up
             // to date. Check to see if it has updated, and if so, download it and

--- a/src/app/inventory/store/d2-item-factory.ts
+++ b/src/app/inventory/store/d2-item-factory.ts
@@ -78,6 +78,13 @@ export function processItems(
   context: ItemCreationContext,
   owner: DimStore,
   items: DestinyItemComponent[],
+  /**
+   * Whether to report items that have no definition to Sentry. A missing def normally
+   * just means the user's manifest is stale, so this should only be true after we've
+   * already refreshed the manifest and the def is *still* missing - which shouldn't
+   * happen, since any item a player owns is in Bungie's current manifest.
+   */
+  reportMissingDefs: boolean,
 ): DimItem[] {
   const result: DimItem[] = [];
 
@@ -112,16 +119,35 @@ export function processItems(
         bucketDef.category !== BucketCategory.Invisible &&
         bucketDef.displayProperties.name
       ) {
-        const itemDef = defs.InventoryItem.get(item.itemHash);
-        reportException('setting store hadErrors', new Error('setting store hadErrors'), {
-          itemHash: item.itemHash,
-          hasDefinition: Boolean(itemDef),
-          hasName: Boolean(itemDef?.displayProperties.name),
-          hasQuestLineName: Boolean(itemDef?.setData?.questLineName),
-          itemBucketHash: item.bucketHash,
-          defBucketHash: itemDef?.inventory?.bucketTypeHash,
-          bucketName: bucketDef.displayProperties.name,
-        });
+        // getOptional so we don't log a second hashLookupFailure for a hash that's
+        // already known to be missing.
+        const itemDef = defs.InventoryItem.getOptional(item.itemHash);
+        if (itemDef) {
+          // We have a definition but still couldn't build the item - an actual DIM bug.
+          reportException('setting store hadErrors', new Error('setting store hadErrors'), {
+            itemHash: item.itemHash,
+            hasDefinition: true,
+            hasName: Boolean(itemDef.displayProperties.name),
+            hasQuestLineName: Boolean(itemDef.setData?.questLineName),
+            itemBucketHash: item.bucketHash,
+            defBucketHash: itemDef.inventory?.bucketTypeHash,
+            bucketName: bucketDef.displayProperties.name,
+          });
+        } else if (reportMissingDefs) {
+          // No definition at all. Normally that just means the manifest is stale, and
+          // flagging hadErrors below kicks off a re-download that fixes it - so we don't
+          // report it on the first pass. reportMissingDefs means we've already refreshed
+          // the manifest and it's *still* missing, which shouldn't happen.
+          reportException('setting store hadErrors', new Error('setting store hadErrors'), {
+            itemHash: item.itemHash,
+            hasDefinition: false,
+            itemBucketHash: item.bucketHash,
+            bucketName: bucketDef.displayProperties.name,
+          });
+        }
+        // Always flag the store: a missing def means the manifest is stale and needs a
+        // re-download, and either way we must not purge tags/notes for items that failed
+        // to load.
         owner.hadErrors = true;
       }
     }

--- a/src/app/inventory/store/d2-store-factory.ts
+++ b/src/app/inventory/store/d2-store-factory.ts
@@ -20,7 +20,11 @@ import { bungieNetPath } from '../../dim-ui/BungieImage';
 import { DimCharacterStat, DimStore, DimTitle } from '../store-types';
 import { ItemCreationContext, processItems } from './d2-item-factory';
 
-export function buildStores(itemCreationContext: ItemCreationContext): DimStore[] {
+export function buildStores(
+  itemCreationContext: ItemCreationContext,
+  /** Report items with no definition to Sentry - see processItems. */
+  reportMissingDefs = false,
+): DimStore[] {
   // TODO: components may be hidden (privacy)
 
   const { profileResponse } = itemCreationContext;
@@ -47,10 +51,10 @@ Please carefully read the instructions in docs/CONTRIBUTING.md -> \
 
     const lastPlayedDate = findLastPlayedDate(profileResponse);
 
-    const vault = processVault(itemCreationContext);
+    const vault = processVault(itemCreationContext, reportMissingDefs);
 
     const characters = Object.keys(profileResponse.characters.data).map((characterId) =>
-      processCharacter(itemCreationContext, characterId, lastPlayedDate),
+      processCharacter(itemCreationContext, characterId, lastPlayedDate, reportMissingDefs),
     );
     const stores = [...characters, vault];
 
@@ -65,6 +69,7 @@ function processCharacter(
   itemCreationContext: ItemCreationContext,
   characterId: string,
   lastPlayedDate: Date,
+  reportMissingDefs: boolean,
 ): DimStore {
   const { defs, buckets, profileResponse } = itemCreationContext;
   const character = profileResponse.characters.data![characterId];
@@ -88,11 +93,14 @@ function processCharacter(
     }
   }
 
-  store.items = processItems(itemCreationContext, store, items);
+  store.items = processItems(itemCreationContext, store, items, reportMissingDefs);
   return store;
 }
 
-function processVault(itemCreationContext: ItemCreationContext): DimStore {
+function processVault(
+  itemCreationContext: ItemCreationContext,
+  reportMissingDefs: boolean,
+): DimStore {
   const { buckets, profileResponse } = itemCreationContext;
   const profileInventory = profileResponse.profileInventory.data
     ? profileResponse.profileInventory.data.items
@@ -109,7 +117,7 @@ function processVault(itemCreationContext: ItemCreationContext): DimStore {
     }
   }
 
-  store.items = processItems(itemCreationContext, store, items);
+  store.items = processItems(itemCreationContext, store, items, reportMissingDefs);
   return store;
 }
 


### PR DESCRIPTION
When an item has no manifest definition, makeItem can't build it and processItems reported "setting store hadErrors" to Sentry. But a missing def almost always just means the user's cached manifest is stale, and flagging hadErrors already kicks off a re-download (in d2-stores) that fixes it on retry - so reporting on the first pass was noise. A player with a stale manifest produced a flood of expected exceptions, each also logging a redundant second hashLookupFailure from the re-lookup.

Thread a reportMissingDefs flag from the store load through buildStores into processItems, set only on the second attempt (attempt === 1) - which is reached only after the manifest has actually been refreshed. So a no-def item is reported only if it's still missing after a fresh manifest, which shouldn't happen since any item a player owns is in Bungie's current manifest. Items that have a definition but still fail to build are reported as before (a real DIM bug), and hadErrors is still set unconditionally so the manifest refresh and tag/note protection are unaffected. Use getOptional to avoid the redundant hashLookupFailure.

Fixes DIM-1YK6

