### PR TITLE
Fix: Armory used invalid ornament screenshot.

### DIFF
--- a/src/app/armory/Armory.tsx
+++ b/src/app/armory/Armory.tsx
@@ -27,6 +27,7 @@ import { hideItemPopup } from 'app/item-popup/item-popup';
 import { useD2Definitions } from 'app/manifest/selectors';
 import Objective from 'app/progress/Objective';
 import { Reward } from 'app/progress/Reward';
+import { badDefaultOrnament } from 'app/search/d2-known-values';
 import { AppIcon, compareIcon, faMinusSquare, faPlusSquare, thumbsUpIcon } from 'app/shell/icons';
 import { useIsPhonePortrait } from 'app/shell/selectors';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
@@ -92,8 +93,10 @@ export default function Armory({
 
   const collectible = item.collectibleHash ? defs.Collectible.get(item.collectibleHash) : undefined;
 
-  // Use the ornament's screenshot if available
-  const ornamentSocket = item.sockets?.allSockets.find((s) => s.plugged?.plugDef.screenshot);
+  // Use the ornament's screenshot if available (and valid)
+  const ornamentSocket = item.sockets?.allSockets.find(
+    (s) => s.plugged?.plugDef.screenshot && s.plugged?.plugDef.hash !== badDefaultOrnament,
+  );
   const screenshot = ornamentSocket?.plugged?.plugDef.screenshot || itemDef.screenshot;
   const flavorText = itemDef.flavorText || itemDef.displaySource;
 

--- a/src/app/search/d2-known-values.ts
+++ b/src/app/search/d2-known-values.ts
@@ -17,8 +17,11 @@ import {
 // this file has non-programatically decided information
 // hashes, names, & enums, hand-crafted and chosen by us
 
+// An image like ⍁ that one should try to find a replacement image for.
 export const d2MissingIcon = '/img/misc/missing_icon_d2.png';
-
+// A "Default Ornament" definition that advertises having a screenshot,
+// but doesn't have one, and shouldn't be used if it did.
+export const badDefaultOrnament = 3854296178;
 //
 // GAME MECHANICS KNOWN VALUES
 //


### PR DESCRIPTION
Bungie erroneously associates a (404) screenshot with the new Default Ornament plug item. This ignores its screenshot. Isolated to Armory right now because it's the only place DIM uses plugs' screenshots.