### PR TITLE
Fix saved loadouts placing tuning mods on the wrong armor piece

### DIFF
--- a/src/app/loadout-drawer/loadout-utils.test.ts
+++ b/src/app/loadout-drawer/loadout-utils.test.ts
@@ -1,0 +1,35 @@
+import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { getTestDefinitions } from 'testing/test-utils';
+import { resolveLoadoutModHashes } from './loadout-utils';
+
+describe('resolveLoadoutModHashes', () => {
+  let defs: D2ManifestDefinitions;
+
+  beforeAll(async () => {
+    defs = await getTestDefinitions();
+  });
+
+  // The LO worker stores tuning mods in canonical slot order and fitMostMods relies
+  // on that order to put each one back on the right piece. resolveLoadoutModHashes
+  // must preserve stored order (display sorting lives in the render components), so
+  // this guards against a sort being reintroduced here. Tuning mods are the case
+  // that matters: they share a plug category, type name, and (zero) energy cost, so
+  // sortMods would order them by name.
+  it('preserves the order of tuning mods', () => {
+    const grenadeTuning = 455024236; // "+Grenade / ..."
+    const superTuning = 4026414261; // "+Super / ..."
+    const nameOf = (hash: number) =>
+      (defs.InventoryItem.get(hash) as PluggableInventoryItemDefinition).displayProperties.name;
+
+    // Feed them in the order a name sort would flip, so this fails if the sort
+    // (which used to scramble tuning assignment) is ever reintroduced.
+    const [first, second] =
+      nameOf(grenadeTuning) < nameOf(superTuning)
+        ? [superTuning, grenadeTuning]
+        : [grenadeTuning, superTuning];
+
+    const resolved = resolveLoadoutModHashes(defs, [first, second], new Set());
+    expect(resolved.map((mod) => mod.originalModHash)).toEqual([first, second]);
+  });
+});

--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -16,11 +16,7 @@ import { calculateAssumedItemEnergy, isAssumedMasterworked } from 'app/loadout/a
 import { UNSET_PLUG_HASH } from 'app/loadout/known-values';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { fitMostMods } from 'app/loadout/mod-assignment-utils';
-import {
-  isInsertableArmor2Mod,
-  mapToAvailableModCostVariant,
-  sortMods,
-} from 'app/loadout/mod-utils';
+import { isInsertableArmor2Mod, mapToAvailableModCostVariant } from 'app/loadout/mod-utils';
 import { getTotalModStatChanges } from 'app/loadout/stats';
 import { D1BucketHashes } from 'app/search/d1-known-values';
 import {
@@ -934,7 +930,11 @@ export function resolveLoadoutModHashes(
     }
   }
 
-  return mods.sort((a, b) => sortMods(a.resolvedMod, b.resolvedMod));
+  // Return mods in their stored order. The worker stores tuning mods in slot
+  // order and fitMostMods relies on that to place each one back on its item, so
+  // this resolver must not reorder them. Display sorting (see sortMods) is done by
+  // the components that render mods, not here.
+  return mods;
 }
 
 /**

--- a/src/app/loadout/loadout-ui/LoadoutMods.tsx
+++ b/src/app/loadout/loadout-ui/LoadoutMods.tsx
@@ -18,7 +18,7 @@ import { useSelector } from 'react-redux';
 import ModPicker from '../ModPicker';
 import ModAssignmentDrawer from '../mod-assignment-drawer/ModAssignmentDrawer';
 import { useLoadoutMods } from '../mod-assignment-drawer/selectors';
-import { createGetModRenderKey } from '../mod-utils';
+import { createGetModRenderKey, sortMods } from '../mod-utils';
 import * as styles from './LoadoutMods.m.scss';
 import PlugDef from './PlugDef';
 
@@ -98,6 +98,14 @@ export const LoadoutMods = memo(function LoadoutMods({
   // otherwise we'd duplicate auto mods into loadout parameter mods when confirming
   const [resolvedMods] = useLoadoutMods(loadout, storeId);
 
+  // Mods are stored/resolved in the order the loadout keeps them (slot order for
+  // tuning mods, which the assignment code relies on); sort here purely for a
+  // stable grouped display.
+  const sortedMods = useMemo(
+    () => allMods.toSorted((a, b) => sortMods(a.resolvedMod, b.resolvedMod)),
+    [allMods],
+  );
+
   // TODO: filter down by usable mods?
   // TODO: Hide the "Add Mod" button when no more mods can fit
   // TODO: turn the mod assignment drawer into a super mod editor?
@@ -122,7 +130,7 @@ export const LoadoutMods = memo(function LoadoutMods({
   return (
     <div>
       <div className={styles.modsGrid}>
-        {allMods.map((mod) => (
+        {sortedMods.map((mod) => (
           <LoadoutMod
             className={clsx({
               [styles.missingItem]: !(


### PR DESCRIPTION
resolveLoadoutModHashes sorted a loadout's mods, and sortMods falls through to an alphabetical tiebreak for tuning mods (they share plug category, type, and zero cost). That threw away the worker's canonical slot order, which fitMostMods relies on to place each tuning mod back on its item. With an exotic in the set (which accepts any tuning mod and sorts first), a legendary's directional mod could land on the exotic and the exotic's own mod go unassigned.

Stop sorting in resolveLoadoutModHashes -- it feeds fitMostMods, which needs the stored slot order. Sorting is a display concern, so do it where mods are rendered (LoadoutMods) instead. Other mod displays already sort themselves (ModPicker) or map mods onto sockets (Sockets), so they're unaffected.