### PR TITLE
Allow in-game loadouts to equip vaulted items

### DIFF
--- a/src/app/loadout/ingame/ingame-loadout-utils.ts
+++ b/src/app/loadout/ingame/ingame-loadout-utils.ts
@@ -4,6 +4,7 @@ import { allItemsSelector, createItemContextSelector } from 'app/inventory/selec
 import { DimStore } from 'app/inventory/store-types';
 import { ItemCreationContext } from 'app/inventory/store/d2-item-factory';
 import { applySocketOverrides } from 'app/inventory/store/override-sockets';
+import { spaceLeftForItem } from 'app/inventory/stores-helpers';
 import { itemsByItemId } from 'app/loadout-drawer/loadout-utils';
 import { convertInGameLoadoutPlugItemHashesToSocketOverrides } from 'app/loadout/loadout-type-converters';
 import { InGameLoadout, ResolvedLoadoutItem, ResolvedLoadoutMod } from 'app/loadout/loadout-types';
@@ -133,16 +134,11 @@ export function implementsDimLoadout(
 
 /**
  * to be equipped via in-game loadouts, an item must be on the char already,
- * or in the vault, but with room in the character's pockets for a transfer.
- *
- * AUG 29 2023:
- * Bungie has reenabled in-game loadouts, but they cannot pull from the vault.
- * we temporarily only consider an item IGL-equippable if it's on the char in question.
+ * or in the vault, but with room in the character's pockets for a transfer
  */
-export function itemCouldBeEquipped(store: DimStore, item: DimItem, _stores: DimStore[]) {
+export function itemCouldBeEquipped(store: DimStore, item: DimItem, stores: DimStore[]) {
   return (
-    item.owner === store.id
-    // || (item.owner === 'vault' && spaceLeftForItem(store, item, stores) > 0)
+    item.owner === store.id || (item.owner === 'vault' && spaceLeftForItem(store, item, stores) > 0)
   );
 }
 

--- a/src/app/loadout/loadout-types.ts
+++ b/src/app/loadout/loadout-types.ts
@@ -37,7 +37,7 @@ export type InGameLoadout = DestinyLoadoutComponent & {
   /**
    * The index of the loadout in the list of the user's loadouts.
    *
-   * 0-indexed and maxes out at 9, under the current game setup.
+   * 0-indexed and maxes out at 19, under the current game setup.
    * Make sure to add 1 for the loadout's display number.
    */
   index: number;


### PR DESCRIPTION
Partially reverts e6c6a5700c3183f17e586bdf07fa14ab2ad0ab4d
In-game loadouts seem to allow this again, this PR makes the warning icon behavior consistent with in-game.
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
