### PR TITLE
Loadout Optimizer: tune exotics without requiring a pinned exotic

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -670,7 +670,6 @@
     "SetBonusModWarning": "This set contains an item with a configurable set bonus mod. Manually apply the correct mod to activate the desired set bonus.",
     "ExoticClassItemPerks": "If you want specific perks, use searches like exactperk:\"spirit of verity\". Click perks in the Optimizer results to add or remove them from the item filter.",
     "ExoticSpecialCategory": "Special",
-    "ExoticTuningNote": "Lock a specific exotic, or choose Any Exotic, to also consider its tuning mods.",
     "Filter": "Settings",
     "Legendary": "Legendary",
     "LockItem": "Pin item",

--- a/src/app/loadout-analyzer/analysis.ts
+++ b/src/app/loadout-analyzer/analysis.ts
@@ -336,9 +336,6 @@ export async function analyzeLoadout(
 
             const processInfo = worker({
               anyExotic: loadoutParameters.exoticArmorHash === LOCKED_EXOTIC_ANY_EXOTIC,
-              expandExoticTuning:
-                loadoutParameters.exoticArmorHash === LOCKED_EXOTIC_ANY_EXOTIC ||
-                (loadoutParameters.exoticArmorHash ?? 0) > 0,
               armorEnergyRules,
               autoModDefs,
               autoStatMods: loadoutParameters.autoStatMods,

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -283,10 +283,6 @@ export default memo(function LoadoutBuilder({
     armorEnergyRules,
     desiredStatRanges,
     anyExotic: lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC,
-    // Only pay for exotic tuning variants when the user is actually targeting an
-    // exotic (any exotic, or a specific one), not on the default unfiltered run.
-    expandExoticTuning:
-      lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC || (lockedExoticHash ?? 0) > 0,
     autoStatMods,
     strictUpgrades: Boolean(strictUpgradesStatConstraints && !mergedConstraintsImplyStrictUpgrade),
   });

--- a/src/app/loadout-builder/filter/ExoticPicker.tsx
+++ b/src/app/loadout-builder/filter/ExoticPicker.tsx
@@ -221,12 +221,7 @@ export default function ExoticPicker({
             <FakeExoticTile
               selected={lockedExoticHash === undefined}
               title={t('LoadoutBuilder.NoExoticPreference')}
-              description={
-                <>
-                  <span>{t('LoadoutBuilder.NoExoticPreferenceDescription')}</span>
-                  <span>{t('LoadoutBuilder.ExoticTuningNote')}</span>
-                </>
-              }
+              description={t('LoadoutBuilder.NoExoticPreferenceDescription')}
               icon={noExoticPreferenceIcon}
               onSelected={() => {
                 onSelected(undefined);

--- a/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerExotic.tsx
@@ -222,15 +222,10 @@ function ChosenExoticOption({
         ),
       };
       break;
-    case undefined: {
+    case undefined:
       info = {
         title: t('LoadoutBuilder.NoExoticPreference'),
-        description: (
-          <>
-            <div>{t('LoadoutBuilder.NoExoticPreferenceDescription')}</div>
-            <div>{t('LoadoutBuilder.ExoticTuningNote')}</div>
-          </>
-        ),
+        description: t('LoadoutBuilder.NoExoticPreferenceDescription'),
         icon: (
           <div className="item">
             <img src={noExoticPreferenceIcon} className="item-img" />
@@ -238,7 +233,6 @@ function ChosenExoticOption({
         ),
       };
       break;
-    }
     default: {
       const exoticArmor = defs.InventoryItem.get(lockedExoticHash);
       const fakeItem = makeFakeItem(itemCreationContext, exoticArmor.hash);

--- a/src/app/loadout-builder/process-worker/process-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.test.ts
@@ -128,7 +128,6 @@ describe('process-utils mod assignment', () => {
             armorEnergyRules,
             desiredStatRanges: [],
             autoStatMods: true,
-            expandExoticTuning: false,
           })[0];
         }
         if (!arms && isArmor2Arms(storeItem)) {
@@ -137,7 +136,6 @@ describe('process-utils mod assignment', () => {
             armorEnergyRules,
             desiredStatRanges: [],
             autoStatMods: true,
-            expandExoticTuning: false,
           })[0];
         }
         if (!chest && isArmor2Chest(storeItem)) {
@@ -146,7 +144,6 @@ describe('process-utils mod assignment', () => {
             armorEnergyRules,
             desiredStatRanges: [],
             autoStatMods: true,
-            expandExoticTuning: false,
           })[0];
         }
         if (!legs && isArmor2Legs(storeItem)) {
@@ -155,7 +152,6 @@ describe('process-utils mod assignment', () => {
             armorEnergyRules,
             desiredStatRanges: [],
             autoStatMods: true,
-            expandExoticTuning: false,
           })[0];
         }
         if (!classItem && isArmor2ClassItem(storeItem)) {
@@ -164,7 +160,6 @@ describe('process-utils mod assignment', () => {
             armorEnergyRules,
             desiredStatRanges: [],
             autoStatMods: true,
-            expandExoticTuning: false,
           })[0];
         }
 

--- a/src/app/loadout-builder/process-worker/process.test.ts
+++ b/src/app/loadout-builder/process-worker/process.test.ts
@@ -108,7 +108,6 @@ describe('process equivalence', () => {
               armorEnergyRules,
               desiredStatRanges: defaultRanges(),
               autoStatMods: true,
-              expandExoticTuning: false,
             })[0];
             if (mapped) {
               baseItems[bucketHash as keyof ProcessItemsByBucket].push(mapped);
@@ -290,5 +289,129 @@ describe('process equivalence', () => {
     const result = await process(1, inputs, noProgress);
     // Which set is found first is iteration-order dependent; only existence matters
     expect(result.sets.length).toBeGreaterThan(0);
+  });
+
+  // A directional (+5/-5) and a balanced-style (+1/+1/+1) tuning variant for
+  // the equivalence scenarios below.
+  const makeVariants = (exotic: ProcessItem) => {
+    const statA = armorStats[1];
+    const statB = armorStats[4];
+    return [
+      {
+        modHash: 111,
+        stats: {
+          ...exotic.stats,
+          [statA]: exotic.stats[statA] + 5,
+          [statB]: exotic.stats[statB] - 5,
+        },
+      },
+      {
+        modHash: 222,
+        stats: {
+          ...exotic.stats,
+          [armorStats[0]]: exotic.stats[armorStats[0]] + 1,
+          [statA]: exotic.stats[statA] + 1,
+          [statB]: exotic.stats[statB] + 1,
+        },
+      },
+    ];
+  };
+
+  it('tail-resolved exotic tuning variants match the equivalent bucket expansion', async () => {
+    // An exotic's tuning choice is resolved in the per-set tail instead of
+    // being expanded into bucket items. Both formulations enumerate the same
+    // candidate sets, so everything except the combo count and the subtree
+    // skip accounting must be identical.
+    // Keep the corpus small enough that every valid set fits in the top-200
+    // tracker, so results can't differ by boundary tie-breaking.
+    const patchCommon = (inputs: ProcessInputs) => {
+      inputs.autoStatMods = true;
+      inputs.desiredStatRanges[0].minStat = 20;
+      eachBucket(inputs, (items) => items.splice(2));
+      inputs.filteredItems[BucketHashes.Helmet][0].isExotic = true;
+    };
+
+    const tailInputs = cloneInputs((inputs) => {
+      patchCommon(inputs);
+      const exotic = inputs.filteredItems[BucketHashes.Helmet][0];
+      exotic.tuningVariants = makeVariants(exotic);
+    });
+    const expandedInputs = cloneInputs((inputs) => {
+      patchCommon(inputs);
+      const helms = inputs.filteredItems[BucketHashes.Helmet];
+      const exotic = helms[0];
+      helms.splice(
+        0,
+        1,
+        ...makeVariants(exotic).map((v) => ({
+          ...exotic,
+          includedTuningMod: v.modHash,
+          stats: v.stats,
+        })),
+      );
+    });
+
+    const tailDigest = await runAndDigest(tailInputs);
+    const expandedDigest = await runAndDigest(expandedInputs);
+    expect(tailDigest.sets).toEqual(expandedDigest.sets);
+    expect(tailDigest.statRangesFiltered).toEqual(expandedDigest.statRangesFiltered);
+    expect(tailDigest.numProcessed).toBe(expandedDigest.numProcessed);
+    expect(tailDigest.lowerBoundsExceeded).toEqual(expandedDigest.lowerBoundsExceeded);
+    expect(tailDigest.sets.length).toBeGreaterThan(0);
+    // The tuning mod actually shows up in the returned sets
+    expect(tailDigest.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
+      true,
+    );
+  });
+
+  it('tail-resolved tuning matches expansion when the tracker boundary prunes variants', async () => {
+    // With the full corpus the top-200 tracker fills up and most variant
+    // evaluations are skipped by the per-set pre-gate, which must not change
+    // anything observable. Which same-total sets sit at the heap boundary is
+    // iteration-order dependent, so compare order-independent invariants:
+    // the multiset of retained totals, the stat ranges, and the number of
+    // candidates considered.
+    const markExotics = (inputs: ProcessInputs) => {
+      inputs.autoStatMods = true;
+      inputs.filteredItems[BucketHashes.Helmet][0].isExotic = true;
+      inputs.filteredItems[BucketHashes.Helmet][3].isExotic = true;
+      inputs.filteredItems[BucketHashes.ChestArmor][2].isExotic = true;
+    };
+
+    const tailInputs = cloneInputs((inputs) => {
+      markExotics(inputs);
+      for (const bucketHash of ArmorBucketHashes) {
+        for (const item of inputs.filteredItems[bucketHash]) {
+          if (item.isExotic) {
+            item.tuningVariants = makeVariants(item);
+          }
+        }
+      }
+    });
+    const expandedInputs = cloneInputs((inputs) => {
+      markExotics(inputs);
+      for (const bucketHash of ArmorBucketHashes) {
+        inputs.filteredItems[bucketHash] = inputs.filteredItems[bucketHash].flatMap((item) =>
+          item.isExotic
+            ? makeVariants(item).map((v) => ({
+                ...item,
+                includedTuningMod: v.modHash,
+                stats: v.stats,
+              }))
+            : [item],
+        );
+      }
+    });
+
+    const tailDigest = await runAndDigest(tailInputs);
+    const expandedDigest = await runAndDigest(expandedInputs);
+    expect(tailDigest.sets.map((s) => s.enabledStatsTotal).sort()).toEqual(
+      expandedDigest.sets.map((s) => s.enabledStatsTotal).sort(),
+    );
+    expect(tailDigest.statRangesFiltered).toEqual(expandedDigest.statRangesFiltered);
+    expect(tailDigest.numProcessed).toBe(expandedDigest.numProcessed);
+    expect(tailDigest.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
+      true,
+    );
   });
 });

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -192,6 +192,8 @@ export async function process(
     stats: number[];
     mods: number[];
     bonusStats: number[];
+    /** Stat deltas of the tuning mod chosen for the set's tunable item, if any. */
+    tuningDeltas: number[] | undefined;
   }>(RETURNED_ARMOR_SETS);
 
   const { activityMods, generalMods } = lockedMods;
@@ -229,11 +231,46 @@ export async function process(
 
   // Parallel per-bucket arrays so the hot loop reads flat numbers instead of
   // hashing into maps, converting booleans, or allocating per combination.
-  const helmSoA = buildBucketSoA(helms, statsCache, setBonusHashes, perkHashes);
-  const gauntSoA = buildBucketSoA(gauntlets, statsCache, setBonusHashes, perkHashes);
-  const chestSoA = buildBucketSoA(chests, statsCache, setBonusHashes, perkHashes);
-  const legSoA = buildBucketSoA(legs, statsCache, setBonusHashes, perkHashes);
-  const classItemSoA = buildBucketSoA(classItems, statsCache, setBonusHashes, perkHashes);
+  const helmSoA = buildBucketSoA(
+    helms,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const gauntSoA = buildBucketSoA(
+    gauntlets,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const chestSoA = buildBucketSoA(
+    chests,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const legSoA = buildBucketSoA(
+    legs,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const classItemSoA = buildBucketSoA(
+    classItems,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
 
   const numSetBonuses = setBonusHashes.length;
 
@@ -631,64 +668,42 @@ export async function process(
               }
             }
 
-            numProcessed++;
             const ciBase = classItemIdx * 6;
 
-            // Add the class item's stats onto the outer levels' running
-            // partial sums to form the overall set stats.
-            // Note that mod stats could theoretically take these negative, but
-            // none do in practice.
-            //
-            // Note: JavaScript engines apparently don't unroll loops
-            // automatically and this makes a big difference in speed.
-            stats[0] = statsAfterLeg[0] + classItemSoA.stats[ciBase];
-            stats[1] = statsAfterLeg[1] + classItemSoA.stats[ciBase + 1];
-            stats[2] = statsAfterLeg[2] + classItemSoA.stats[ciBase + 2];
-            stats[3] = statsAfterLeg[3] + classItemSoA.stats[ciBase + 3];
-            stats[4] = statsAfterLeg[4] + classItemSoA.stats[ciBase + 4];
-            stats[5] = statsAfterLeg[5] + classItemSoA.stats[ciBase + 5];
-
-            // A version of the set stats that have been clamped to the max stat
-            // constraint.
-            effectiveStats[0] = Math.min(stats[0], maxStatConstraints[0]);
-            effectiveStats[1] = Math.min(stats[1], maxStatConstraints[1]);
-            effectiveStats[2] = Math.min(stats[2], maxStatConstraints[2]);
-            effectiveStats[3] = Math.min(stats[3], maxStatConstraints[3]);
-            effectiveStats[4] = Math.min(stats[4], maxStatConstraints[4]);
-            effectiveStats[5] = Math.min(stats[5], maxStatConstraints[5]);
-
-            // neededStats is the extra stats we'd need in each stat in order to
-            // hit the stat minimums, and totalNeededStats is just the sum of
-            // those. This informs the logic for deciding how to add stat mods.
-            neededStats[0] = 0;
-            neededStats[1] = 0;
-            neededStats[2] = 0;
-            neededStats[3] = 0;
-            neededStats[4] = 0;
-            neededStats[5] = 0;
-            let totalNeededStats = 0;
-
-            // Check which stats we're under the stat minimums on.
-            let totalStats = 0;
-            for (let index = 0; index < 6; index++) {
-              const filter = desiredStatRanges[index];
-              if (filter.maxStat > 0 /* non-ignored stat */) {
-                const value = effectiveStats[index];
-                // Update the minimum stat range while we're here
-                const statRange = statRanges[index];
-                if (value < statRange.minStat) {
-                  statRange.minStat = value;
-                }
-                totalStats += value;
-                if (filter.minStat > 0) {
-                  const neededValue = filter.minStat - value;
-                  if (neededValue > 0) {
-                    totalNeededStats += neededValue;
-                    neededStats[index] = neededValue;
-                  }
-                }
-              }
+            // At most one item in a valid set carries tuning variants (only
+            // exotics do, and double exotics were pruned above). Each variant
+            // is evaluated below as its own candidate set, sharing all the
+            // loop-level work and the per-set energy cache.
+            let tuningInfo = helmSoA.tuning[helmIdx];
+            let tuningSlot = 0;
+            if (tuningInfo === undefined) {
+              tuningInfo = gauntSoA.tuning[gauntIdx];
+              tuningSlot = 1;
             }
+            if (tuningInfo === undefined) {
+              tuningInfo = chestSoA.tuning[chestIdx];
+              tuningSlot = 2;
+            }
+            if (tuningInfo === undefined) {
+              tuningInfo = legSoA.tuning[legIdx];
+              tuningSlot = 3;
+            }
+            if (tuningInfo === undefined) {
+              tuningInfo = classItemSoA.tuning[classItemIdx];
+              tuningSlot = 4;
+            }
+            const tuningVariants = tuningInfo?.variants;
+            const numVariants = tuningVariants !== undefined ? tuningVariants.length : 1;
+
+            const classItem = classItems[classItemIdx];
+            armor[0] = helm;
+            armor[1] = gaunt;
+            armor[2] = chest;
+            armor[3] = leg;
+            armor[4] = classItem;
+            // The energy profile doesn't depend on tuning, so the cache is
+            // shared across all variants of this armor set.
+            energyCache.result = undefined;
 
             const numArtifice = artificeP4 + classItemSoA.artifice[classItemIdx];
 
@@ -698,168 +713,281 @@ export async function process(
               numArtifice * artificeStatBoost +
               precalculatedInfo.numAvailableGeneralMods * majorStatBoost;
 
-            // Check to see if it would be at all possible to hit the needed
-            // stat total with the best case mod bonuses. If totalNeededStats is
-            // 0 this passes trivially.
-            lowerBoundsChecked++;
-            if (totalNeededStats > maxModBonus) {
-              lowerBoundsFailed++;
-              continue;
-            }
-
-            const classItem = classItems[classItemIdx];
-            armor[0] = helm;
-            armor[1] = gaunt;
-            armor[2] = chest;
-            armor[3] = leg;
-            armor[4] = classItem;
-            energyCache.result = undefined;
-
-            // Items that individually can't fit their slot-specific mods were
-            // filtered out before even passing them to the worker, so we only
-            // do this combined mods + auto-stats check if we need to check
-            // whether the set can fit the mods and hit target stats. This is a
-            // fast check to see if enough mods can fit to hit needed stat
-            // minimums.
-            if (
-              (hasMods || totalNeededStats > 0) &&
-              !pickAndAssignSlotIndependentMods(
-                precalculatedInfo,
-                setStatistics.modsStatistics,
-                armor,
-                totalNeededStats > 0 ? neededStats : undefined,
-                numArtifice,
-              )
-            ) {
-              // There's no way for this set to fit all requested mods while
-              // satisfying tier lower bounds, so continue on. setStatistics
-              // have been updated in pickAndAssignSlotIndependentMods.
-              continue;
-            }
-
-            // At this point we know this set satisfies all constraints.
-            // Update the max stat ranges. We need to do this before we short
-            // circuit anything so that the stat ranges are accurate.
-            //
-            // updateMaxStats only ever raises the running maxes, so once they
-            // have converged (the common steady state in large searches) we can
-            // skip the call for sets that provably can't raise any of them.
-            // These conditions mirror its internal update conditions exactly.
-            let mayImproveMax = false;
-            for (let index = 0; index < 6; index++) {
-              const maxSeen = statRanges[index].maxStat;
-              if (
-                maxSeen < desiredStatRanges[index].minStat ||
-                stats[index] > maxSeen ||
-                (maxSeen < MAX_STAT && stats[index] + maxModBonus > maxSeen)
-              ) {
-                mayImproveMax = true;
-                break;
+            if (tuningInfo !== undefined) {
+              // Almost all sets die at the couldInsert prune, and paying the
+              // per-variant arithmetic for each of them adds up, so decide
+              // once per set whether any variant could matter. Stat-range
+              // minimums are updated here with the per-stat minimum across
+              // variants, which matches what the per-variant updates would
+              // produce; the convergence gate and heap bound use per-stat/
+              // per-variant maximums, so this only skips variants that could
+              // neither improve the displayed ranges nor make the top sets.
+              const { minDeltas, maxDeltas, maxNetGain } = tuningInfo;
+              stats[0] = statsAfterLeg[0] + classItemSoA.stats[ciBase];
+              stats[1] = statsAfterLeg[1] + classItemSoA.stats[ciBase + 1];
+              stats[2] = statsAfterLeg[2] + classItemSoA.stats[ciBase + 2];
+              stats[3] = statsAfterLeg[3] + classItemSoA.stats[ciBase + 3];
+              stats[4] = statsAfterLeg[4] + classItemSoA.stats[ciBase + 4];
+              stats[5] = statsAfterLeg[5] + classItemSoA.stats[ciBase + 5];
+              let totalBase = 0;
+              let mayMatter = false;
+              for (let index = 0; index < 6; index++) {
+                const filter = desiredStatRanges[index];
+                const statRange = statRanges[index];
+                if (filter.maxStat > 0 /* non-ignored stat */) {
+                  const minValue = Math.min(stats[index] + minDeltas[index], filter.maxStat);
+                  if (minValue < statRange.minStat) {
+                    statRange.minStat = minValue;
+                  }
+                  totalBase += Math.min(stats[index], filter.maxStat);
+                }
+                const maxSeen = statRange.maxStat;
+                const bestValue = stats[index] + maxDeltas[index];
+                if (
+                  maxSeen < filter.minStat ||
+                  bestValue > maxSeen ||
+                  (maxSeen < MAX_STAT && bestValue + maxModBonus > maxSeen)
+                ) {
+                  mayMatter = true;
+                }
+              }
+              if (!mayMatter && !setTracker.couldInsert(totalBase + maxNetGain + maxModBonus)) {
+                numProcessed += numVariants;
+                skipLowTier += numVariants;
+                continue;
               }
             }
-            const foundAnyImprovement =
-              mayImproveMax &&
-              updateMaxStats(
+
+            for (let variantIdx = 0; variantIdx < numVariants; variantIdx++) {
+              numProcessed++;
+
+              // Add the class item's stats onto the outer levels' running
+              // partial sums to form the overall set stats.
+              // Note that mod stats could theoretically take these negative, but
+              // none do in practice.
+              //
+              // Note: JavaScript engines apparently don't unroll loops
+              // automatically and this makes a big difference in speed.
+              stats[0] = statsAfterLeg[0] + classItemSoA.stats[ciBase];
+              stats[1] = statsAfterLeg[1] + classItemSoA.stats[ciBase + 1];
+              stats[2] = statsAfterLeg[2] + classItemSoA.stats[ciBase + 2];
+              stats[3] = statsAfterLeg[3] + classItemSoA.stats[ciBase + 3];
+              stats[4] = statsAfterLeg[4] + classItemSoA.stats[ciBase + 4];
+              stats[5] = statsAfterLeg[5] + classItemSoA.stats[ciBase + 5];
+              if (tuningVariants !== undefined) {
+                const deltas = tuningVariants[variantIdx].deltas;
+                stats[0] += deltas[0];
+                stats[1] += deltas[1];
+                stats[2] += deltas[2];
+                stats[3] += deltas[3];
+                stats[4] += deltas[4];
+                stats[5] += deltas[5];
+              }
+
+              // A version of the set stats that have been clamped to the max stat
+              // constraint.
+              effectiveStats[0] = Math.min(stats[0], maxStatConstraints[0]);
+              effectiveStats[1] = Math.min(stats[1], maxStatConstraints[1]);
+              effectiveStats[2] = Math.min(stats[2], maxStatConstraints[2]);
+              effectiveStats[3] = Math.min(stats[3], maxStatConstraints[3]);
+              effectiveStats[4] = Math.min(stats[4], maxStatConstraints[4]);
+              effectiveStats[5] = Math.min(stats[5], maxStatConstraints[5]);
+
+              // neededStats is the extra stats we'd need in each stat in order to
+              // hit the stat minimums, and totalNeededStats is just the sum of
+              // those. This informs the logic for deciding how to add stat mods.
+              neededStats[0] = 0;
+              neededStats[1] = 0;
+              neededStats[2] = 0;
+              neededStats[3] = 0;
+              neededStats[4] = 0;
+              neededStats[5] = 0;
+              let totalNeededStats = 0;
+
+              // Check which stats we're under the stat minimums on.
+              let totalStats = 0;
+              for (let index = 0; index < 6; index++) {
+                const filter = desiredStatRanges[index];
+                if (filter.maxStat > 0 /* non-ignored stat */) {
+                  const value = effectiveStats[index];
+                  // Update the minimum stat range while we're here
+                  const statRange = statRanges[index];
+                  if (value < statRange.minStat) {
+                    statRange.minStat = value;
+                  }
+                  totalStats += value;
+                  if (filter.minStat > 0) {
+                    const neededValue = filter.minStat - value;
+                    if (neededValue > 0) {
+                      totalNeededStats += neededValue;
+                      neededStats[index] = neededValue;
+                    }
+                  }
+                }
+              }
+
+              // Check to see if it would be at all possible to hit the needed
+              // stat total with the best case mod bonuses. If totalNeededStats is
+              // 0 this passes trivially.
+              lowerBoundsChecked++;
+              if (totalNeededStats > maxModBonus) {
+                lowerBoundsFailed++;
+                continue;
+              }
+
+              // Items that individually can't fit their slot-specific mods were
+              // filtered out before even passing them to the worker, so we only
+              // do this combined mods + auto-stats check if we need to check
+              // whether the set can fit the mods and hit target stats. This is a
+              // fast check to see if enough mods can fit to hit needed stat
+              // minimums.
+              if (
+                (hasMods || totalNeededStats > 0) &&
+                !pickAndAssignSlotIndependentMods(
+                  precalculatedInfo,
+                  setStatistics.modsStatistics,
+                  armor,
+                  totalNeededStats > 0 ? neededStats : undefined,
+                  numArtifice,
+                )
+              ) {
+                // There's no way for this set to fit all requested mods while
+                // satisfying tier lower bounds, so continue on. setStatistics
+                // have been updated in pickAndAssignSlotIndependentMods.
+                continue;
+              }
+
+              // At this point we know this set satisfies all constraints.
+              // Update the max stat ranges. We need to do this before we short
+              // circuit anything so that the stat ranges are accurate.
+              //
+              // updateMaxStats only ever raises the running maxes, so once they
+              // have converged (the common steady state in large searches) we can
+              // skip the call for sets that provably can't raise any of them.
+              // These conditions mirror its internal update conditions exactly.
+              let mayImproveMax = false;
+              for (let index = 0; index < 6; index++) {
+                const maxSeen = statRanges[index].maxStat;
+                if (
+                  maxSeen < desiredStatRanges[index].minStat ||
+                  stats[index] > maxSeen ||
+                  (maxSeen < MAX_STAT && stats[index] + maxModBonus > maxSeen)
+                ) {
+                  mayImproveMax = true;
+                  break;
+                }
+              }
+              const foundAnyImprovement =
+                mayImproveMax &&
+                updateMaxStats(
+                  precalculatedInfo,
+                  armor,
+                  stats,
+                  numArtifice,
+                  desiredStatRanges,
+                  statRanges,
+                  energyCache,
+                );
+
+              // Drop this set if it could never make it into our top
+              // RETURNED_ARMOR_SETS sets. We do this only after confirming that
+              // any required stat mods fit and updating our max tiers so that the
+              // max available tier info stays accurate.
+              if (!setTracker.couldInsert(totalStats + maxModBonus)) {
+                skipLowTier++;
+                continue;
+              }
+
+              const optimalResult = pickOptimalStatMods(
                 precalculatedInfo,
                 armor,
                 stats,
-                numArtifice,
                 desiredStatRanges,
-                statRanges,
+                numArtifice,
                 energyCache,
               );
+              if (!optimalResult) {
+                // This means we couldn't assign mods in a way that satisfied
+                // minimum stat constraints. This can happen if the mods that
+                // would be needed don't fit into the available slots.
+                setStatistics.modsStatistics.finalAssignment.modsAssignmentFailed++;
+                continue;
+              }
 
-            // Drop this set if it could never make it into our top
-            // RETURNED_ARMOR_SETS sets. We do this only after confirming that
-            // any required stat mods fit and updating our max tiers so that the
-            // max available tier info stays accurate.
-            if (!setTracker.couldInsert(totalStats + maxModBonus)) {
-              skipLowTier++;
-              continue;
-            }
+              const { bonusStats, mods } = optimalResult;
+              const finalStats = [
+                effectiveStats[0] + bonusStats[0],
+                effectiveStats[1] + bonusStats[1],
+                effectiveStats[2] + bonusStats[2],
+                effectiveStats[3] + bonusStats[3],
+                effectiveStats[4] + bonusStats[4],
+                effectiveStats[5] + bonusStats[5],
+              ];
+              const finalTotalStats =
+                finalStats[0] +
+                finalStats[1] +
+                finalStats[2] +
+                finalStats[3] +
+                finalStats[4] +
+                finalStats[5];
 
-            const optimalResult = pickOptimalStatMods(
-              precalculatedInfo,
-              armor,
-              stats,
-              desiredStatRanges,
-              numArtifice,
-              energyCache,
-            );
-            if (!optimalResult) {
-              // This means we couldn't assign mods in a way that satisfied
-              // minimum stat constraints. This can happen if the mods that
-              // would be needed don't fit into the available slots.
-              setStatistics.modsStatistics.finalAssignment.modsAssignmentFailed++;
-              continue;
-            }
+              // Now use our more accurate extra tiers prediction
+              if (!setTracker.couldInsert(finalTotalStats)) {
+                skipLowTier++;
+                continue;
+              }
 
-            const { bonusStats, mods } = optimalResult;
-            const finalStats = [
-              effectiveStats[0] + bonusStats[0],
-              effectiveStats[1] + bonusStats[1],
-              effectiveStats[2] + bonusStats[2],
-              effectiveStats[3] + bonusStats[3],
-              effectiveStats[4] + bonusStats[4],
-              effectiveStats[5] + bonusStats[5],
-            ];
-            const finalTotalStats =
-              finalStats[0] +
-              finalStats[1] +
-              finalStats[2] +
-              finalStats[3] +
-              finalStats[4] +
-              finalStats[5];
+              // Calculate the numeric stat mix for fast integer comparison.
+              // This encodes each stat value (0-200) into 8 bits, packed into a single integer.
+              // Only non-ignored stats are included, maintaining lexical ordering for priority.
+              const numericStatMix = encodeStatMix(finalStats, desiredStatRanges);
 
-            // Now use our more accurate extra tiers prediction
-            if (!setTracker.couldInsert(finalTotalStats)) {
-              skipLowTier++;
-              continue;
-            }
-
-            // Calculate the numeric stat mix for fast integer comparison.
-            // This encodes each stat value (0-200) into 8 bits, packed into a single integer.
-            // Only non-ignored stats are included, maintaining lexical ordering for priority.
-            const numericStatMix = encodeStatMix(finalStats, desiredStatRanges);
-
-            // Add on any tuning mods that were preset on the items.
-            mods.push(
+              // Add on any tuning mods, preset on the items or chosen for the
+              // tunable item.
               // It's important that we keep the order of these tuning mods in
               // the order of the armor (even when we assign mods dynamically,
               // later), so that when we assign them in fitMostMods they get
               // assigned to the same item. Otherwise, we could end up swapping
               // between one balanced mod and one tuning mod, and the balanced
               // mod's stat bonuses could be slightly different.
-              ...compact([
+              const tuningMods = [
                 helm.includedTuningMod,
                 gaunt.includedTuningMod,
                 chest.includedTuningMod,
                 leg.includedTuningMod,
                 classItem.includedTuningMod,
-              ]),
-            );
+              ];
+              if (tuningVariants !== undefined) {
+                tuningMods[tuningSlot] = tuningVariants[variantIdx].modHash;
+              }
+              mods.push(...compact(tuningMods));
 
-            processStatistics.numValidSets++;
-            // And now insert our set using the predicted total tier and numeric stat mix.
-            setTracker.insert({
-              enabledStatsTotal: finalTotalStats,
-              statMix: numericStatMix,
-              power: getPower(armor),
-              // Copy the reused scratch arrays since the tracker retains them.
-              armor: armor.slice(),
-              stats: stats.slice(),
-              statsTotal: sum(stats),
-              mods,
-              bonusStats,
-            });
+              processStatistics.numValidSets++;
+              // And now insert our set using the predicted total tier and numeric stat mix.
+              setTracker.insert({
+                enabledStatsTotal: finalTotalStats,
+                statMix: numericStatMix,
+                power: getPower(armor),
+                // Copy the reused scratch arrays since the tracker retains them.
+                armor: armor.slice(),
+                stats: stats.slice(),
+                statsTotal: sum(stats),
+                mods,
+                bonusStats,
+                // The chosen variant's deltas, so the final mapping can report
+                // the tuned item's armor-only stats.
+                tuningDeltas:
+                  tuningVariants !== undefined ? tuningVariants[variantIdx].deltas : undefined,
+              });
 
-            if (stopOnFirstSet) {
-              if (strictUpgrades) {
-                if (foundAnyImprovement) {
+              if (stopOnFirstSet) {
+                if (strictUpgrades) {
+                  if (foundAnyImprovement) {
+                    break itemLoop;
+                  }
+                } else {
                   break itemLoop;
                 }
-              } else {
-                break itemLoop;
               }
             }
           }
@@ -881,7 +1009,7 @@ export async function process(
 
   const finalSets = setTracker.getArmorSets();
 
-  const sets = filterMap(finalSets, ({ armor, stats, mods, bonusStats, ...rest }) => {
+  const sets = filterMap(finalSets, ({ armor, stats, mods, bonusStats, tuningDeltas, ...rest }) => {
     const armorOnlyStats: Partial<ArmorStats> = {};
     const fullStats: Partial<ArmorStats> = {};
 
@@ -908,8 +1036,15 @@ export async function process(
         hasStrictUpgrade ||= value > statFilter.minStat;
       }
 
+      // statsCache holds the tunable item's base stats, so add the chosen
+      // tuning mod's contribution back in.
       armorOnlyStats[statHash] =
-        helmStats[i] + gauntStats[i] + chestStats[i] + legStats[i] + classItemStats[i];
+        helmStats[i] +
+        gauntStats[i] +
+        chestStats[i] +
+        legStats[i] +
+        classItemStats[i] +
+        (tuningDeltas !== undefined ? tuningDeltas[i] : 0);
     }
 
     if (strictUpgrades && !hasStrictUpgrade) {
@@ -985,6 +1120,28 @@ interface BucketSoA {
   maxPerks: Int8Array;
   /** The best set-bonus deficit reduction any item in this bucket can make (set piece + wildcard). */
   maxSetContrib: number;
+  /**
+   * Per item, the candidate tuning mods with their stat deltas in stat
+   * priority order, or undefined. Only exotics carry these; the tail resolves
+   * the choice per set instead of the loop enumerating variants.
+   */
+  tuning: (TuningBucketEntry | undefined)[];
+}
+
+interface TuningVariant {
+  modHash: number;
+  /** Tuned stats minus base stats, in stat priority order. */
+  deltas: number[];
+}
+
+interface TuningBucketEntry {
+  variants: TuningVariant[];
+  /** Per stat, the lowest delta across the variants (for exact stat-range minimums). */
+  minDeltas: number[];
+  /** Per stat, the highest delta across the variants (for the max-range convergence gate). */
+  maxDeltas: number[];
+  /** The best net gain any variant can add to the enabled-stat total. */
+  maxNetGain: number;
 }
 
 function buildBucketSoA(
@@ -992,6 +1149,8 @@ function buildBucketSoA(
   statsCache: Map<ProcessItem, number[]>,
   setBonusHashes: number[],
   perkHashes: number[],
+  statOrder: number[],
+  desiredStatRanges: DesiredStatRange[],
 ): BucketSoA {
   const n = items.length;
   const numPerks = perkHashes.length;
@@ -1005,10 +1164,36 @@ function buildBucketSoA(
     hasExotic: false,
     maxPerks: new Int8Array(numPerks),
     maxSetContrib: 0,
+    tuning: new Array<TuningBucketEntry | undefined>(n),
   };
   for (let i = 0; i < n; i++) {
     const item = items[i];
     soa.exotic[i] = item.isExotic ? 1 : 0;
+    if (item.tuningVariants?.length) {
+      const variants = item.tuningVariants.map((v) => ({
+        modHash: v.modHash,
+        deltas: statOrder.map((statHash) => v.stats[statHash] - item.stats[statHash]),
+      }));
+      const minDeltas = [0, 0, 0, 0, 0, 0];
+      const maxDeltas = [0, 0, 0, 0, 0, 0];
+      let maxNetGain = 0;
+      for (let s = 0; s < 6; s++) {
+        minDeltas[s] = Math.min(...variants.map((v) => v.deltas[s]));
+        maxDeltas[s] = Math.max(...variants.map((v) => v.deltas[s]));
+      }
+      for (const v of variants) {
+        let netGain = 0;
+        for (let s = 0; s < 6; s++) {
+          if (desiredStatRanges[s].maxStat > 0 && v.deltas[s] > 0) {
+            netGain += v.deltas[s];
+          }
+        }
+        if (netGain > maxNetGain) {
+          maxNetGain = netGain;
+        }
+      }
+      soa.tuning[i] = { variants, minDeltas, maxDeltas, maxNetGain };
+    }
     soa.artifice[i] = item.isArtifice ? 1 : 0;
     soa.wildcard[i] = item.hasSetBonusModSocket ? 1 : 0;
     soa.setBonusIdx[i] = item.setBonus !== undefined ? setBonusHashes.indexOf(item.setBonus) : -1;

--- a/src/app/loadout-builder/process-worker/types.ts
+++ b/src/app/loadout-builder/process-worker/types.ts
@@ -44,6 +44,12 @@ export interface ProcessItem {
    * to the ArmorSet.statMods list.
    */
   includedTuningMod?: number;
+  /**
+   * For exotics with a tuning socket: the candidate tuning mods and the item's
+   * stats with each one plugged. A valid set has at most one exotic, so the
+   * worker resolves this choice per set instead of multiplying the search.
+   */
+  tuningVariants?: { modHash: number; stats: { [statHash: number]: number } }[];
 }
 
 export type ProcessItemsByBucket = {

--- a/src/app/loadout-builder/process/mappers.test.ts
+++ b/src/app/loadout-builder/process/mappers.test.ts
@@ -1,11 +1,15 @@
 import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
+import { armorStats } from 'app/search/d2-known-values';
+import { getArmor3TuningSocket } from 'app/utils/socket-utils';
 import { getTestStores } from 'testing/test-utils';
 import { loDefaultArmorEnergyRules, MIN_LO_ITEM_ENERGY } from '../types';
 import { mapDimItemToProcessItems } from './mappers';
 
 describe('lo process mappers', () => {
   let classItem: DimItem;
+  let exoticTuningItem: DimItem | undefined;
+  let legendaryTuningItem: DimItem | undefined;
 
   beforeAll(async () => {
     const stores = await getTestStores();
@@ -18,6 +22,10 @@ describe('lo process mappers', () => {
         }
       }
     }
+
+    const armor = stores.flatMap((store) => store.items).filter((item) => item.bucket.inArmor);
+    exoticTuningItem = armor.find((item) => item.isExotic && getArmor3TuningSocket(item));
+    legendaryTuningItem = armor.find((item) => !item.isExotic && getArmor3TuningSocket(item));
   });
 
   test('mapped energy capacity is 10 when assumed masterwork is used', () => {
@@ -30,7 +38,6 @@ describe('lo process mappers', () => {
       modsForSlot: [],
       desiredStatRanges: [],
       autoStatMods: true,
-      expandExoticTuning: false,
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(10);
@@ -47,7 +54,6 @@ describe('lo process mappers', () => {
       modsForSlot: [],
       desiredStatRanges: [],
       autoStatMods: true,
-      expandExoticTuning: false,
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(modifiedItem.energy?.energyCapacity);
@@ -64,9 +70,58 @@ describe('lo process mappers', () => {
       modsForSlot: [],
       desiredStatRanges: [],
       autoStatMods: true,
-      expandExoticTuning: false,
     })[0];
 
     expect(mappedItem.remainingEnergyCapacity).toBe(MIN_LO_ITEM_ENERGY);
+  });
+
+  test('a tuning-capable exotic maps to a single item with tuning variants attached', () => {
+    if (!exoticTuningItem) {
+      return; // no tuning-capable exotic in the test data
+    }
+    const mappedItems = mapDimItemToProcessItems({
+      dimItem: exoticTuningItem,
+      armorEnergyRules: loDefaultArmorEnergyRules,
+      modsForSlot: [],
+      desiredStatRanges: armorStats.map((statHash) => ({ statHash, minStat: 0, maxStat: 200 })),
+      autoStatMods: true,
+    });
+
+    expect(mappedItems).toHaveLength(1);
+    const [mappedItem] = mappedItems;
+    expect(mappedItem.includedTuningMod).toBeUndefined();
+    expect(mappedItem.tuningVariants!.length).toBeGreaterThan(0);
+    const socketPlugs = getArmor3TuningSocket(exoticTuningItem)!.reusablePlugItems!.map(
+      (p) => p.plugItemHash,
+    );
+    for (const variant of mappedItem.tuningVariants!) {
+      expect(socketPlugs).toContain(variant.modHash);
+    }
+    // The variants carry the item's stats as tuned by each mod
+    expect(
+      mappedItem.tuningVariants!.some(
+        (variant) =>
+          !armorStats.every((statHash) => variant.stats[statHash] === mappedItem.stats[statHash]),
+      ),
+    ).toBe(true);
+  });
+
+  test('a tuning-capable legendary still expands into one item per tuning mod', () => {
+    if (!legendaryTuningItem) {
+      return; // no tuning-capable legendary in the test data
+    }
+    const mappedItems = mapDimItemToProcessItems({
+      dimItem: legendaryTuningItem,
+      armorEnergyRules: loDefaultArmorEnergyRules,
+      modsForSlot: [],
+      desiredStatRanges: armorStats.map((statHash) => ({ statHash, minStat: 0, maxStat: 200 })),
+      autoStatMods: true,
+    });
+
+    expect(mappedItems.length).toBeGreaterThan(0);
+    for (const mappedItem of mappedItems) {
+      expect(mappedItem.includedTuningMod).toBeDefined();
+      expect(mappedItem.tuningVariants).toBeUndefined();
+    }
   });
 });

--- a/src/app/loadout-builder/process/mappers.ts
+++ b/src/app/loadout-builder/process/mappers.ts
@@ -23,7 +23,7 @@ import {
 import { emptyPlugHashes } from 'data/d2/empty-plug-hashes';
 import { StatHashes } from 'data/d2/generated-enums';
 import { minBy } from 'es-toolkit';
-import { DimItem, PluggableInventoryItemDefinition } from '../../inventory/item-types';
+import { DimItem, DimSocket, PluggableInventoryItemDefinition } from '../../inventory/item-types';
 import {
   getModTypeTagByPlugCategoryHash,
   getSpecialtySocketMetadata,
@@ -68,20 +68,12 @@ export function mapDimItemToProcessItems({
   modsForSlot,
   desiredStatRanges,
   autoStatMods,
-  expandExoticTuning,
 }: {
   dimItem: DimItem;
   armorEnergyRules: ArmorEnergyRules;
   modsForSlot?: PluggableInventoryItemDefinition[];
   desiredStatRanges: DesiredStatRange[];
   autoStatMods: boolean;
-  /**
-   * Whether to generate tuning-mod variants for exotics. Tier 5 exotics expose
-   * every tuning mod (not a single set), so this multiplies combinations. We
-   * only do it when the user is actually targeting an exotic, otherwise the
-   * default unfiltered run would pay that cost for exotics nobody asked for.
-   */
-  expandExoticTuning: boolean;
 }): ProcessItem[] {
   const { id, hash, name, isExotic, power, setBonus } = dimItem;
 
@@ -117,63 +109,81 @@ export function mapDimItemToProcessItems({
 
   const tuningSocket = getArmor3TuningSocket(dimItem);
 
-  // Make a version of the item for each possible tuning mod that could be applied.
-  // The dump-stat filter below keeps the number of variants bounded.
-  if (
-    autoStatMods &&
-    (!isExotic || expandExoticTuning) &&
-    tuningSocket?.reusablePlugItems?.length
-  ) {
-    const processItems: ProcessItem[] = [];
-    const allPlugs = tuningSocket.plugSet?.plugs;
-    // By default, we'll sacrifice the last ignored stat, or the last from among the lowest maximums
-    const defaultDumpStat =
-      desiredStatRanges.findLast((r) => r.maxStat === 0)?.statHash ??
-      minBy(Array.from(desiredStatRanges.entries()), ([i, r]) => r.maxStat * 1000 - i)?.[1]
-        .statHash;
-
-    for (const { plugItemHash, enabled } of tuningSocket.reusablePlugItems) {
-      if (!enabled || emptyPlugHashes.has(plugItemHash)) {
-        continue;
-      }
-      const plug = allPlugs?.find((p) => p.plugDef.hash === plugItemHash);
-      if (plug) {
-        const def = plug.plugDef;
-        if (isPluggableItem(def) && def.investmentStats?.length) {
-          const tunedStats = { ...stats };
-          let dumpStatHash: StatHashes | undefined = undefined;
-          for (const { statTypeHash, activationRule, value } of mapAndFilterInvestmentStats(def)) {
-            if (
-              armorStats.includes(statTypeHash) &&
-              isPlugStatActive(activationRule, { item: dimItem, statHash: statTypeHash })
-            ) {
-              tunedStats[statTypeHash] = Math.min(MAX_STAT, tunedStats[statTypeHash] + value);
-              if (value < 0) {
-                dumpStatHash = statTypeHash;
-              }
-            }
-          }
-          const desiredMax = dumpStatHash
-            ? desiredStatRanges.find((r) => r.statHash === dumpStatHash)!.maxStat
-            : 0;
-          // If we are dumping
-          if (
-            // This is balanced tuning
-            dumpStatHash === undefined ||
-            // This is dumping the stat we want to dump
-            (defaultDumpStat && dumpStatHash === defaultDumpStat) ||
-            // The maximum is low enough that we might actually want to dump this stat to benefit others
-            (desiredMax > 0 && desiredMax <= 175)
-          ) {
-            processItems.push({ ...processItem, includedTuningMod: def.hash, stats: tunedStats });
-          }
-        }
-      }
+  if (autoStatMods && tuningSocket?.reusablePlugItems?.length) {
+    const variants = buildTuningVariants(dimItem, stats, tuningSocket, desiredStatRanges);
+    if (isExotic) {
+      // Exotics expose every tuning mod, and expanding them into separate items
+      // multiplies the search, so the worker picks among the variants per set
+      // instead (a valid set has at most one exotic).
+      return variants.length ? [{ ...processItem, tuningVariants: variants }] : [processItem];
     }
-    return processItems;
+    // Make a version of the item for each possible tuning mod that could be applied.
+    return variants.map((v) => ({
+      ...processItem,
+      includedTuningMod: v.modHash,
+      stats: v.stats,
+    }));
   }
 
   return [processItem];
+}
+
+/**
+ * The tuning mods worth considering for this item, with the item's stats as
+ * tuned by each. The dump-stat filter keeps the number of variants bounded.
+ */
+function buildTuningVariants(
+  dimItem: DimItem,
+  stats: { [statHash: number]: number },
+  tuningSocket: DimSocket,
+  desiredStatRanges: DesiredStatRange[],
+): { modHash: number; stats: { [statHash: number]: number } }[] {
+  const variants: { modHash: number; stats: { [statHash: number]: number } }[] = [];
+  const allPlugs = tuningSocket.plugSet?.plugs;
+  // By default, we'll sacrifice the last ignored stat, or the last from among the lowest maximums
+  const defaultDumpStat =
+    desiredStatRanges.findLast((r) => r.maxStat === 0)?.statHash ??
+    minBy(Array.from(desiredStatRanges.entries()), ([i, r]) => r.maxStat * 1000 - i)?.[1].statHash;
+
+  for (const { plugItemHash, enabled } of tuningSocket.reusablePlugItems ?? []) {
+    if (!enabled || emptyPlugHashes.has(plugItemHash)) {
+      continue;
+    }
+    const plug = allPlugs?.find((p) => p.plugDef.hash === plugItemHash);
+    if (plug) {
+      const def = plug.plugDef;
+      if (isPluggableItem(def) && def.investmentStats?.length) {
+        const tunedStats = { ...stats };
+        let dumpStatHash: StatHashes | undefined = undefined;
+        for (const { statTypeHash, activationRule, value } of mapAndFilterInvestmentStats(def)) {
+          if (
+            armorStats.includes(statTypeHash) &&
+            isPlugStatActive(activationRule, { item: dimItem, statHash: statTypeHash })
+          ) {
+            tunedStats[statTypeHash] = Math.min(MAX_STAT, tunedStats[statTypeHash] + value);
+            if (value < 0) {
+              dumpStatHash = statTypeHash;
+            }
+          }
+        }
+        const desiredMax = dumpStatHash
+          ? desiredStatRanges.find((r) => r.statHash === dumpStatHash)!.maxStat
+          : 0;
+        // If we are dumping
+        if (
+          // This is balanced tuning
+          dumpStatHash === undefined ||
+          // This is dumping the stat we want to dump
+          (defaultDumpStat && dumpStatHash === defaultDumpStat) ||
+          // The maximum is low enough that we might actually want to dump this stat to benefit others
+          (desiredMax > 0 && desiredMax <= 175)
+        ) {
+          variants.push({ modHash: def.hash, stats: tunedStats });
+        }
+      }
+    }
+  }
+  return variants;
 }
 
 export function mapAutoMods(defs: AutoModDefs): AutoModData {

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -65,7 +65,6 @@ export function runProcess({
   desiredStatRanges,
   anyExotic,
   autoStatMods,
-  expandExoticTuning,
   strictUpgrades,
   stopOnFirstSet,
   lastInput,
@@ -81,7 +80,6 @@ export function runProcess({
   desiredStatRanges: DesiredStatRange[];
   anyExotic: boolean;
   autoStatMods: boolean;
-  expandExoticTuning: boolean;
   strictUpgrades: boolean;
   stopOnFirstSet: boolean;
   lastInput: ProcessInputs | undefined;
@@ -121,7 +119,6 @@ export function runProcess({
         desiredStatRanges,
         modsForSlot: bucketSpecificMods[bucketHash] || [],
         autoStatMods,
-        expandExoticTuning,
       }).map((processItem) => ({
         dimItem,
         processItem,

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -62,7 +62,6 @@ export function useProcess({
   desiredStatRanges,
   anyExotic,
   autoStatMods,
-  expandExoticTuning,
   strictUpgrades,
 }: {
   selectedStore: DimStore;
@@ -75,7 +74,6 @@ export function useProcess({
   desiredStatRanges: DesiredStatRange[];
   anyExotic: boolean;
   autoStatMods: boolean;
-  expandExoticTuning: boolean;
   strictUpgrades: boolean;
 }) {
   const [{ result, processing, totalCombos, completedCombos, startTime, resultStoreId }, setState] =
@@ -131,7 +129,6 @@ export function useProcess({
         desiredStatRanges,
         anyExotic,
         autoStatMods,
-        expandExoticTuning,
         stopOnFirstSet: false,
         strictUpgrades,
         lastInput: inputsRef.current,
@@ -195,7 +192,6 @@ export function useProcess({
     anyExotic,
     armorEnergyRules,
     autoStatMods,
-    expandExoticTuning,
     lockedModMap,
     setBonuses,
     perks,

--- a/src/app/loadout/mod-assignment-utils.test.ts
+++ b/src/app/loadout/mod-assignment-utils.test.ts
@@ -347,10 +347,10 @@ describe('fitMostMods tuning assignment', () => {
     }
 
     // A set with a tuning-capable exotic and a tuning-capable legendary, filled out
-    // with non-tuning pieces. On a default LO run the exotic isn't given a tuning
-    // mod (expandExoticTuning is off), so the flat mod list holds only the
-    // legendary's mod. The exotic must not consume it -- both the exotic accepting
-    // any tuning mod and slot order could otherwise pull the mod onto the exotic.
+    // with non-tuning pieces. When LO didn't tune the exotic (auto stat mods off, or
+    // an older saved loadout), the flat mod list holds only the legendary's mod. The
+    // exotic must not consume it -- both the exotic accepting any tuning mod and
+    // slot order could otherwise pull the mod onto the exotic.
     const items = [
       exoticTuningItem,
       legendary,

--- a/src/app/loadout/mod-assignment-utils.ts
+++ b/src/app/loadout/mod-assignment-utils.ts
@@ -390,14 +390,15 @@ export function fitMostMods({
     .filter((item) => getArmor3TuningSocket(item) !== undefined)
     .sort(compareBy((item) => (ArmorBucketHashes as number[]).indexOf(item.bucket.hash)));
 
-  // The mapper always generates a tuning mod for every tuning-capable *legendary*,
-  // but only tunes an exotic when the user targeted one (expandExoticTuning). When
-  // it doesn't, the exotic still has a tuning socket, so leaving it in the candidate
-  // list lets it match the first mod (it accepts anything), steal a legendary's mod,
-  // and shift everything after it -- the actual bug. Since every legendary is always
-  // tuned, one more mod than there are tuning-capable legendaries is the tell that
-  // the exotic was tuned; otherwise it wasn't, so drop it from the candidates. Once
-  // the exotic is correctly kept or dropped the slot-order pass is exact.
+  // LO always tunes every tuning-capable *legendary*, but a set's exotic may or
+  // may not have been tuned (auto stat mods off, or a loadout saved before LO
+  // tuned exotics). When it wasn't, the exotic still has a tuning socket, so
+  // leaving it in the candidate list lets it match the first mod (it accepts
+  // anything), steal a legendary's mod, and shift everything after it -- the
+  // actual bug. Since every legendary is always tuned, one more mod than there
+  // are tuning-capable legendaries is the tell that the exotic was tuned;
+  // otherwise it wasn't, so drop it from the candidates. Once the exotic is
+  // correctly kept or dropped the slot-order pass is exact.
   const legendaryTuningCount = count(tuningItems, (item) => !item.isExotic);
   const exoticWasTuned = tuningMods.length > legendaryTuningCount;
   const tuningCandidates = exoticWasTuned

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -706,7 +706,6 @@
     "ExistingLoadout": "Existing Loadout",
     "Exotic": "Exotic Armor",
     "ExoticSpecialCategory": "Special",
-    "ExoticTuningNote": "Lock a specific exotic, or choose Any Exotic, to also consider its tuning mods.",
     "Filter": "Settings",
     "IgnoreStat": "If unchecked, Loadout Optimizer will pretend this stat doesn't exist when building sets",
     "IncreaseStatPriority": "Increase stat priority",


### PR DESCRIPTION
11860:
<img width="440" height="29" alt="image" src="https://github.com/user-attachments/assets/95492ac8-6eed-4086-9bb8-c4a560e244a4" />
11862:
<img width="444" height="32" alt="image" src="https://github.com/user-attachments/assets/3428921b-8089-40b2-86d1-da4801f7cd0e" />


Exotic tuning variants were only generated when the user pinned an exotic, because expanding each tier 5 exotic into 5-6 bucket items grew the search 13.8x. Instead of expanding exotics at all, attach their tuning variants to a single base item and resolve the choice in the per-set tail: a valid set has at most one exotic, so this costs at most 6 tail evaluations per candidate set instead of multiplying the enumeration.

A per-set pre-gate keeps the tail cheap in the steady state: stat-range minimums are updated exactly using per-stat minimum deltas across variants, and the variant loop only runs when some variant could improve the displayed ranges or beat the heap boundary (bounded by the best net gain any variant offers). Pinned and any-exotic searches get faster since their buckets are no longer multiplied by variant count.

Equivalence tests pin tail resolution against the old bucket expansion, both below tracker capacity (identical output) and with boundary pruning active (identical retained totals, ranges, and candidate counts).

Changelog: The Loadout Optimizer now applies tuning mods to Tier 5 exotics even when no exotic is pinned.

Depends on: #11860

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
