### PR TITLE
Reload to recover from chunk-load errors after a deploy

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,8 @@
 import { settingSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import clsx from 'clsx';
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Route, Routes, useLocation } from 'react-router';
 import * as styles from './App.m.scss';
@@ -22,19 +23,19 @@ import Header from './shell/Header';
 import ScrollToTop from './shell/ScrollToTop';
 import SneakyUpdates from './shell/SneakyUpdates';
 
-const WhatsNew = lazy(
+const WhatsNew = lazyWithRetry(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './whats-new/WhatsNew'),
 );
-const SettingsPage = lazy(
+const SettingsPage = lazyWithRetry(
   () => import(/* webpackChunkName: "settings" */ './settings/SettingsPage'),
 );
-const Debug = lazy(
+const Debug = lazyWithRetry(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './debug/Debug'),
 );
-const Privacy = lazy(
+const Privacy = lazyWithRetry(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './shell/Privacy'),
 );
-const About = lazy(
+const About = lazyWithRetry(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './shell/About'),
 );
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import { settingSelector } from 'app/dim-api/selectors';
 import { RootState } from 'app/store/types';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import clsx from 'clsx';
 import { Suspense } from 'react';
 import { useSelector } from 'react-redux';
@@ -23,19 +23,19 @@ import Header from './shell/Header';
 import ScrollToTop from './shell/ScrollToTop';
 import SneakyUpdates from './shell/SneakyUpdates';
 
-const WhatsNew = lazyWithRetry(
+const WhatsNew = lazy(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './whats-new/WhatsNew'),
 );
-const SettingsPage = lazyWithRetry(
+const SettingsPage = lazy(
   () => import(/* webpackChunkName: "settings" */ './settings/SettingsPage'),
 );
-const Debug = lazyWithRetry(
+const Debug = lazy(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './debug/Debug'),
 );
-const Privacy = lazyWithRetry(
+const Privacy = lazy(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './shell/Privacy'),
 );
-const About = lazyWithRetry(
+const About = lazy(
   () => import(/* webpackChunkName: "about-whatsnew-privacy-debug" */ './shell/About'),
 );
 

--- a/src/app/armory/LazyArmory.ts
+++ b/src/app/armory/LazyArmory.ts
@@ -1,3 +1,3 @@
-import { lazy } from 'react';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 
-export default lazy(() => import('./Armory' /* webpackChunkName: "item-popup-armory" */));
+export default lazyWithRetry(() => import('./Armory' /* webpackChunkName: "item-popup-armory" */));

--- a/src/app/armory/LazyArmory.ts
+++ b/src/app/armory/LazyArmory.ts
@@ -1,3 +1,3 @@
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 
-export default lazyWithRetry(() => import('./Armory' /* webpackChunkName: "item-popup-armory" */));
+export default lazy(() => import('./Armory' /* webpackChunkName: "item-popup-armory" */));

--- a/src/app/compare/CompareContainer.tsx
+++ b/src/app/compare/CompareContainer.tsx
@@ -1,14 +1,14 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { gaPageView } from 'app/google';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { Suspense, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { endCompareSession } from './actions';
 import { compareSessionSelector } from './selectors';
 
-const Compare = lazyWithRetry(() => import(/* webpackChunkName: "compare" */ './Compare'));
+const Compare = lazy(() => import(/* webpackChunkName: "compare" */ './Compare'));
 
 export default function CompareContainer({ destinyVersion }: { destinyVersion: DestinyVersion }) {
   const session = useSelector(compareSessionSelector);

--- a/src/app/compare/CompareContainer.tsx
+++ b/src/app/compare/CompareContainer.tsx
@@ -1,13 +1,14 @@
 import { DestinyVersion } from '@destinyitemmanager/dim-api-types';
 import { gaPageView } from 'app/google';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { Suspense, lazy, useEffect } from 'react';
+import { lazyWithRetry } from 'app/utils/chunk-load';
+import { Suspense, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { endCompareSession } from './actions';
 import { compareSessionSelector } from './selectors';
 
-const Compare = lazy(() => import(/* webpackChunkName: "compare" */ './Compare'));
+const Compare = lazyWithRetry(() => import(/* webpackChunkName: "compare" */ './Compare'));
 
 export default function CompareContainer({ destinyVersion }: { destinyVersion: DestinyVersion }) {
   const session = useSelector(compareSessionSelector);

--- a/src/app/item-feed/ItemFeedPage.tsx
+++ b/src/app/item-feed/ItemFeedPage.tsx
@@ -2,11 +2,12 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useLoadStores } from 'app/inventory/store/hooks';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import { usePageTitle } from 'app/utils/hooks';
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import * as styles from './ItemFeedPage.m.scss';
 
-const ItemFeed = lazy(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
+const ItemFeed = lazyWithRetry(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
 
 /**
  * The Item Feed in a full page for mobile.

--- a/src/app/item-feed/ItemFeedSidebar.tsx
+++ b/src/app/item-feed/ItemFeedSidebar.tsx
@@ -2,11 +2,12 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, collapseIcon, faCaretUp } from 'app/shell/icons';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import clsx from 'clsx';
-import { Suspense, lazy, useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import * as styles from './ItemFeedSidebar.m.scss';
 
-const ItemFeed = lazy(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
+const ItemFeed = lazyWithRetry(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
 
 /**
  * The Item Feed in an expandable sidebar to be placed on the inventory screen.

--- a/src/app/item-feed/ItemFeedSidebar.tsx
+++ b/src/app/item-feed/ItemFeedSidebar.tsx
@@ -2,12 +2,12 @@ import ShowPageLoading from 'app/dim-ui/ShowPageLoading';
 import { t } from 'app/i18next-t';
 import { useSetting } from 'app/settings/hooks';
 import { AppIcon, collapseIcon, faCaretUp } from 'app/shell/icons';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import clsx from 'clsx';
 import { Suspense, useEffect } from 'react';
 import * as styles from './ItemFeedSidebar.m.scss';
 
-const ItemFeed = lazyWithRetry(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
+const ItemFeed = lazy(() => import(/* webpackChunkName: "item-feed" */ './ItemFeed'));
 
 /**
  * The Item Feed in an expandable sidebar to be placed on the inventory screen.

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -2,14 +2,17 @@ import { createItemContextSelector, sortedStoresSelector } from 'app/inventory/s
 import { DimStore } from 'app/inventory/store-types';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { lazy, Suspense, useEffect } from 'react';
+import { lazyWithRetry } from 'app/utils/chunk-load';
+import { Suspense, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { useSubscription } from 'use-subscription';
 import { DimItem } from '../inventory/item-types';
 import { hideItemPopup, showItemPopup$ } from './item-popup';
 
-const ItemPopup = lazy(() => import(/* webpackChunkName: "item-popup-armory" */ './ItemPopup'));
+const ItemPopup = lazyWithRetry(
+  () => import(/* webpackChunkName: "item-popup-armory" */ './ItemPopup'),
+);
 
 interface Props {
   boundarySelector?: string;

--- a/src/app/item-popup/ItemPopupContainer.tsx
+++ b/src/app/item-popup/ItemPopupContainer.tsx
@@ -2,7 +2,7 @@ import { createItemContextSelector, sortedStoresSelector } from 'app/inventory/s
 import { DimStore } from 'app/inventory/store-types';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
 import { useD2Definitions } from 'app/manifest/selectors';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { Suspense, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -10,9 +10,7 @@ import { useSubscription } from 'use-subscription';
 import { DimItem } from '../inventory/item-types';
 import { hideItemPopup, showItemPopup$ } from './item-popup';
 
-const ItemPopup = lazyWithRetry(
-  () => import(/* webpackChunkName: "item-popup-armory" */ './ItemPopup'),
-);
+const ItemPopup = lazy(() => import(/* webpackChunkName: "item-popup-armory" */ './ItemPopup'));
 
 interface Props {
   boundarySelector?: string;

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -7,7 +7,7 @@ import { warnMissingClass } from 'app/loadout-builder/loadout-builder-reducer';
 import { decodeUrlLoadout } from 'app/loadout/loadout-share/loadout-import';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { errorMessage } from 'app/utils/errors';
 import { useEventBusListener } from 'app/utils/hooks';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
@@ -17,10 +17,10 @@ import { useLocation, useNavigate } from 'react-router';
 import { EditLoadoutState, addItem$, editLoadout$ } from './loadout-events';
 import { convertToLoadoutItem, newLoadout, pickBackingStore } from './loadout-utils';
 
-const LoadoutDrawer = lazyWithRetry(
+const LoadoutDrawer = lazy(
   () => import(/* webpackChunkName: "loadout-drawer" */ './LoadoutDrawer'),
 );
-const D1LoadoutDrawer = lazyWithRetry(
+const D1LoadoutDrawer = lazy(
   () =>
     import(
       /* webpackChunkName: "d1-loadout-drawer" */ 'app/destiny1/loadout-drawer/D1LoadoutDrawer'

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -7,19 +7,20 @@ import { warnMissingClass } from 'app/loadout-builder/loadout-builder-reducer';
 import { decodeUrlLoadout } from 'app/loadout/loadout-share/loadout-import';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { showNotification } from 'app/notifications/notifications';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import { errorMessage } from 'app/utils/errors';
 import { useEventBusListener } from 'app/utils/hooks';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router';
 import { EditLoadoutState, addItem$, editLoadout$ } from './loadout-events';
 import { convertToLoadoutItem, newLoadout, pickBackingStore } from './loadout-utils';
 
-const LoadoutDrawer = lazy(
+const LoadoutDrawer = lazyWithRetry(
   () => import(/* webpackChunkName: "loadout-drawer" */ './LoadoutDrawer'),
 );
-const D1LoadoutDrawer = lazy(
+const D1LoadoutDrawer = lazyWithRetry(
   () =>
     import(
       /* webpackChunkName: "d1-loadout-drawer" */ 'app/destiny1/loadout-drawer/D1LoadoutDrawer'

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -14,6 +14,7 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
@@ -21,7 +22,6 @@ import { debounce } from 'es-toolkit';
 import { AnimatePresence, LayoutGroup, Variants, motion } from 'motion/react';
 import React, {
   Suspense,
-  lazy,
   memo,
   useCallback,
   useDeferredValue,
@@ -86,7 +86,9 @@ const loadoutAutoCompleterSelector = createSelector(
   createAutocompleter,
 );
 
-const LazyFilterHelp = lazy(() => import(/* webpackChunkName: "filter-help" */ './FilterHelp'));
+const LazyFilterHelp = lazyWithRetry(
+  () => import(/* webpackChunkName: "filter-help" */ './FilterHelp'),
+);
 
 const RowContents = memo(({ item }: { item: SearchItem }) => {
   function highlight(text: string, section: string) {

--- a/src/app/search/SearchBar.tsx
+++ b/src/app/search/SearchBar.tsx
@@ -14,7 +14,7 @@ import { toggleSearchResults } from 'app/shell/actions';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { isiOSBrowser } from 'app/utils/browsers';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { Portal } from 'app/utils/temp-container';
 import clsx from 'clsx';
 import { UseComboboxState, UseComboboxStateChangeOptions, useCombobox } from 'downshift';
@@ -86,9 +86,7 @@ const loadoutAutoCompleterSelector = createSelector(
   createAutocompleter,
 );
 
-const LazyFilterHelp = lazyWithRetry(
-  () => import(/* webpackChunkName: "filter-help" */ './FilterHelp'),
-);
+const LazyFilterHelp = lazy(() => import(/* webpackChunkName: "filter-help" */ './FilterHelp'));
 
 const RowContents = memo(({ item }: { item: SearchItem }) => {
   function highlight(text: string, section: string) {

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -26,10 +26,11 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { RootState } from 'app/store/types';
 import StripSockets from 'app/strip-sockets/StripSockets';
 import { setAppBadge } from 'app/utils/app-badge';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import { noop } from 'app/utils/functions';
 import SingleVendorSheetContainer from 'app/vendors/single-vendor/SingleVendorSheetContainer';
 import { fetchWishList } from 'app/wishlists/wishlist-fetch';
-import { lazy, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Route, Routes, useLocation, useParams } from 'react-router';
 import { Hotkey } from '../hotkeys/hotkeys';
@@ -40,39 +41,49 @@ import * as styles from './Destiny.m.scss';
 import ErrorPanel from './ErrorPanel';
 
 // TODO: Could be slightly better to group these a bit, but for now we break them each into a separate chunk.
-const Inventory = lazy(
+const Inventory = lazyWithRetry(
   () => import(/* webpackChunkName: "inventory" */ 'app/inventory-page/Inventory'),
 );
-const Progress = lazy(() => import(/* webpackChunkName: "progress" */ 'app/progress/Progress'));
-const LoadoutBuilderContainer = lazy(
+const Progress = lazyWithRetry(
+  () => import(/* webpackChunkName: "progress" */ 'app/progress/Progress'),
+);
+const LoadoutBuilderContainer = lazyWithRetry(
   () =>
     import(/* webpackChunkName: "loadoutBuilder" */ 'app/loadout-builder/LoadoutBuilderContainer'),
 );
-const D1LoadoutBuilder = lazy(
+const D1LoadoutBuilder = lazyWithRetry(
   () =>
     import(
       /* webpackChunkName: "d1LoadoutBuilder" */ 'app/destiny1/loadout-builder/D1LoadoutBuilder'
     ),
 );
-const Vendors = lazy(async () => import(/* webpackChunkName: "vendors" */ 'app/vendors/Vendors'));
-const SingleVendorPage = lazy(
+const Vendors = lazyWithRetry(
+  async () => import(/* webpackChunkName: "vendors" */ 'app/vendors/Vendors'),
+);
+const SingleVendorPage = lazyWithRetry(
   async () =>
     import(/* webpackChunkName: "vendors" */ 'app/vendors/single-vendor/SingleVendorPage'),
 );
-const D1Vendors = lazy(
+const D1Vendors = lazyWithRetry(
   () => import(/* webpackChunkName: "d1vendors" */ 'app/destiny1/vendors/D1Vendors'),
 );
-const RecordBooks = lazy(
+const RecordBooks = lazyWithRetry(
   () => import(/* webpackChunkName: "recordbooks" */ 'app/destiny1/record-books/RecordBooks'),
 );
-const Organizer = lazy(() => import(/* webpackChunkName: "organizer" */ 'app/organizer/Organizer'));
-const Activities = lazy(
+const Organizer = lazyWithRetry(
+  () => import(/* webpackChunkName: "organizer" */ 'app/organizer/Organizer'),
+);
+const Activities = lazyWithRetry(
   () => import(/* webpackChunkName: "activities" */ 'app/destiny1/activities/Activities'),
 );
-const Records = lazy(() => import(/* webpackChunkName: "records" */ 'app/records/Records'));
-const Loadouts = lazy(() => import(/* webpackChunkName: "loadouts" */ 'app/loadout/Loadouts'));
+const Records = lazyWithRetry(
+  () => import(/* webpackChunkName: "records" */ 'app/records/Records'),
+);
+const Loadouts = lazyWithRetry(
+  () => import(/* webpackChunkName: "loadouts" */ 'app/loadout/Loadouts'),
+);
 
-const SearchHistory = lazy(
+const SearchHistory = lazyWithRetry(
   () => import(/* webpackChunkName: "searchHistory" */ '../search/SearchHistory'),
 );
 

--- a/src/app/shell/Destiny.tsx
+++ b/src/app/shell/Destiny.tsx
@@ -26,7 +26,7 @@ import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { RootState } from 'app/store/types';
 import StripSockets from 'app/strip-sockets/StripSockets';
 import { setAppBadge } from 'app/utils/app-badge';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { noop } from 'app/utils/functions';
 import SingleVendorSheetContainer from 'app/vendors/single-vendor/SingleVendorSheetContainer';
 import { fetchWishList } from 'app/wishlists/wishlist-fetch';
@@ -41,49 +41,39 @@ import * as styles from './Destiny.m.scss';
 import ErrorPanel from './ErrorPanel';
 
 // TODO: Could be slightly better to group these a bit, but for now we break them each into a separate chunk.
-const Inventory = lazyWithRetry(
+const Inventory = lazy(
   () => import(/* webpackChunkName: "inventory" */ 'app/inventory-page/Inventory'),
 );
-const Progress = lazyWithRetry(
-  () => import(/* webpackChunkName: "progress" */ 'app/progress/Progress'),
-);
-const LoadoutBuilderContainer = lazyWithRetry(
+const Progress = lazy(() => import(/* webpackChunkName: "progress" */ 'app/progress/Progress'));
+const LoadoutBuilderContainer = lazy(
   () =>
     import(/* webpackChunkName: "loadoutBuilder" */ 'app/loadout-builder/LoadoutBuilderContainer'),
 );
-const D1LoadoutBuilder = lazyWithRetry(
+const D1LoadoutBuilder = lazy(
   () =>
     import(
       /* webpackChunkName: "d1LoadoutBuilder" */ 'app/destiny1/loadout-builder/D1LoadoutBuilder'
     ),
 );
-const Vendors = lazyWithRetry(
-  async () => import(/* webpackChunkName: "vendors" */ 'app/vendors/Vendors'),
-);
-const SingleVendorPage = lazyWithRetry(
+const Vendors = lazy(async () => import(/* webpackChunkName: "vendors" */ 'app/vendors/Vendors'));
+const SingleVendorPage = lazy(
   async () =>
     import(/* webpackChunkName: "vendors" */ 'app/vendors/single-vendor/SingleVendorPage'),
 );
-const D1Vendors = lazyWithRetry(
+const D1Vendors = lazy(
   () => import(/* webpackChunkName: "d1vendors" */ 'app/destiny1/vendors/D1Vendors'),
 );
-const RecordBooks = lazyWithRetry(
+const RecordBooks = lazy(
   () => import(/* webpackChunkName: "recordbooks" */ 'app/destiny1/record-books/RecordBooks'),
 );
-const Organizer = lazyWithRetry(
-  () => import(/* webpackChunkName: "organizer" */ 'app/organizer/Organizer'),
-);
-const Activities = lazyWithRetry(
+const Organizer = lazy(() => import(/* webpackChunkName: "organizer" */ 'app/organizer/Organizer'));
+const Activities = lazy(
   () => import(/* webpackChunkName: "activities" */ 'app/destiny1/activities/Activities'),
 );
-const Records = lazyWithRetry(
-  () => import(/* webpackChunkName: "records" */ 'app/records/Records'),
-);
-const Loadouts = lazyWithRetry(
-  () => import(/* webpackChunkName: "loadouts" */ 'app/loadout/Loadouts'),
-);
+const Records = lazy(() => import(/* webpackChunkName: "records" */ 'app/records/Records'));
+const Loadouts = lazy(() => import(/* webpackChunkName: "loadouts" */ 'app/loadout/Loadouts'));
 
-const SearchHistory = lazyWithRetry(
+const SearchHistory = lazy(
   () => import(/* webpackChunkName: "searchHistory" */ '../search/SearchHistory'),
 );
 

--- a/src/app/utils/chunk-load.ts
+++ b/src/app/utils/chunk-load.ts
@@ -1,5 +1,5 @@
 import { ComponentType, lazy, LazyExoticComponent } from 'react';
-
+import { delay } from './promises';
 /**
  * Was this error a failure to load a lazily-imported JS or CSS chunk? webpack throws a
  * ChunkLoadError for JS and an error with code CSS_CHUNK_LOAD_FAILED for CSS.
@@ -31,7 +31,7 @@ async function retryChunkImport<T>(
     return await factory();
   } catch (e) {
     if (retries > 0 && isChunkLoadError(e)) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await delay(delayMs);
       return retryChunkImport(factory, retries - 1, delayMs);
     }
     throw e;

--- a/src/app/utils/chunk-load.ts
+++ b/src/app/utils/chunk-load.ts
@@ -1,0 +1,49 @@
+import { ComponentType, lazy, LazyExoticComponent } from 'react';
+
+/**
+ * Was this error a failure to load a lazily-imported JS or CSS chunk? webpack throws a
+ * ChunkLoadError for JS and an error with code CSS_CHUNK_LOAD_FAILED for CSS.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.name === 'ChunkLoadError' ||
+    (error as { code?: string }).code === 'CSS_CHUNK_LOAD_FAILED' ||
+    /Loading (?:CSS )?chunk [\w-]+ failed/i.test(error.message)
+  );
+}
+
+/**
+ * Retry a dynamic import that failed to load a chunk. These failures are usually transient -
+ * a network blip, or the service worker taking control of the page mid-navigation during an
+ * update - and a second attempt a moment later succeeds (we intentionally keep old chunk files
+ * on the server, so the reference stays valid). Non-chunk errors, and chunk errors that survive
+ * the retries, are rethrown so the error boundary still handles them.
+ */
+async function retryChunkImport<T>(
+  factory: () => Promise<T>,
+  retries = 2,
+  delayMs = 300,
+): Promise<T> {
+  try {
+    return await factory();
+  } catch (e) {
+    if (retries > 0 && isChunkLoadError(e)) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      return retryChunkImport(factory, retries - 1, delayMs);
+    }
+    throw e;
+  }
+}
+
+/**
+ * Like React.lazy, but retries the import a couple of times if it fails with a chunk-load error
+ * before giving up. Use this instead of lazy() for route/component code-splitting.
+ */
+export function lazyWithRetry<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(() => retryChunkImport(factory));
+}

--- a/src/app/vendors/single-vendor/SingleVendorSheetContainer.tsx
+++ b/src/app/vendors/single-vendor/SingleVendorSheetContainer.tsx
@@ -1,11 +1,11 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
-import { lazyWithRetry } from 'app/utils/chunk-load';
+import { lazyWithRetry as lazy } from 'app/utils/chunk-load';
 import { useEventBusListener } from 'app/utils/hooks';
 import React, { Suspense, createContext, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { SingleVendorState, hideVendorSheet$ } from './single-vendor-sheet';
 
-const SingleVendorSheet = lazyWithRetry(
+const SingleVendorSheet = lazy(
   async () =>
     import(/* webpackChunkName: "vendors" */ 'app/vendors/single-vendor/SingleVendorSheet'),
 );

--- a/src/app/vendors/single-vendor/SingleVendorSheetContainer.tsx
+++ b/src/app/vendors/single-vendor/SingleVendorSheetContainer.tsx
@@ -1,10 +1,11 @@
 import { currentAccountSelector } from 'app/accounts/selectors';
+import { lazyWithRetry } from 'app/utils/chunk-load';
 import { useEventBusListener } from 'app/utils/hooks';
-import React, { Suspense, createContext, lazy, useCallback, useState } from 'react';
+import React, { Suspense, createContext, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { SingleVendorState, hideVendorSheet$ } from './single-vendor-sheet';
 
-const SingleVendorSheet = lazy(
+const SingleVendorSheet = lazyWithRetry(
   async () =>
     import(/* webpackChunkName: "vendors" */ 'app/vendors/single-vendor/SingleVendorSheet'),
 );


### PR DESCRIPTION
When a new version of DIM deploys while a tab is open, the running build references content-hashed JS/CSS chunk files that the deploy has replaced. Lazily navigating to a route then fails to load the now-missing chunk (ChunkLoadError / CSS_CHUNK_LOAD_FAILED), and ErrorBoundary showed an error panel and reported it to Sentry.

Detect chunk-load failures in ErrorBoundary and reload the page once to pull the fresh index.html and recover, instead of showing an error. A sessionStorage timestamp guards against reload loops: if a chunk fails again within 10s of a reload, we fall through to the normal error panel and report instead.

Fixes DIM-1YPE

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
