### PR TITLE
Loadout Optimizer: don't let an un-tuned exotic steal a legendary's tuning mod

### DIFF
--- a/src/app/loadout/mod-assignment-utils.test.ts
+++ b/src/app/loadout/mod-assignment-utils.test.ts
@@ -339,4 +339,66 @@ describe('fitMostMods tuning assignment', () => {
     expect(unassignedMods).toHaveLength(0);
     expect(itemModAssignments[legendary.id].map((mod) => mod.hash)).toContain(directionalHash);
   });
+
+  it("leaves an un-tuned exotic alone so it can't steal a legendary's tuning mod", () => {
+    const legendary = legendaryTuningItem;
+    if (!legendary || legendary.bucket.hash === exoticTuningItem.bucket.hash) {
+      return; // need an exotic and a legendary tuning piece in different buckets
+    }
+
+    // A set with a tuning-capable exotic and a tuning-capable legendary, filled out
+    // with non-tuning pieces. On a default LO run the exotic isn't given a tuning
+    // mod (expandExoticTuning is off), so the flat mod list holds only the
+    // legendary's mod. The exotic must not consume it -- both the exotic accepting
+    // any tuning mod and slot order could otherwise pull the mod onto the exotic.
+    const items = [
+      exoticTuningItem,
+      legendary,
+      ...nonTuningArmor.filter((item) => item.bucket.hash !== legendary.bucket.hash).slice(0, 3),
+    ];
+    const { itemModAssignments, unassignedMods } = fitMostMods({
+      defs,
+      items,
+      plannedMods: [balancedTuningMod],
+      armorEnergyRules: loDefaultArmorEnergyRules,
+    });
+
+    expect(unassignedMods).toHaveLength(0);
+    expect(itemModAssignments[legendary.id].map((mod) => mod.hash)).toContain(
+      balancedTuningMod.hash,
+    );
+    expect(itemModAssignments[exoticTuningItem.id].map((mod) => mod.hash)).not.toContain(
+      balancedTuningMod.hash,
+    );
+  });
+
+  it('keeps the exotic in play when there are more tuning mods than legendaries', () => {
+    const legendary = legendaryTuningItem;
+    if (!legendary || legendary.bucket.hash === exoticTuningItem.bucket.hash) {
+      return;
+    }
+
+    // Two tuning mods but only one tuning-capable legendary means the extra mod must
+    // belong to the exotic (the user targeted an exotic, so it got tuned too), so the
+    // exotic stays a candidate and both pieces end up with a mod.
+    const items = [
+      exoticTuningItem,
+      legendary,
+      ...nonTuningArmor.filter((item) => item.bucket.hash !== legendary.bucket.hash).slice(0, 3),
+    ];
+    const { itemModAssignments, unassignedMods } = fitMostMods({
+      defs,
+      items,
+      plannedMods: [balancedTuningMod, balancedTuningMod],
+      armorEnergyRules: loDefaultArmorEnergyRules,
+    });
+
+    expect(unassignedMods).toHaveLength(0);
+    expect(itemModAssignments[legendary.id].map((mod) => mod.hash)).toContain(
+      balancedTuningMod.hash,
+    );
+    expect(itemModAssignments[exoticTuningItem.id].map((mod) => mod.hash)).toContain(
+      balancedTuningMod.hash,
+    );
+  });
 });

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -386,24 +386,35 @@ export function fitMostMods({
   // tuning stat, so they can take any tuning mod; a legendary only takes balanced
   // tuning or the directional mod matching its locked stat -- a subset of what an
   // exotic accepts.
-  //
-  // This previously filtered out exotics, which was only safe because tuning was
-  // never assigned to exotics. Now that it can be (expandExoticTuning), that
-  // exclusion dropped or scrambled the exotic's tuning mod -- the actual bug.
   const tuningItems = items
     .filter((item) => getArmor3TuningSocket(item) !== undefined)
     .sort(compareBy((item) => (ArmorBucketHashes as number[]).indexOf(item.bucket.hash)));
+
+  // The mapper always generates a tuning mod for every tuning-capable *legendary*,
+  // but only tunes an exotic when the user targeted one (expandExoticTuning). When
+  // it doesn't, the exotic still has a tuning socket, so leaving it in the candidate
+  // list lets it match the first mod (it accepts anything), steal a legendary's mod,
+  // and shift everything after it -- the actual bug. Since every legendary is always
+  // tuned, one more mod than there are tuning-capable legendaries is the tell that
+  // the exotic was tuned; otherwise it wasn't, so drop it from the candidates. Once
+  // the exotic is correctly kept or dropped the slot-order pass is exact.
+  const legendaryTuningCount = count(tuningItems, (item) => !item.isExotic);
+  const exoticWasTuned = tuningMods.length > legendaryTuningCount;
+  const tuningCandidates = exoticWasTuned
+    ? tuningItems
+    : tuningItems.filter((item) => !item.isExotic);
+
   for (const tuningMod of tuningMods) {
     const modStat = tuningModToTunedStathash[tuningMod.hash];
-    const targetItemIndex = tuningItems.findIndex((item) => {
+    const targetItemIndex = tuningCandidates.findIndex((item) => {
       const itemStat = getArmor3TuningStat(item);
       // Exotic (itemStat undefined) takes any tuning mod; a legendary takes
       // balanced tuning (modStat undefined) or its own locked-stat directional.
       return itemStat === undefined || modStat === undefined || itemStat === modStat;
     });
     if (targetItemIndex !== -1) {
-      bucketSpecificAssignments[tuningItems[targetItemIndex].id].assigned.push(tuningMod);
-      tuningItems.splice(targetItemIndex, 1);
+      bucketSpecificAssignments[tuningCandidates[targetItemIndex].id].assigned.push(tuningMod);
+      tuningCandidates.splice(targetItemIndex, 1);
     } else {
       unassignedMods.push(tuningMod);
     }


### PR DESCRIPTION
Followup to #11847. bhollis pointed out a remaining problem: when LO picks an exotic the user didn't select, we won't tune it, but the tuning mods still get mis-assigned.

### The bug
`fitMostMods` re-derives which tuning mod goes on which item by a single greedy pass over the tuning-capable items in canonical slot order. That relies on every tuning-capable item in the set having a corresponding mod in the flat list — but an exotic only gets a tuning mod when the user is targeting an exotic (`expandExoticTuning`).

On a default run LO can still land an exotic in a set (one exotic is allowed unless `anyExotic` requires it), and that exotic keeps its tuning socket. So it stayed in the candidate list, matched the first tuning mod (an exotic accepts *any* tuning mod), stole a legendary's mod, and shifted everything after it. The rendered/applied stats then diverged from what the worker computed — for a directional mod it lands on the wrong piece; for balanced tuning the totals actually change.

### The fix
The LO mapper always generates a tuning mod for every tuning-capable *legendary* (balanced always qualifies), and only an exotic can be un-tuned. So the flat mod list holds exactly one mod per tuned item, and the count is decisive:

- `#tuningMods == #tuning-capable legendaries` → the exotic wasn't tuned → drop it
- `#tuningMods > #tuning-capable legendaries` → the exotic was tuned → keep it

Once the exotic is correctly kept or dropped, the slot-order pass is **exact, not a heuristic** — balanced tuning lands back on the same legendary the worker chose, straight from the flat list, and a tuned exotic still sits at its slot position.

No new assignment layer or pinning — just the candidate filter, building on the greedy pass from #11847.

### Testing
New `fitMostMods` tuning tests:
- an un-tuned exotic leaves a legendary's balanced mod in place (verified this **fails on the pre-fix code** — the exotic stole it)
- a tuned exotic keeps its mod when there are more mods than legendaries

Full `mod-assignment-utils` suite green; typecheck and lint clean.
