### PR TITLE
Loadout Optimizer: make worker log stats readable after the run

### DIFF
--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -125,13 +125,15 @@ export async function process(
     'combinations from',
     numItems,
     'items',
-    {
+    // Stringified because these workers get terminated when the run ends, and
+    // DevTools can't inspect live objects logged from a dead worker.
+    JSON.stringify({
       helms: helms.length,
       gauntlets: gauntlets.length,
       chests: chests.length,
       legs: legs.length,
       classItems: classItems.length,
-    },
+    }),
   );
 
   const setStatistics: ProcessStatistics['statistics'] = {
@@ -620,17 +622,14 @@ export async function process(
     'ms - ',
     Math.floor((combos * 1000) / totalTime),
     'combos/s',
-    // Split into multiple objects so console.log will show them all expanded
+    // Stringified because these workers get terminated when the run ends, and
+    // DevTools can't inspect live objects logged from a dead worker.
     'sets outright skipped:',
-    setStatistics.skipReasons,
+    JSON.stringify(setStatistics.skipReasons),
     'lower bounds:',
-    setStatistics.lowerBoundsExceeded,
+    JSON.stringify(setStatistics.lowerBoundsExceeded),
     'mod assignment stats:',
-    'early check:',
-    setStatistics.modsStatistics.earlyModsCheck,
-    'auto mods pick:',
-    setStatistics.modsStatistics.autoModsPick,
-    setStatistics.modsStatistics,
+    JSON.stringify(setStatistics.modsStatistics),
   );
 
   const statRangesFiltered = Object.fromEntries(

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -629,7 +629,12 @@ export async function process(
     'lower bounds:',
     JSON.stringify(setStatistics.lowerBoundsExceeded),
     'mod assignment stats:',
-    JSON.stringify(setStatistics.modsStatistics),
+    'early check:',
+    JSON.stringify(setStatistics.modsStatistics.earlyModsCheck),
+    'auto mods pick:',
+    JSON.stringify(setStatistics.modsStatistics.autoModsPick),
+    'final assignment:',
+    JSON.stringify(setStatistics.modsStatistics.finalAssignment),
   );
 
   const statRangesFiltered = Object.fromEntries(


### PR DESCRIPTION
The LO worker's summary logs pass live objects to `console.log`, but LO terminates its workers as soon as a run finishes, and DevTools can't inspect objects logged from a dead worker. They render, and copy into bug reports, as `[object Object]`:

```
[loadout optimizer thread 5] 1.996 found 1 stat mixes after processing 53005050 stat combinations in 1840.8000001907349 ms -  28794573 combos/s sets outright skipped: [object Object] lower bounds: [object Object] mod assignment stats: early check: [object Object] auto mods pick: [object Object] [object Object]
```

This stringifies the objects in both worker log lines (the per-bucket item counts in the "Processing N combinations" line, and the end-of-run statistics) so the numbers survive worker termination and paste correctly:

```
[loadout optimizer thread 5] ... sets outright skipped: {"doubleExotic":0,"noExotic":0,"skippedLowTier":0,"insufficientSetBonus":0,"insufficientPerks":0} lower bounds: {"timesChecked":1,"timesFailed":0} mod assignment stats: early check: {"timesChecked":0,"timesFailed":0} auto mods pick: {"timesChecked":0,"timesFailed":0} final assignment: {"modAssignmentAttempted":0,"modsAssignmentFailed":0,"autoModsAssignmentFailed":0}
```

The mod assignment stats keep their three labeled sections as before, with `final assignment:` now labeled too instead of riding along as the unlabeled combined object.