### PR TITLE
Don't look up itemHash 0 when matching collectibles by icon

### DIFF
--- a/src/app/records/collectible-matching.ts
+++ b/src/app/records/collectible-matching.ts
@@ -61,7 +61,11 @@ export const createCollectibleFinder = memoizeOne((defs: D2ManifestDefinitions) 
         // where the icon matches our icon (e.g. Y1 Trials / Prophecy: Bond Judgment vs. Judgement's Wrap)
         const collectiblesByReverseItemIcon = keyBy(
           collectibles,
-          (c) => defs.InventoryItem.get(c.itemHash)?.displayProperties.icon,
+          // Some collectibles have itemHash 0 (no associated item). Skip the lookup for
+          // those - get(0) would report an invalidHash exception, and with no item there's
+          // no icon to match on anyway. '' is never a real icon path, so it won't match.
+          (c) =>
+            c.itemHash ? (defs.InventoryItem.get(c.itemHash)?.displayProperties.icon ?? '') : '',
         );
         return [classType, { collectiblesByName, collectiblesByReverseItemIcon }] as const;
       }),


### PR DESCRIPTION
Some collectibles have itemHash 0 (no associated item). The reverse-icon index in armorCollectiblesByClassType looked every collectible's item up with get(), and get(0) hits the invalidHash branch, reporting a Sentry exception. Guard the lookup on a non-zero itemHash so hash 0 is skipped - there's no item or icon to match on anyway. Nonzero hashes still go through get() and keep their normal hashLookupFailure diagnostics.

Fixes DIM-1YMH

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
