### PR TITLE
Fix flaky CI manifest download by seeding the cache via curl

### DIFF
--- a/.github/workflows/manifest-cache.yml
+++ b/.github/workflows/manifest-cache.yml
@@ -1,0 +1,46 @@
+name: Warm Manifest Cache
+
+# PR validation needs the current Destiny manifest, but a PR can only restore
+# caches from its own branch or the default branch. Since PR Validation is
+# pull_request-only, nothing keeps a default-branch manifest cache fresh, so once
+# Bungie ships a new manifest every PR falls back to the (unreliable) live
+# download. This job runs on the default branch to publish a current manifest
+# cache that all PRs can restore.
+
+on:
+  schedule:
+    # Every 6 hours - manifest updates are infrequent and this only re-downloads
+    # when the version actually changed.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: warm-manifest-cache
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      # A unique key always saves a fresh entry; restore-keys reuses the previous
+      # one so an unchanged manifest is a no-op. PRs find this via the shared
+      # `destiny-manifest-` prefix.
+      - name: Cache Manifest
+        uses: actions/cache@v5
+        with:
+          path: manifest-cache
+          key: destiny-manifest-${{ github.run_id }}
+          restore-keys: |
+            destiny-manifest-
+
+      - name: Download manifest
+        run: bash build/download-manifest.sh
+
+      # Keep only the newest manifest so the cache doesn't accumulate old versions.
+      - name: Prune old manifests
+        run: |
+          cd manifest-cache
+          ls -t | tail -n +2 | xargs -r rm -f

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -38,6 +38,13 @@ jobs:
           restore-keys: |
             destiny-manifest-
 
+      # Seed the cache with the current manifest via curl when the restored cache
+      # is missing or stale. The in-test download streams a ~190MB body that
+      # truncates from GitHub runners; this avoids relying on it. No-op when the
+      # current manifest is already cached.
+      - name: Download manifest
+        run: bash build/download-manifest.sh
+
       - name: Run tests
         run: pnpm test
         env:

--- a/build/download-manifest.sh
+++ b/build/download-manifest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Pre-populate manifest-cache/ with the current Destiny manifest for CI tests.
+#
+# The test harness downloads the manifest itself, but it streams the ~190MB
+# per-table definitions through Node's fetch, and that transfer truncates from
+# GitHub runners ("Premature close") - see the failures around 2026-06. curl
+# pulls the gzipped aggregate (~23MB on the wire) and detects/retries truncated
+# transfers, so seeding the cache here lets the in-test cache-hit path take over
+# and the fragile in-process download never runs.
+set -euo pipefail
+
+cache_dir="manifest-cache"
+mkdir -p "$cache_dir"
+
+# The manifest info endpoint is small and reliable; it tells us the versioned
+# path of the single combined ("aggregate") manifest file.
+manifest_path=$(
+  curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+    https://www.bungie.net/Platform/Destiny2/Manifest/ |
+    jq -r '.Response.jsonWorldContentPaths.en'
+)
+filename=$(basename "$manifest_path")
+
+if [ -f "$cache_dir/$filename" ]; then
+  echo "Manifest $filename already cached"
+  exit 0
+fi
+
+# Download to a temp file and move into place only on success, so an interrupted
+# transfer can't leave a partial file that later reads as the cached manifest.
+echo "Downloading manifest $filename"
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+curl -fSL --compressed --retry 5 --retry-all-errors --retry-delay 2 \
+  -o "$tmp" "https://www.bungie.net$manifest_path"
+mv "$tmp" "$cache_dir/$filename"
+echo "Saved $cache_dir/$filename"


### PR DESCRIPTION
PR test runs fetch the live Destiny manifest, but Node's fetch streams the ~190MB per-table definitions over a connection that truncates from GitHub runners (Premature close), and the in-test retry/cache-buster loop can't recover. The manifest cache used to mask this, but PRs can only restore caches from their own branch or the default branch, and PR Validation (pull_request-only) never refreshes a default-branch cache, so once Bungie ships a new manifest every PR falls back to the broken download.

Two fixes: a build/download-manifest.sh that curls the gzipped aggregate (~23MB on the wire) with retries and detects truncation, wired into PR Validation before the tests so the in-test cache-hit path takes over; and a scheduled manifest-cache workflow that runs on the default branch to keep a current manifest cache that all PRs can restore.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
