### PR TITLE
Only rewrite en.json when its content changes

### DIFF
--- a/build/i18n.cjs
+++ b/build/i18n.cjs
@@ -1,0 +1,55 @@
+// Runs i18next-scanner, but only writes src/locale/en.json when the generated
+// content actually changes.
+//
+// Why: the dev server's file watcher reacts to writes, not content. `pnpm start`
+// runs watch:i18n in parallel with the dev server, and i18next-scanner rewrites
+// en.json on every startup (same bytes, fresh mtime). rspack imports en.json, so
+// that no-op write makes it do a spurious recompile right after the initial
+// build. That extra compile ships an HMR update a warm browser applies
+// mid-first-load, which can fail with "factory is undefined" across split chunks
+// until you reload. Scanning into a temp dir and copying only on a real change
+// removes that trigger (and incidentally stops needless en.json mtime churn).
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const localeFile = path.join(root, 'src', 'locale', 'en.json');
+const tmpOut = fs.mkdtempSync(path.join(os.tmpdir(), 'dim-i18n-'));
+
+try {
+  // Resolve the scanner's CLI so this works whether invoked via pnpm or directly.
+  let result;
+  const env = { ...process.env, I18N_OUTPUT_DIR: tmpOut };
+  try {
+    const pkg = require('i18next-scanner/package.json');
+    const pkgDir = path.dirname(require.resolve('i18next-scanner/package.json'));
+    const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['i18next-scanner'];
+    result = spawnSync(
+      process.execPath,
+      [path.join(pkgDir, binRel), '--config', './i18next-scanner.config.cjs'],
+      { stdio: 'inherit', env },
+    );
+  } catch {
+    result = spawnSync('i18next-scanner', ['--config', './i18next-scanner.config.cjs'], {
+      stdio: 'inherit',
+      shell: true,
+      env,
+    });
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+
+  const generated = path.join(tmpOut, 'src', 'locale', 'en.json');
+  const next = fs.readFileSync(generated, 'utf8');
+  const current = fs.existsSync(localeFile) ? fs.readFileSync(localeFile, 'utf8') : null;
+  if (next !== current) {
+    fs.mkdirSync(path.dirname(localeFile), { recursive: true });
+    fs.writeFileSync(localeFile, next);
+  }
+} finally {
+  fs.rmSync(tmpOut, { recursive: true, force: true });
+}

--- a/build/i18n.cjs
+++ b/build/i18n.cjs
@@ -17,39 +17,29 @@ const path = require('node:path');
 const root = path.resolve(__dirname, '..');
 const localeFile = path.join(root, 'src', 'locale', 'en.json');
 const tmpOut = fs.mkdtempSync(path.join(os.tmpdir(), 'dim-i18n-'));
+// Clean up the scratch dir on any exit. Has to be an exit handler rather than a
+// finally: the process.exit() below short-circuits finally blocks.
+process.on('exit', () => fs.rmSync(tmpOut, { recursive: true, force: true }));
 
-try {
-  // Resolve the scanner's CLI so this works whether invoked via pnpm or directly.
-  let result;
-  const env = { ...process.env, I18N_OUTPUT_DIR: tmpOut };
-  try {
-    const pkg = require('i18next-scanner/package.json');
-    const pkgDir = path.dirname(require.resolve('i18next-scanner/package.json'));
-    const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['i18next-scanner'];
-    result = spawnSync(
-      process.execPath,
-      [path.join(pkgDir, binRel), '--config', './i18next-scanner.config.cjs'],
-      { stdio: 'inherit', env },
-    );
-  } catch {
-    result = spawnSync('i18next-scanner', ['--config', './i18next-scanner.config.cjs'], {
-      stdio: 'inherit',
-      shell: true,
-      env,
-    });
-  }
+// Run the scanner's CLI via its resolved entry point rather than relying on a
+// `i18next-scanner` shim being on PATH.
+const pkg = require('i18next-scanner/package.json');
+const pkgDir = path.dirname(require.resolve('i18next-scanner/package.json'));
+const binRel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin['i18next-scanner'];
+const result = spawnSync(
+  process.execPath,
+  [path.join(pkgDir, binRel), '--config', './i18next-scanner.config.cjs'],
+  { stdio: 'inherit', env: { ...process.env, I18N_OUTPUT_DIR: tmpOut } },
+);
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
 
-  const generated = path.join(tmpOut, 'src', 'locale', 'en.json');
-  const next = fs.readFileSync(generated, 'utf8');
-  const current = fs.existsSync(localeFile) ? fs.readFileSync(localeFile, 'utf8') : null;
-  if (next !== current) {
-    fs.mkdirSync(path.dirname(localeFile), { recursive: true });
-    fs.writeFileSync(localeFile, next);
-  }
-} finally {
-  fs.rmSync(tmpOut, { recursive: true, force: true });
+const generated = path.join(tmpOut, 'src', 'locale', 'en.json');
+const next = fs.readFileSync(generated, 'utf8');
+const current = fs.existsSync(localeFile) ? fs.readFileSync(localeFile, 'utf8') : null;
+if (next !== current) {
+  fs.mkdirSync(path.dirname(localeFile), { recursive: true });
+  fs.writeFileSync(localeFile, next);
 }

--- a/i18next-scanner.config.cjs
+++ b/i18next-scanner.config.cjs
@@ -4,7 +4,9 @@ const typescript = require('typescript');
 
 module.exports = {
   input: ['src/app/**/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}', 'src/browsercheck.js'],
-  output: './',
+  // build/i18n.cjs points this at a temp dir so it can diff the result and only
+  // overwrite src/locale/en.json on a real change (see that file for why).
+  output: process.env.I18N_OUTPUT_DIR || './',
   options: {
     debug: false,
     removeUnusedKeys: true,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:beta": "pnpm -s bundle --env=beta --node-env=production",
     "build:pr": "pnpm -s bundle --env=pr --node-env=production",
     "build:dev": "pnpm -s bundle --env=dev",
-    "i18n": "i18next-scanner --config ./i18next-scanner.config.cjs",
+    "i18n": "node build/i18n.cjs",
     "start": "pnpm run --reporter-hide-prefix --stream '/^(watch:i18n|devserver)$/'",
     "devserver": "nodemon --delay 2 --watch config/webpack.ts --watch config/feature-flags.ts --watch config/content-security-policy.ts --watch pnpm-lock.yaml -e ts,js,json,lock --exec \"pnpm install --frozen-lockfile --prefer-offline && rspack serve --config ./config/webpack.ts --env=dev || pnpm touch\"",
     "touch": "node -e \"require('fs').utimes('config/webpack.ts', new Date(), new Date(), () => {})\"",


### PR DESCRIPTION
watch:i18n runs i18next-scanner at startup, which rewrote src/locale/en.json with a fresh mtime on every run even when the content was identical. The dev server watches writes (not content), so that no-op write triggered a spurious recompile right after the initial build. build/i18n.cjs scans into a temp dir (via I18N_OUTPUT_DIR) and overwrites en.json only on a real change.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
