### PR TITLE
Type i18n keys with a shared registry instead of metadata

### DIFF
--- a/i18next-scanner.config.cjs
+++ b/i18next-scanner.config.cjs
@@ -2,6 +2,37 @@ const fs = require('fs');
 const path = require('path');
 const typescript = require('typescript');
 
+// Load the shared key registry from its TS source. It's pure data (type-only imports), so we can transpile and eval it standalone.
+function loadI18nRegistry() {
+  const src = fs.readFileSync(path.resolve(__dirname, 'src/app/i18n-keys.ts'), 'utf8');
+  const { outputText } = typescript.transpileModule(src, {
+    compilerOptions: {
+      module: typescript.ModuleKind.CommonJS,
+      target: typescript.ScriptTarget.ES2019,
+    },
+  });
+  const mod = { exports: {} };
+  new Function('module', 'exports', 'require', outputText)(mod, mod.exports, require);
+  return mod.exports;
+}
+
+const { I18N_KEYS, I18N_CONTEXTS } = loadI18nRegistry();
+
+// Emit `Prefix.Value` for every registered key. Done from the transform rather than a custom
+// flush, which would override the scanner's default resource-writing. Runs once.
+let registryEmitted = false;
+function emitRegistryKeys(parser) {
+  if (registryEmitted) {
+    return;
+  }
+  registryEmitted = true;
+  for (const [prefix, values] of Object.entries(I18N_KEYS)) {
+    for (const value of values) {
+      parser.set(`${prefix}.${value}`);
+    }
+  }
+}
+
 module.exports = {
   input: ['src/app/**/*.{js,jsx,ts,tsx,cjs,mjs,cts,mts}', 'src/browsercheck.js'],
   // build/i18n.cjs points this at a temp dir so it can diff the result and only
@@ -26,67 +57,38 @@ module.exports = {
     context: true,
     contextFallback: true,
     contextDefaultValues: ['male', 'female'],
-    allowDynamicKeys: true,
   },
-  transform: function customTransform(file, enc, done) {
-    'use strict';
-    const tsExts = ['.ts', '.tsx'];
+  transform(file, enc, done) {
     const parser = this.parser;
+    emitRegistryKeys(parser);
 
     const { base, ext } = path.parse(file.path);
     let content = fs.readFileSync(file.path, enc);
-    const isTs = tsExts.includes(ext) && !base.includes('.d.ts');
+    const isTs = ['.ts', '.tsx'].includes(ext) && !base.includes('.d.ts');
 
     if (isTs) {
-      const { outputText } = typescript.transpileModule(content, {
-        compilerOptions: {
-          target: 'es2018',
-          jsx: 'preserve',
-        },
+      content = typescript.transpileModule(content, {
+        compilerOptions: { target: 'es2018', jsx: 'preserve' },
         fileName: path.basename(file.path),
-      });
-      content = outputText;
+      }).outputText;
     }
 
-    // prettier-ignore
-    const contexts = {
-      compact: ['compact'],
-      max: ['Max'],
-    };
-
-    // prettier-ignore
-    const keys = {
-      buckets: { list: ['General', 'Inventory', 'Postmaster', 'Progress', 'Unknown'] },
-      difficulty: { list: ['Normal', 'Hard'] },
-      progress: { list: ['Bounties', 'Items', 'Quests'] },
-      sockets: { list: ['Mod', 'Ability', 'Shader', 'Ornament', 'Fragment', 'Aspect', 'Projection', 'Transmat', 'Super'] }
-    };
-    const dimTransformer = (key, options) => {
-      if (options.metadata?.context) {
-        // Add context based on metadata
+    const transformer = (key, options) => {
+      const contexts = I18N_CONTEXTS[key];
+      if (contexts) {
+        // Drop the runtime-dynamic context so the scanner's native male/female expansion
+        // doesn't kick in; keep the rest of options so plurals still expand per variant.
         delete options.context;
-        const context = contexts[options.metadata?.context];
         parser.set(key, options);
-        for (let i = 0; i < context?.length; i++) {
-          parser.set(`${key}${parser.options.contextSeparator}${context[i]}`, options);
+        for (const ctx of contexts) {
+          parser.set(`${key}${parser.options.contextSeparator}${ctx}`, options);
         }
-      }
-
-      if (options.metadata?.keys) {
-        // Add keys based on metadata (dynamic or otherwise)
-        const list = keys[options.metadata?.keys].list;
-        for (let i = 0; i < list?.length; i++) {
-          parser.set(`${key}${list[i]}`, options);
-        }
-      }
-
-      // Add all other non-metadata related keys w/ default options
-      if (!options.metadata) {
+      } else {
         parser.set(key, options);
       }
     };
 
-    parser.parseFuncFromString(content, { list: ['t', 'tl', 'DimError'] }, dimTransformer);
+    parser.parseFuncFromString(content, { list: ['t', 'tl', 'DimError'] }, transformer);
 
     done();
   },

--- a/src/app/destiny1/activities/Activities.tsx
+++ b/src/app/destiny1/activities/Activities.tsx
@@ -185,9 +185,7 @@ function useActivities(defs: D1ManifestDefinitions | undefined, characters: D1St
         tier.activityData.recommendedLight === 390
           ? '390'
           : tier.tierDisplayName
-            ? t(`Activities.${tier.tierDisplayName}`, {
-                metadata: { keys: 'difficulty' },
-              })
+            ? t(`Activities.${tier.tierDisplayName}`)
             : tierDef.activityName;
 
       const characters =

--- a/src/app/i18n-keys.ts
+++ b/src/app/i18n-keys.ts
@@ -1,0 +1,53 @@
+import type { BucketSortType } from 'app/inventory/inventory-buckets';
+
+/**
+ * Single source of truth for i18n keys built from a prefix plus a runtime value.
+ * The i18next-scanner reads this to emit the full `Prefix.Value` key set, which
+ * in turn types `t()`. Keep it pure data (only `import type`) so the scanner can
+ * load it standalone in Node.
+ */
+
+// Mirrors BucketSortType (enforced by `satisfies`) so titles exist for every category.
+export const BUCKETS = [
+  'General',
+  'Inventory',
+  'Postmaster',
+  'Progress',
+  'Unknown',
+  'Weapons',
+  'Armor',
+] as const satisfies readonly BucketSortType[];
+
+/** Pursuit groupings rendered as `Progress.<group>` titles. */
+export const PROGRESS_GROUPS = ['Bounties', 'Items', 'Quests'] as const;
+
+/** Socket categories rendered as `Sockets.Insert.<kind>` / `Sockets.Select.<kind>`. */
+export const SOCKET_KINDS = [
+  'Mod',
+  'Ability',
+  'Shader',
+  'Ornament',
+  'Fragment',
+  'Aspect',
+  'Projection',
+  'Transmat',
+  'Super',
+] as const;
+
+/** D1 activity difficulties rendered as `Activities.<difficulty>`. */
+export const DIFFICULTIES = ['Normal', 'Hard'] as const;
+
+/** `Prefix -> values`. The scanner flattens this to `Prefix.Value` keys; the app references them as `t(`Prefix.${value}`)`. */
+export const I18N_KEYS = {
+  Bucket: BUCKETS,
+  Progress: PROGRESS_GROUPS,
+  'Sockets.Insert': SOCKET_KINDS,
+  'Sockets.Select': SOCKET_KINDS,
+  Activities: DIFFICULTIES,
+} as const;
+
+/** Context variants by base key. The scanner emits a `BaseKey_<context>` key for each; the app selects one via i18next's `context` option. */
+export const I18N_CONTEXTS = {
+  'Countdown.Days': ['compact'],
+  'Stats.TierProgress': ['Max'],
+} as const;

--- a/src/app/i18next-t.ts
+++ b/src/app/i18next-t.ts
@@ -7,7 +7,7 @@ export type I18nKey = ParseKeys;
 export const t = (
   key: I18nKey,
   opts?:
-    | { count?: number; context?: string; metadata?: { context?: string[]; keys?: string } }
+    | { count?: number; context?: string }
     | {
         [arg: string]: number | string;
       },

--- a/src/app/inventory-page/CategoryStrip.tsx
+++ b/src/app/inventory-page/CategoryStrip.tsx
@@ -25,7 +25,7 @@ export default function CategoryStrip({
               onClick={() => onCategorySelected(category)}
               className={clsx({ [styles.selected]: category === selectedCategoryId })}
             >
-              {t(`Bucket.${category as BucketSortType}`, { metadata: { keys: 'buckets' } })}
+              {t(`Bucket.${category as BucketSortType}`)}
             </div>
           ),
       )}

--- a/src/app/inventory-page/DesktopStores.tsx
+++ b/src/app/inventory-page/DesktopStores.tsx
@@ -169,7 +169,7 @@ function CollapsibleContainer({
 
   return (
     <InventoryCollapsibleTitle
-      title={t(`Bucket.${category as BucketSortType}`, { metadata: { keys: 'buckets' } })}
+      title={t(`Bucket.${category as BucketSortType}`)}
       sectionId={category}
       stores={stores}
     >

--- a/src/app/item-popup/SocketDetailsSelectedPlug.tsx
+++ b/src/app/item-popup/SocketDetailsSelectedPlug.tsx
@@ -176,9 +176,7 @@ export default function SocketDetailsSelectedPlug({
     canInsertPlug(socket, plug.hash, destiny2CoreSettings, defs);
 
   const kind = uiCategorizeSocket(defs, socket.socketDefinition);
-  const insertName = canDoAWA
-    ? t(`Sockets.Insert.${kind}`, { metadata: { keys: 'sockets' } })
-    : t(`Sockets.Select.${kind}`, { metadata: { keys: 'sockets' } });
+  const insertName = canDoAWA ? t(`Sockets.Insert.${kind}`) : t(`Sockets.Select.${kind}`);
 
   const [insertInProgress, setInsertInProgress] = useState(false);
 

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -330,7 +330,7 @@ function LoadoutEditCategorySection({
   return (
     <LoadoutEditSection
       className={styles.section}
-      title={t(`Bucket.${category}`, { metadata: { keys: 'buckets' } })}
+      title={t(`Bucket.${category}`)}
       onClear={() => handleClearCategory(category)}
       onRandomize={() => handleRandomizeCategory(allItems, category, searchFilter)}
       hasRandomizeQuery={searchFilter !== stubTrue}

--- a/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutItemCategorySection.tsx
@@ -137,7 +137,7 @@ export default function LoadoutItemCategorySection({
       ) : (
         <>
           <div className={clsx(styles.placeholder, `category-${category}`)}>
-            {t(`Bucket.${category}`, { metadata: { keys: 'buckets' } })}
+            {t(`Bucket.${category}`)}
           </div>
         </>
       )}

--- a/src/app/progress/Pursuits.tsx
+++ b/src/app/progress/Pursuits.tsx
@@ -63,10 +63,7 @@ export default function Pursuits({ store }: { store: DimStore }) {
         (group) =>
           pursuits[group] && (
             <section id={group} key={group}>
-              <CollapsibleTitle
-                title={t(`Progress.${group}`, { metadata: { keys: 'progress' } })}
-                sectionId={`pursuits-${group}`}
-              >
+              <CollapsibleTitle title={t(`Progress.${group}`)} sectionId={`pursuits-${group}`}>
                 <PursuitsGroup defs={defs} pursuits={pursuits[group]} store={store} />
               </CollapsibleTitle>
             </section>

--- a/src/app/store-stats/D1CharacterStats.tsx
+++ b/src/app/store-stats/D1CharacterStats.tsx
@@ -26,7 +26,6 @@ export function D1CharacterStats({
     const tier = Math.floor(Math.min(300, stat.value) / 60);
     const next = t('Stats.TierProgress', {
       context: tier === 5 ? 'Max' : '',
-      metadata: { context: ['max'] },
       progress: tier === 5 ? stat.value : stat.value % 60,
       tier,
       nextTier: tier + 1,

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -62,7 +62,6 @@ export function i15dDurationFromMs(milliseconds: number, compact = false) {
     ? `${t('Countdown.Days', {
         count: days,
         context: compact ? 'compact' : '',
-        metadata: { context: ['compact'] },
       })} ${hhMM}`
     : `${hhMM}`;
 }
@@ -83,7 +82,6 @@ export function i15dDurationFromMsWithSeconds(milliseconds: number) {
     ? `${t('Countdown.Days', {
         count: days,
         context: '',
-        metadata: { context: ['compact'] },
       })} ${hhMM}`
     : `${hhMM}`;
 }


### PR DESCRIPTION
Replace the metadata-driven dynamic translation keys with a single typed source of truth, and drive the i18next-scanner from it.

- Add src/app/i18n-keys.ts: domain constants (BUCKETS, PROGRESS_GROUPS, SOCKET_KINDS, DIFFICULTIES) and the I18N_KEYS / I18N_CONTEXTS registries. BUCKETS is tied to BucketSortType via `satisfies` so it cannot drift.
- Drive i18next-scanner from the registry: transpile and load I18N_KEYS / I18N_CONTEXTS and emit their Prefix.Value (and context-variant) keys, replacing the metadata parsing, dynamic-key inference, hardcoded maps, and allowDynamicKeys. Generated en.json is unchanged.
- Drop the per-call metadata: keys map to plain t(`Prefix.${value}`) template literals. The scanner emits the full key set from the registry, and t()'s ParseKeys-typed key still type-checks each literal, so no helper or cast is needed beyond ones the call sites already had.
- Drop the scanner-only metadata from the context calls (the native i18next context option already drives them at runtime), and remove the now-unused metadata option from the t() wrapper type.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
