### PR TITLE
Fix perk tooltips shrinking to the item popup width

### DIFF
--- a/src/app/dim-ui/PressTip.m.scss
+++ b/src/app/dim-ui/PressTip.m.scss
@@ -12,7 +12,10 @@ $horizontal-padding: 11px;
   position: absolute;
   background-color: var(--theme-tooltip-body-bg);
   color: #dadaea;
-  width: fit-content;
+  // Size to the content (capped by max-width), not the available space. The
+  // tooltip is positioned by offset within its containing block (often the item
+  // popup), and fit-content would shrink it to whatever room is left there.
+  width: max-content;
   max-width: 306px;
   border: 1px solid var(--theme-tooltip-border);
   border-top-width: $theme-tooltip-corner-radius;


### PR DESCRIPTION
After the Floating UI migration the tooltip is positioned by left/top offset within its containing block (the item popup), so width: fit-content shrank it to the room left at that offset and capped it at the popup width. Use width: max-content so it sizes to its content (still capped by max-width) regardless of position or containing block.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
