### PR TITLE
escape formula-like cells in csv export

### DIFF
--- a/src/app/utils/csv.test.ts
+++ b/src/app/utils/csv.test.ts
@@ -33,3 +33,13 @@ test('csv unpack', () => {
   const output = serializeCsv(arrayData, { unpackArrays: ['arr'] });
   expect(output).toMatchSnapshot();
 });
+
+test('csv escapes formula-like cells', () => {
+  const data = [{ name: '=cmd|calc', note: '@SUM(1)', tag: '+1', id: '-2' }];
+
+  const output = serializeCsv(data, {});
+  expect(output).toContain("'=cmd|calc");
+  expect(output).toContain("'@SUM(1)");
+  expect(output).toContain("'+1");
+  expect(output).toContain("'-2");
+});

--- a/src/app/utils/csv.ts
+++ b/src/app/utils/csv.ts
@@ -72,7 +72,7 @@ export function serializeCsv(data: CsvRow[], exportOptions: CsvExportOptions): s
     );
   }
 
-  return Papa.unparse(data, { columns: [...columnSet] });
+  return Papa.unparse(data, { columns: [...columnSet], escapeFormulae: true });
 }
 
 export function downloadCsv(


### PR DESCRIPTION
**Formula injection in CSV export**
The inventory and loadout CSV exports write item names, tags and notes straight through `serializeCsv`, and notes/tags can come from a shared loadout or an imported tags-notes CSV rather than just the local user. If one of those values starts with `=`, `+`, `-`, `@`, a tab or a carriage return, a spreadsheet treats it as a formula when the file is opened, so an exported sheet can run an attacker's expression. Turned on PapaParse's `escapeFormulae` so those cells get a leading apostrophe at the point we serialise.