### PR TITLE
Loadout Optimizer: process-loop performance

### DIFF
--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -1,7 +1,13 @@
 import { MAX_STAT } from 'app/loadout/known-values';
 import { generatePermutationsOfFive } from 'app/loadout/mod-permutations';
 import { count } from 'app/utils/collections';
-import { ArmorStatHashes, artificeStatBoost, DesiredStatRange, MinMaxStat } from '../types';
+import {
+  ArmorStatHashes,
+  artificeStatBoost,
+  DesiredStatRange,
+  majorStatBoost,
+  MinMaxStat,
+} from '../types';
 import { AutoModsCache, buildAutoModsMap, chooseAutoMods, ModsPick } from './auto-stat-mod-utils';
 import { AutoModData, ModAssignmentStatistics, ProcessItem, ProcessMod } from './types';
 
@@ -162,6 +168,11 @@ export function updateMaxStats(
     return foundAnyImprovement;
   }
 
+  // Cheap upper bound on what auto mods can add to one stat (ignoring energy and
+  // slot limits), used to skip the search for sets that can't raise the max.
+  const maxSingleStatBonus =
+    info.numAvailableGeneralMods * majorStatBoost + numArtificeMods * artificeStatBoost;
+
   let remainingEnergyResult: ReturnType<typeof getRemainingEnergiesPerAssignment> | undefined;
 
   // You wouldn't believe it, but Firefox is actually slow loading constants
@@ -179,50 +190,63 @@ export function updateMaxStats(
       continue;
     }
 
+    // If even the best-case mod bonus can't beat the running max, the search
+    // below would just fail, so skip it (and its energy precompute).
+    if (value + maxSingleStatBonus <= statRange.maxStat) {
+      continue;
+    }
+
     remainingEnergyResult ??= getRemainingEnergiesPerAssignment(
       info.activityModPermutations,
       armor,
     );
     const { remainingEnergiesPerAssignment, setEnergy } = remainingEnergyResult;
+    const energyBudget = setEnergy - info.totalModEnergyCost;
 
-    // Since we calculate the maximum stat value we can hit for a stat in
-    // isolation, require all other stats to hit their constrained minimums, but
-    // for this stat we start from the highest stat max we've observed. Remember
-    // that this array is expressed in terms of additional stat points.
+    // We push this stat as high as it'll go with the other stats held at their
+    // minimums. Values here are additional stat points, not totals.
     const previousRequiredMinimum = requiredMinimumExtraStats[statIndex];
-    requiredMinimumExtraStats[statIndex] = statRange.maxStat - value;
 
