### PR TITLE
Fall back zh-cht/zh-chs to each other before English

### DIFF
--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -86,11 +86,13 @@ export async function initi18n(): Promise<void> {
   await i18next.use(HttpApi).init<HttpBackendOptions>({
     debug: false,
     lng: lang,
-    // The two Chinese variants are mutually intelligible enough that a missing
-    // key is better served by the other variant than by English.
+    // Variants of the same language are mutually intelligible enough that a
+    // missing key is better served by the sibling variant than by English.
     fallbackLng: {
       'zh-cht': ['zh-chs', 'en'],
       'zh-chs': ['zh-cht', 'en'],
+      'es-mx': ['es', 'en'],
+      es: ['es-mx', 'en'],
       default: ['en'],
     },
     lowerCaseLng: true,

--- a/src/app/i18n.ts
+++ b/src/app/i18n.ts
@@ -86,7 +86,13 @@ export async function initi18n(): Promise<void> {
   await i18next.use(HttpApi).init<HttpBackendOptions>({
     debug: false,
     lng: lang,
-    fallbackLng: 'en',
+    // The two Chinese variants are mutually intelligible enough that a missing
+    // key is better served by the other variant than by English.
+    fallbackLng: {
+      'zh-cht': ['zh-chs', 'en'],
+      'zh-chs': ['zh-cht', 'en'],
+      default: ['en'],
+    },
     lowerCaseLng: true,
     supportedLngs: DIM_LANGS,
     load: 'currentOnly',


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->

Changelog: Chinese and Spanish language variants now fall back to their sibling variant before English for any untranslated text.