### PR TITLE
Don't report DestinyItemUnequippable to Sentry

### DIFF
--- a/src/app/utils/sentry.ts
+++ b/src/app/utils/sentry.ts
@@ -16,7 +16,11 @@ const ignoreDimErrors: (string | PlatformErrorCodes)[] = [
   'BungieService.NotConnected',
   'BungieService.NotConnectedOrBlocked',
   'ItemService.ExoticError',
+  // Both of these mean the character's equipment is locked (in an activity, or logged
+  // out of one) - expected, and DIM already shows the user a helpful message. See
+  // checkEquipNotPossible in loadout-apply.ts, which treats them as the same condition.
   PlatformErrorCodes.DestinyCannotPerformActionAtThisLocation,
+  PlatformErrorCodes.DestinyItemUnequippable,
 ];
 
 const options: BrowserOptions = {


### PR DESCRIPTION
DestinyItemUnequippable (1640) means the character's equipment is locked - they're in an activity, or logged out while still in a locked-equipment activity. It's expected and not a DIM bug, and DIM already shows the user a helpful message. checkEquipNotPossible in loadout-apply.ts already treats it as the same condition as DestinyCannotPerformActionAtThisLocation, which was already in the Sentry ignore list - this just adds its sibling so the equivalent error stops being reported.

Fixes DIM-1YKA

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
