### PR TITLE
Loadout Optimizer: wait for vendor items before the first search

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -182,7 +182,7 @@ export default memo(function LoadoutBuilder({
     [resolvedMods, autoStatMods],
   );
 
-  const { vendorItems } = useLoVendorItems(selectedStoreId);
+  const { vendorItems, vendorItemsLoading } = useLoVendorItems(selectedStoreId);
   const armorItems = useArmorItems(classType, vendorItems);
 
   const { modMap: lockedModMap, unassignedMods } = useMemo(
@@ -289,6 +289,9 @@ export default memo(function LoadoutBuilder({
       lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC || (lockedExoticHash ?? 0) > 0,
     autoStatMods,
     strictUpgrades: Boolean(strictUpgradesStatConstraints && !mergedConstraintsImplyStrictUpgrade),
+    // Vendor items get merged into the process inputs once they load, so
+    // starting before that just wastes a run that immediately gets restarted.
+    pauseProcessing: vendorItemsLoading,
   });
 
   const resultSets = result?.sets;

--- a/src/app/loadout-builder/loadout-builder-vendors.ts
+++ b/src/app/loadout-builder/loadout-builder-vendors.ts
@@ -44,10 +44,11 @@ export function useLoVendorItems(selectedStoreId: string) {
   const vendorItems = useSelector(loVendorItemsSelector(selectedStoreId));
   const vendors = useSelector(vendorsByCharacterSelector);
 
-  useLoadVendors(account, selectedStoreId);
+  const vendorItemsLoading = useLoadVendors(account, selectedStoreId);
 
   return {
     vendorItems,
+    vendorItemsLoading,
     error: vendors[selectedStoreId]?.error,
   };
 }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -64,6 +64,7 @@ export function useProcess({
   autoStatMods,
   expandExoticTuning,
   strictUpgrades,
+  pauseProcessing,
 }: {
   selectedStore: DimStore;
   filteredItems: ItemsByBucket;
@@ -77,6 +78,12 @@ export function useProcess({
   autoStatMods: boolean;
   expandExoticTuning: boolean;
   strictUpgrades: boolean;
+  /**
+   * Hold off starting a new process run while the item inputs are still
+   * settling (e.g. vendor items are loading), so the first run isn't
+   * immediately thrown away and restarted.
+   */
+  pauseProcessing: boolean;
 }) {
   const [{ result, processing, totalCombos, completedCombos, startTime, resultStoreId }, setState] =
     useState<ProcessState>({
@@ -106,6 +113,10 @@ export function useProcess({
   const inputsRef = useRef<ProcessInputs>(undefined);
 
   useEffect(() => {
+    if (pauseProcessing) {
+      // When this flips back, the effect re-runs and starts the process.
+      return;
+    }
     const doProcess = async () => {
       const handleProgress = (completed: number, total: number) => {
         const now = Date.now();
@@ -203,11 +214,14 @@ export function useProcess({
     autoModDefs,
     strictUpgrades,
     firstTime,
+    pauseProcessing,
   ]);
 
   return {
     result: resultStoreId === selectedStore.id ? result : null,
-    processing,
+    // While paused, a run is imminent, so report it as processing to keep the
+    // UI from showing a "no results" state.
+    processing: processing || pauseProcessing,
     startTime,
     totalCombos,
     completedCombos,

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -31,6 +31,14 @@ export const loadedError = createAction('vendors/LOADED_ERROR')<{
   error: Error;
 }>();
 
+/**
+ * The load kicked off by loadAllVendors has settled, successfully or not,
+ * including the follow-up per-vendor item component fetches.
+ */
+export const finishedLoading = createAction('vendors/FINISHED_LOADING')<{
+  characterId: string;
+}>();
+
 export const setShowUnacquiredOnly = createAction('vendors/SHOW_UNCOLLECTED_ONLY')<boolean>();
 
 export function loadAllVendors(
@@ -152,6 +160,7 @@ export function loadAllVendors(
       const error = convertToError(e);
       dispatch(loadedError({ characterId, error }));
     } finally {
+      dispatch(finishedLoading({ characterId }));
       infoLog(
         'Vendors',
         [

--- a/src/app/vendors/hooks.ts
+++ b/src/app/vendors/hooks.ts
@@ -2,15 +2,17 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { refresh$ } from 'app/shell/refresh-events';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
+import { RootState } from 'app/store/types';
 import { useEventBusListener } from 'app/utils/hooks';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { loadAllVendors } from './actions';
 
 /**
  * Loads all vendors for the given account+character, and tries refreshing them
  * when the app refreshes.
  *
- * Returns whether the initial load is still running (including the follow-up
+ * Returns whether the initial load is still settling (including the follow-up
  * per-vendor item component fetches). Refreshes don't re-enter the loading
  * state, since existing vendor data stays usable while it updates.
  */
@@ -20,22 +22,9 @@ export function useLoadVendors(
   active = true,
 ): boolean {
   const dispatch = useThunkDispatch();
-  const [loading, setLoading] = useState(Boolean(storeId && active));
   useEffect(() => {
     if (storeId && active) {
-      let live = true;
-      setLoading(true);
-      const promise = dispatch(loadAllVendors(account, storeId)).finally(() => {
-        if (live) {
-          setLoading(false);
-        }
-      });
-      loadingTracker.addPromise(promise);
-      return () => {
-        live = false;
-      };
-    } else {
-      setLoading(false);
+      loadingTracker.addPromise(dispatch(loadAllVendors(account, storeId)));
     }
   }, [account, storeId, dispatch, active]);
 
@@ -51,5 +40,8 @@ export function useLoadVendors(
     ),
   );
 
-  return loading;
+  const fullyLoaded = useSelector((state: RootState) =>
+    storeId ? Boolean(state.vendors.vendorsByCharacter[storeId]?.fullyLoaded) : false,
+  );
+  return Boolean(storeId && active) && !fullyLoaded;
 }

--- a/src/app/vendors/hooks.ts
+++ b/src/app/vendors/hooks.ts
@@ -3,22 +3,39 @@ import { loadingTracker } from 'app/shell/loading-tracker';
 import { refresh$ } from 'app/shell/refresh-events';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
 import { useEventBusListener } from 'app/utils/hooks';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { loadAllVendors } from './actions';
 
 /**
  * Loads all vendors for the given account+character, and tries refreshing them
  * when the app refreshes.
+ *
+ * Returns whether the initial load is still running (including the follow-up
+ * per-vendor item component fetches). Refreshes don't re-enter the loading
+ * state, since existing vendor data stays usable while it updates.
  */
 export function useLoadVendors(
   account: DestinyAccount,
   storeId: string | undefined,
   active = true,
-) {
+): boolean {
   const dispatch = useThunkDispatch();
+  const [loading, setLoading] = useState(Boolean(storeId && active));
   useEffect(() => {
     if (storeId && active) {
-      loadingTracker.addPromise(dispatch(loadAllVendors(account, storeId)));
+      let live = true;
+      setLoading(true);
+      const promise = dispatch(loadAllVendors(account, storeId)).finally(() => {
+        if (live) {
+          setLoading(false);
+        }
+      });
+      loadingTracker.addPromise(promise);
+      return () => {
+        live = false;
+      };
+    } else {
+      setLoading(false);
     }
   }, [account, storeId, dispatch, active]);
 
@@ -33,4 +50,6 @@ export function useLoadVendors(
       [account, active, dispatch, storeId],
     ),
   );
+
+  return loading;
 }

--- a/src/app/vendors/reducer.ts
+++ b/src/app/vendors/reducer.ts
@@ -16,6 +16,12 @@ export interface VendorsState {
       /** ms epoch time */
       lastLoaded?: number;
       error?: Error;
+      /**
+       * Whether the first load has settled, including the follow-up per-vendor
+       * item component fetches. Stays true across refreshes, since the
+       * existing data remains usable while it updates.
+       */
+      fullyLoaded?: boolean;
     };
   }>;
   showUnacquiredOnly: boolean;
@@ -45,6 +51,7 @@ export const vendors: Reducer<VendorsState, VendorsAction | AccountsAction> = (
           vendorsResponse: vendorsResponse,
           lastLoaded: Date.now(),
           error: undefined,
+          fullyLoaded: state.vendorsByCharacter[characterId]?.fullyLoaded,
         };
         if (oldItemComponents) {
           draft.vendorsByCharacter[characterId].vendorsResponse!.itemComponents = oldItemComponents;
@@ -88,6 +95,20 @@ export const vendors: Reducer<VendorsState, VendorsAction | AccountsAction> = (
           [characterId]: {
             ...state.vendorsByCharacter[characterId],
             error,
+          },
+        },
+      };
+    }
+
+    case getType(actions.finishedLoading): {
+      const { characterId } = action.payload;
+      return {
+        ...state,
+        vendorsByCharacter: {
+          ...state.vendorsByCharacter,
+          [characterId]: {
+            ...state.vendorsByCharacter[characterId],
+            fullyLoaded: true,
           },
         },
       };


### PR DESCRIPTION
Entering LO kicked off a search immediately, then vendor items finished loading a few seconds later, changing the inputs and restarting the whole search. Track completion of the vendor load (including the follow-up item component fetches) and hold off processing until it settles, presenting the wait as processing so the UI doesn't flash a no-results state. Vendor load failures resolve the same promise, so a failed load starts the search without vendor items rather than pausing forever. Refreshes don't re-enter the loading state; unchanged inputs are already caught by the existing input memoization.