### PR TITLE
Remove prefetchSrc from CSP configuration

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -76,7 +76,6 @@ export default function csp(
       // Mastodon feed
       'https://www.mastofeed.com/apiv2/feed',
     ],
-    prefetchSrc: [SELF],
     objectSrc: SELF,
     // Web app manifest
     manifestSrc: SELF,


### PR DESCRIPTION
Remove prefetchSrc directive from Content Security Policy.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/prefetch-src

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
