### PR TITLE
validate clarity description link scheme before rendering

### DIFF
--- a/src/app/clarity/descriptions/ClarityDescriptions.test.ts
+++ b/src/app/clarity/descriptions/ClarityDescriptions.test.ts
@@ -1,0 +1,15 @@
+import { isAllowedLink } from './ClarityDescriptions';
+
+test('isAllowedLink accepts http(s) URLs', () => {
+  expect(isAllowedLink('https://d2foundry.gg/')).toBe(true);
+  expect(isAllowedLink('http://example.com/path?a=b')).toBe(true);
+});
+
+test('isAllowedLink rejects dangerous or malformed schemes', () => {
+  expect(isAllowedLink('javascript:alert(document.cookie)')).toBe(false);
+  expect(isAllowedLink('data:text/html,<script>alert(1)</script>')).toBe(false);
+  expect(isAllowedLink('vbscript:msgbox(1)')).toBe(false);
+  expect(isAllowedLink('file:///etc/passwd')).toBe(false);
+  expect(isAllowedLink('not a url')).toBe(false);
+  expect(isAllowedLink('')).toBe(false);
+});

--- a/src/app/clarity/descriptions/ClarityDescriptions.tsx
+++ b/src/app/clarity/descriptions/ClarityDescriptions.tsx
@@ -7,10 +7,27 @@ import { useSelector } from 'react-redux';
 import * as styles from './Description.m.scss';
 import { LinesContent, Perk } from './descriptionInterface';
 
+/**
+ * Clarity descriptions come from a community-maintained database we fetch at
+ * runtime, so the `link` on a line is untrusted input. Only render it as a real
+ * link if it's an http(s) URL - this mirrors the scheme check we already do for
+ * community wishlist URLs in validateWishListURLs.
+ */
+export function isAllowedLink(link: string): boolean {
+  try {
+    const { protocol } = new URL(link);
+    return protocol === 'https:' || protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 const customContent = (content: LinesContent) => {
-  if (content.link) {
+  if (content.link && isAllowedLink(content.link)) {
     return <ExternalLink href={content.link}>{content.text}</ExternalLink>;
   }
+  // Unsafe or malformed link: keep showing the text, just not as a link.
+  return applyFormatting(content.text);
 };
 
 const joinClassNames = (classNames?: (keyof typeof styles)[]) =>


### PR DESCRIPTION
DIM pulls community-authored perk descriptions from the Clarity database at runtime, and each line can carry a link that we render as an anchor through ExternalLink. That link is untrusted, and until now its scheme wasn't checked, so a description could point a link at anything, an off-site phishing page or a javascript:/data: URL, and it would render in every user's item popup. React does neutralise javascript: hrefs on its own, but leaning on that for safety feels a bit fragile, and off-site or other-scheme links still go through. I noticed we already guard the other community feed we fetch, since wishlist URLs have to pass an https check in validateWishListURLs, so the Clarity links were really just the inconsistent case. This limits a rendered link to http(s) and otherwise falls back to showing the text, so the description content is unchanged for well-behaved data. I kept it inside the clarity rendering helper so nothing else shifts.