-    // TODO: Rather than iterating one point at a time, we could run our greedy
-    // assignment search that maximizes stats but with stat ranges that prevent
-    // us from going over our minimum? Or maybe do a binary search for the
-    // maximum we can reach?
-    while (statRange.maxStat < maxStat) {
-      // Now that tiers no longer matter (since Edge of Fate), we consider any
-      // stat point increase a "tier". This should be a short-term change -
-      // ideally we'd reconsider all these algorithms to see if they could be
-      // simplified now that the tier concept is gone.
-      requiredMinimumExtraStats[statIndex] += 1;
-
-      // Now see if there's any way to hit that stat with mods.
-      if (
-        !chooseAutoMods(
-          info,
-          requiredMinimumExtraStats,
-          numArtificeMods,
-          remainingEnergiesPerAssignment,
-          setEnergy - info.totalModEnergyCost,
-        )
-      ) {
-        break;
+    // First just probe whether we can beat the current max at all. In steady
+    // state most sets can't, so this single check replaces the old
+    // increment-by-one loop.
+    requiredMinimumExtraStats[statIndex] = statRange.maxStat - value + 1;
+    if (
+      chooseAutoMods(
+        info,
+        requiredMinimumExtraStats,
+        numArtificeMods,
+        remainingEnergiesPerAssignment,
+        energyBudget,
+      )
+    ) {
+      // We can do better than the running max. Binary search for the highest
+      // reachable value rather than stepping one point at a time. chooseAutoMods
+      // is monotonic in a single stat's requirement, so this is exact.
+      let good = requiredMinimumExtraStats[statIndex];
+      let high = maxStat - value;
+      while (good < high) {
+        const mid = (good + high + 1) >> 1;
+        requiredMinimumExtraStats[statIndex] = mid;
+        if (
+          chooseAutoMods(
+            info,
+            requiredMinimumExtraStats,
+            numArtificeMods,
+            remainingEnergiesPerAssignment,
+            energyBudget,
+          )
+        ) {
+          good = mid;
+        } else {
+          high = mid - 1;
+        }
       }
-
-      const newValue = value + requiredMinimumExtraStats[statIndex];
+      const newValue = value + good;
       // filter.minStat < filter.maxStat just checks to make sure you can
       // actually improve the stat given the user's new constraints.
       foundAnyImprovement ||= filter.minStat < filter.maxStat && newValue > filter.minStat;
       statRange.maxStat = newValue;
-
-      // Keep going until we hit the max or we can no longer find mods to improve the stat.
     }
 
     requiredMinimumExtraStats[statIndex] = previousRequiredMinimum;

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -204,37 +204,46 @@ export async function process(
   let comboCount = 0;
   // required perks' hashes
   const perkHashes = requiredPerks.map((p) => p.hash);
+  const hasPerkReqs = requiredPerks.length > 0;
   // count of each perk on this item, in an array w/ same order as perkHashes
   const perkCount = (item: ProcessItem) =>
     perkHashes.map((hash) => (item.intrinsicPerks?.includes(hash) ? 1 : 0));
+
+  // Reused across iterations to avoid per-combo allocation in this hot loop.
+  // Safe because each is only read within one iteration and copied before being
+  // stored in the set tracker.
+  const stats = [0, 0, 0, 0, 0, 0];
+  const effectiveStats = [0, 0, 0, 0, 0, 0];
+  const neededStats = [0, 0, 0, 0, 0, 0];
+  const armor: ProcessItem[] = new Array<ProcessItem>(5);
 
   itemLoop: for (let helmIdx = 0; helmIdx < helms.length; helmIdx++) {
     const helm = helms[helmIdx];
     const helmExotic = Number(helm.isExotic);
     const helmArtifice = Number(helm.isArtifice);
     const helmWildcard = helm.hasSetBonusModSocket ? 1 : 0;
-    const helmPerks = perkCount(helm);
+    const helmPerks = hasPerkReqs ? perkCount(helm) : undefined;
     const helmStats = statsCache.get(helm)!;
     for (let gauntIdx = 0; gauntIdx < gauntlets.length; gauntIdx++) {
       const gaunt = gauntlets[gauntIdx];
       const gauntletExotic = Number(gaunt.isExotic);
       const gauntArtifice = Number(gaunt.isArtifice);
       const gauntWildcard = gaunt.hasSetBonusModSocket ? 1 : 0;
-      const gauntPerks = perkCount(gaunt);
+      const gauntPerks = hasPerkReqs ? perkCount(gaunt) : undefined;
       const gauntStats = statsCache.get(gaunt)!;
       for (let chestIdx = 0; chestIdx < chests.length; chestIdx++) {
         const chest = chests[chestIdx];
         const chestExotic = Number(chest.isExotic);
         const chestArtifice = Number(chest.isArtifice);
         const chestWildcard = chest.hasSetBonusModSocket ? 1 : 0;
-        const chestPerks = perkCount(chest);
+        const chestPerks = hasPerkReqs ? perkCount(chest) : undefined;
         const chestStats = statsCache.get(chest)!;
         for (let legIdx = 0; legIdx < legs.length; legIdx++) {
           const leg = legs[legIdx];
           const legExotic = Number(leg.isExotic);
           const legArtifice = Number(leg.isArtifice);
           const legWildcard = leg.hasSetBonusModSocket ? 1 : 0;
-          const legPerks = perkCount(leg);
+          const legPerks = hasPerkReqs ? perkCount(leg) : undefined;
           const legStats = statsCache.get(leg)!;
           innerloop: for (let classItemIdx = 0; classItemIdx < classItems.length; classItemIdx++) {
             const classItem = classItems[classItemIdx];
@@ -265,13 +274,19 @@ export async function process(
             }
 
             // Check required perk counts across the set
-            const classItemPerks = perkCount(classItem);
-            for (let i = 0; i < requiredPerks.length; i++) {
-              const actualCount =
-                helmPerks[i] + gauntPerks[i] + chestPerks[i] + legPerks[i] + classItemPerks[i];
-              if (actualCount < requiredPerks[i].count) {
-                setStatistics.skipReasons.insufficientPerks++;
-                continue innerloop;
+            if (hasPerkReqs) {
+              const classItemPerks = perkCount(classItem);
+              for (let i = 0; i < requiredPerks.length; i++) {
+                const actualCount =
+                  helmPerks![i] +
+                  gauntPerks![i] +
+                  chestPerks![i] +
+                  legPerks![i] +
+                  classItemPerks[i];
+                if (actualCount < requiredPerks[i].count) {
+                  setStatistics.skipReasons.insufficientPerks++;
+                  continue innerloop;
+                }
               }
             }
 
@@ -306,60 +321,67 @@ export async function process(
             //
             // Note: JavaScript engines apparently don't unroll loops
             // automatically and this makes a big difference in speed.
-            const stats = [
+            stats[0] =
               modStatsInStatOrder[0] +
-                helmStats[0] +
-                gauntStats[0] +
-                chestStats[0] +
-                legStats[0] +
-                classItemStats[0],
+              helmStats[0] +
+              gauntStats[0] +
+              chestStats[0] +
+              legStats[0] +
+              classItemStats[0];
+            stats[1] =
               modStatsInStatOrder[1] +
-                helmStats[1] +
-                gauntStats[1] +
-                chestStats[1] +
-                legStats[1] +
-                classItemStats[1],
+              helmStats[1] +
+              gauntStats[1] +
+              chestStats[1] +
+              legStats[1] +
+              classItemStats[1];
+            stats[2] =
               modStatsInStatOrder[2] +
-                helmStats[2] +
-                gauntStats[2] +
-                chestStats[2] +
-                legStats[2] +
-                classItemStats[2],
+              helmStats[2] +
+              gauntStats[2] +
+              chestStats[2] +
+              legStats[2] +
+              classItemStats[2];
+            stats[3] =
               modStatsInStatOrder[3] +
-                helmStats[3] +
-                gauntStats[3] +
-                chestStats[3] +
-                legStats[3] +
-                classItemStats[3],
+              helmStats[3] +
+              gauntStats[3] +
+              chestStats[3] +
+              legStats[3] +
+              classItemStats[3];
+            stats[4] =
               modStatsInStatOrder[4] +
-                helmStats[4] +
-                gauntStats[4] +
-                chestStats[4] +
-                legStats[4] +
-                classItemStats[4],
+              helmStats[4] +
+              gauntStats[4] +
+              chestStats[4] +
+              legStats[4] +
+              classItemStats[4];
+            stats[5] =
               modStatsInStatOrder[5] +
-                helmStats[5] +
-                gauntStats[5] +
-                chestStats[5] +
-                legStats[5] +
-                classItemStats[5],
-            ];
+              helmStats[5] +
+              gauntStats[5] +
+              chestStats[5] +
+              legStats[5] +
+              classItemStats[5];
 
             // A version of the set stats that have been clamped to the max stat
             // constraint.
-            const effectiveStats = [
-              Math.min(stats[0], maxStatConstraints[0]),
-              Math.min(stats[1], maxStatConstraints[1]),
-              Math.min(stats[2], maxStatConstraints[2]),
-              Math.min(stats[3], maxStatConstraints[3]),
-              Math.min(stats[4], maxStatConstraints[4]),
-              Math.min(stats[5], maxStatConstraints[5]),
-            ];
+            effectiveStats[0] = Math.min(stats[0], maxStatConstraints[0]);
+            effectiveStats[1] = Math.min(stats[1], maxStatConstraints[1]);
+            effectiveStats[2] = Math.min(stats[2], maxStatConstraints[2]);
+            effectiveStats[3] = Math.min(stats[3], maxStatConstraints[3]);
+            effectiveStats[4] = Math.min(stats[4], maxStatConstraints[4]);
+            effectiveStats[5] = Math.min(stats[5], maxStatConstraints[5]);
 
             // neededStats is the extra stats we'd need in each stat in order to
             // hit the stat minimums, and totalNeededStats is just the sum of
             // those. This informs the logic for deciding how to add stat mods.
-            const neededStats = [0, 0, 0, 0, 0, 0];
+            neededStats[0] = 0;
+            neededStats[1] = 0;
+            neededStats[2] = 0;
+            neededStats[3] = 0;
+            neededStats[4] = 0;
+            neededStats[5] = 0;
             let totalNeededStats = 0;
 
             // Check which stats we're under the stat minimums on.
@@ -402,7 +424,11 @@ export async function process(
               continue;
             }
 
-            const armor = [helm, gaunt, chest, leg, classItem];
+            armor[0] = helm;
+            armor[1] = gaunt;
+            armor[2] = chest;
+            armor[3] = leg;
+            armor[4] = classItem;
 
             // Items that individually can't fit their slot-specific mods were
             // filtered out before even passing them to the worker, so we only
@@ -513,8 +539,9 @@ export async function process(
               enabledStatsTotal: finalTotalStats,
               statMix: numericStatMix,
               power: getPower(armor),
-              armor,
-              stats,
+              // Copy the reused scratch arrays since the tracker retains them.
+              armor: armor.slice(),
+              stats: stats.slice(),
               statsTotal: sum(stats),
               mods,
               bonusStats,

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -455,7 +455,6 @@ export async function process(
             // At this point we know this set satisfies all constraints.
             // Update the max stat ranges. We need to do this before we short
             // circuit anything so that the stat ranges are accurate.
-            // TODO: Then updateMaxStats assigns auto mods AGAIN, potentially many times, to figure out the max possible stats in each stat individually.
             const foundAnyImprovement = updateMaxStats(
               precalculatedInfo,
               armor,


### PR DESCRIPTION
Splits the performance work off from #11838.

### Changes
- Reuse scratch arrays in the process loop instead of allocating several short-lived arrays per combo (the inner loop runs ~150M times per worker).
- `updateMaxStats`: skip the auto-mod search for sets that can't beat the running max, and binary-search the reachable value instead of stepping one point at a time. Auto-mod assignment is monotonic in a single stat's requirement, so the result is identical.

Valid-set output and computed stat ranges are unchanged; existing unit tests pass. On a representative single-thread benchmark: ~13% faster unconstrained, up to ~21% with stat minimums.

Changelog: Improved Loadout Optimizer speed.
