### PR TITLE
Retry manifest component download in tests

### DIFF
--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -83,10 +83,24 @@ export async function getTestManifestJson() {
 
     await fs.mkdir(cacheDir, { recursive: true });
 
-    const manifestDb = await downloadManifestComponents(
-      manifest.jsonWorldComponentContentPaths.en,
-      allTables,
-    );
+    // The component download can fail partway through on a flaky network (e.g. a
+    // premature stream close on the largest table), so retry with a delay like
+    // the manifest fetch above rather than failing CI on a transient error.
+    let manifestDb: AllDestinyManifestComponents;
+    for (let i = 0; ; i++) {
+      try {
+        manifestDb = await downloadManifestComponents(
+          manifest.jsonWorldComponentContentPaths.en,
+          allTables,
+        );
+        break;
+      } catch (e) {
+        if (i === 4) {
+          throw e;
+        }
+        await delay(1000);
+      }
+    }
     await fs.writeFile(filename, JSON.stringify(manifestDb), 'utf-8');
     return [manifestDb, filename] as const;
   } finally {


### PR DESCRIPTION
## Problem

The `precache-manifest` test downloads the live Destiny manifest from bungie.net. The component download can fail partway through on a flaky network, e.g. a premature stream close on the largest table (`DestinyInventoryItemDefinition`, ~10.6 MB):

```
FetchError: Invalid response body while trying to fetch
https://www.bungie.net/.../DestinyInventoryItemDefinition-...json: Premature close
ERR_STREAM_PREMATURE_CLOSE
```

This trips CI on a transient error that has nothing to do with the change under test. `loadTable` already retries its cache-buster URLs, but those attempts are immediate and back-to-back, so a brief bad patch on the runner's connection blows through all of them.

## Fix

Wrap the `downloadManifestComponents` call in `getTestManifestJson` with a delayed retry loop, mirroring the `d2GetManifest` retry that already sits just above it (5 attempts, 1s delay). The delay between attempts is what lets a transient network condition recover.

Scope is limited to the testing utilities; production manifest loading is unchanged.

## Testing

- `pnpm lint` and `tsc` clean
- `jest -i src/testing/precache-manifest.test.ts` passes