### PR TITLE
Handle Clarity load failures gracefully

### DIFF
--- a/src/app/clarity/descriptions/loadDescriptions.ts
+++ b/src/app/clarity/descriptions/loadDescriptions.ts
@@ -130,17 +130,28 @@ export function loadClarity(): ThunkResult {
     // The latter helps if there was an error loading them - it forces the next
     // refresh to try again.
     if (!descriptions || Date.now() - lastDescriptionUpdate > descriptionReloadAfter) {
-      const newInfo = await loadClarityDescriptions(!descriptions);
-      if (newInfo) {
-        dispatch(actions.loadDescriptions(newInfo));
+      // Clarity is an optional enhancement loaded from GitHub Pages, which can be flaky.
+      // Swallow any failure so it doesn't become an unhandled rejection (loadClarity is
+      // dispatched without awaiting) - DIM works fine with whatever Clarity data it has.
+      try {
+        const newInfo = await loadClarityDescriptions(!descriptions);
+        if (newInfo) {
+          dispatch(actions.loadDescriptions(newInfo));
+        }
+      } catch (e) {
+        errorLog('clarity', 'failed to load descriptions', e);
       }
       lastDescriptionUpdate = Date.now();
     }
 
     if (!characterStats || Date.now() - lastStatsUpdate > descriptionReloadAfter) {
-      const newInfo = await loadClarityStats(!characterStats);
-      if (newInfo) {
-        dispatch(actions.loadCharacterStats(newInfo));
+      try {
+        const newInfo = await loadClarityStats(!characterStats);
+        if (newInfo) {
+          dispatch(actions.loadCharacterStats(newInfo));
+        }
+      } catch (e) {
+        errorLog('clarity', 'failed to load character stats', e);
       }
       lastStatsUpdate = Date.now();
     }


### PR DESCRIPTION
Clarity descriptions and character stats are an optional enhancement fetched from GitHub Pages (database-clarity.github.io). The version-check fetches were caught, but the IDB-fallback fetches (fetchRemoteDescriptions / fetchRemoteStats) ran outside those catches, so when GitHub Pages is down and there's nothing usable in IndexedDB, the fetch threw. loadClarity is dispatched without awaiting, so that became an unhandled promise rejection and got reported to Sentry.

Wrap both load steps in loadClarity in try/catch so a Clarity load failure is logged and swallowed instead of surfacing - DIM works fine with whatever Clarity data it already has.

Fixes DIM-1NNZ

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
