### PR TITLE
Loadout Optimizer: branch-and-bound search pruning (100x+ on real vaults), balanced slicing, warm worker pool

### DIFF
--- a/src/app/loadout-builder/process-worker/__snapshots__/process.test.ts.snap
+++ b/src/app/loadout-builder/process-worker/__snapshots__/process.test.ts.snap
@@ -2,13 +2,13 @@
 
 exports[`process equivalence anyExotic with synthesized exotics 1`] = `
 {
-  "comboLocalSkips": 21120,
+  "comboLocalSkips": 11008,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 11648,
+    "timesChecked": 1592,
     "timesFailed": 0,
   },
-  "numProcessed": 11648,
+  "numProcessed": 1592,
   "sets": [
     {
       "armor": [
@@ -5845,10 +5845,10 @@ exports[`process equivalence locked general and activity mods 1`] = `
   "comboLocalSkips": 0,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 32768,
+    "timesChecked": 2232,
     "timesFailed": 0,
   },
-  "numProcessed": 32768,
+  "numProcessed": 2232,
   "sets": [
     {
       "armor": [
@@ -12485,10 +12485,10 @@ exports[`process equivalence no constraints 1`] = `
   "comboLocalSkips": 0,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 32768,
+    "timesChecked": 2232,
     "timesFailed": 0,
   },
-  "numProcessed": 32768,
+  "numProcessed": 2232,
   "sets": [
     {
       "armor": [
@@ -18322,13 +18322,13 @@ exports[`process equivalence no constraints 1`] = `
 
 exports[`process equivalence required perks 1`] = `
 {
-  "comboLocalSkips": 30464,
+  "comboLocalSkips": 24332,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 2304,
+    "timesChecked": 452,
     "timesFailed": 0,
   },
-  "numProcessed": 2304,
+  "numProcessed": 452,
   "sets": [
     {
       "armor": [
@@ -24165,10 +24165,10 @@ exports[`process equivalence set bonus satisfied only via wildcard 1`] = `
   "comboLocalSkips": 31360,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 1408,
+    "timesChecked": 720,
     "timesFailed": 0,
   },
-  "numProcessed": 1408,
+  "numProcessed": 720,
   "sets": [
     {
       "armor": [
@@ -30002,13 +30002,13 @@ exports[`process equivalence set bonus satisfied only via wildcard 1`] = `
 
 exports[`process equivalence set bonuses with wildcards 1`] = `
 {
-  "comboLocalSkips": 28692,
+  "comboLocalSkips": 22397,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 4076,
+    "timesChecked": 1219,
     "timesFailed": 0,
   },
-  "numProcessed": 4076,
+  "numProcessed": 1219,
   "sets": [
     {
       "armor": [
@@ -35845,10 +35845,10 @@ exports[`process equivalence stat minimums and maximums with auto stat mods 1`] 
   "comboLocalSkips": 0,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 32768,
+    "timesChecked": 1688,
     "timesFailed": 0,
   },
-  "numProcessed": 32768,
+  "numProcessed": 1688,
   "sets": [
     {
       "armor": [
@@ -42885,10 +42885,10 @@ exports[`process equivalence strict upgrades 1`] = `
   "comboLocalSkips": 0,
   "combos": 32768,
   "lowerBoundsExceeded": {
-    "timesChecked": 32768,
+    "timesChecked": 2360,
     "timesFailed": 0,
   },
-  "numProcessed": 32768,
+  "numProcessed": 2360,
   "sets": [
     {
       "armor": [

--- a/src/app/loadout-builder/process-worker/process-baseline.ts
+++ b/src/app/loadout-builder/process-worker/process-baseline.ts
@@ -29,9 +29,11 @@ import { ProcessItem, ProcessResult, ProcessStatistics } from './types';
 const RETURNED_ARMOR_SETS = 200;
 
 /**
- * FROZEN REFERENCE COPY of the #11862 `process()` implementation, used only by
- * the parity harness (`process-parity.test.ts`) as the pre-pareto oracle.
- * Do not edit to track `process.ts`; delete once the pareto work has landed.
+ * Frozen reference copy of the `process()` worker loop, captured at #11862.
+ * The parity and benchmark harnesses (`process-parity.test.ts`,
+ * `process.bench.test.ts`) run this against a candidate `process()` to check
+ * that a perf change stays correct and to measure its speedup. Don't edit it to
+ * track `process.ts` — its whole job is to stay fixed as the baseline.
  */
 export async function processBaseline(
   workerNum: number,

--- a/src/app/loadout-builder/process-worker/process-baseline.ts
+++ b/src/app/loadout-builder/process-worker/process-baseline.ts
@@ -1,0 +1,1183 @@
+import { MAX_STAT } from 'app/loadout/known-values';
+import { compact, filterMap } from 'app/utils/collections';
+import { BucketHashes } from 'data/d2/generated-enums';
+import { sum } from 'es-toolkit';
+import { infoLog } from '../../utils/log';
+import {
+  ArmorBucketHashes,
+  ArmorStatHashes,
+  ArmorStats,
+  artificeStatBoost,
+  DesiredStatRange,
+  majorStatBoost,
+  MinMaxStat,
+  StatRanges,
+} from '../types';
+import { getPower } from '../utils';
+import type { ProcessInputs } from './process';
+import {
+  pickAndAssignSlotIndependentMods,
+  pickOptimalStatMods,
+  precalculateStructures,
+  SetEnergyCache,
+  updateMaxStats,
+} from './process-utils';
+import { encodeStatMix, HeapSetTracker } from './set-tracker';
+import { ProcessItem, ProcessResult, ProcessStatistics } from './types';
+
+/** Caps the maximum number of total armor sets that'll be returned */
+const RETURNED_ARMOR_SETS = 200;
+
+/**
+ * FROZEN REFERENCE COPY of the #11862 `process()` implementation, used only by
+ * the parity harness (`process-parity.test.ts`) as the pre-pareto oracle.
+ * Do not edit to track `process.ts`; delete once the pareto work has landed.
+ */
+export async function processBaseline(
+  workerNum: number,
+  {
+    filteredItems,
+    modStatTotals,
+    lockedMods,
+    setBonuses,
+    requiredPerks,
+    desiredStatRanges,
+    anyExotic,
+    autoModOptions,
+    autoStatMods,
+    strictUpgrades,
+    stopOnFirstSet,
+  }: ProcessInputs,
+  onProgress: (completed: number) => void,
+): Promise<ProcessResult> {
+  const pstart = performance.now();
+
+  // For efficiency, we'll handle most stats as flat arrays in the order the user prioritized their stats.
+  const statOrder = desiredStatRanges.map(({ statHash }): ArmorStatHashes => statHash);
+  // The maximum stat constraints for each stat
+  const maxStatConstraints = desiredStatRanges.map(({ maxStat }) => maxStat);
+  // Convert the list of stat bonuses from mods into a flat array in the same order as `statOrder`.
+  const modStatsInStatOrder = statOrder.map((h) => modStatTotals[h]);
+
+  // This stores the computed min and max value for each stat as we process all sets, so we
+  // can display it on the stat constraint editor.
+  const statRanges = statOrder.map((): MinMaxStat => ({ minStat: MAX_STAT, maxStat: 0 }));
+
+  // Precompute stat arrays for each item in stat order
+  const statsCache = new Map<ProcessItem, number[]>();
+  for (const item of ArmorBucketHashes.flatMap((h) => filteredItems[h])) {
+    statsCache.set(
+      item,
+      statOrder.map((statHash) => item.stats[statHash]),
+    );
+  }
+
+  // Each of these groups has already been reduced (in useProcess.ts) to the
+  // minimum number of items that are worth considering.
+  const helms = filteredItems[BucketHashes.Helmet];
+  const gauntlets = filteredItems[BucketHashes.Gauntlets];
+  const chests = filteredItems[BucketHashes.ChestArmor];
+  const legs = filteredItems[BucketHashes.LegArmor];
+  const classItems = filteredItems[BucketHashes.ClassArmor];
+
+  // Visit high-stat items first so the top-200 heap fills with good sets early,
+  // which lets the couldInsert prune reject low-total sets much sooner. This
+  // doesn't change the results: the enumerated combination set is the same and
+  // the top 200 under the tracker's ordering is order-independent.
+  const enabledStatsTotal = (item: ProcessItem) => {
+    const itemStats = statsCache.get(item)!;
+    let total = 0;
+    for (let i = 0; i < 6; i++) {
+      if (desiredStatRanges[i].maxStat > 0) {
+        total += itemStats[i];
+      }
+    }
+    return total;
+  };
+  for (const bucket of [helms, gauntlets, chests, legs, classItems]) {
+    bucket.sort((a, b) => enabledStatsTotal(b) - enabledStatsTotal(a));
+  }
+
+  // The maximum possible combos we could possibly have
+  const combos = helms.length * gauntlets.length * chests.length * legs.length * classItems.length;
+  const numItems =
+    helms.length + gauntlets.length + chests.length + legs.length + classItems.length;
+
+  infoLog(
+    `loadout optimizer thread ${workerNum}`,
+    'Processing',
+    combos,
+    'combinations from',
+    numItems,
+    'items',
+    {
+      helms: helms.length,
+      gauntlets: gauntlets.length,
+      chests: chests.length,
+      legs: legs.length,
+      classItems: classItems.length,
+    },
+  );
+
+  const setStatistics: ProcessStatistics['statistics'] = {
+    skipReasons: {
+      doubleExotic: 0,
+      noExotic: 0,
+      skippedLowTier: 0,
+      insufficientSetBonus: 0,
+      insufficientPerks: 0,
+    },
+    lowerBoundsExceeded: { timesChecked: 0, timesFailed: 0 },
+    modsStatistics: {
+      earlyModsCheck: { timesChecked: 0, timesFailed: 0 },
+      autoModsPick: { timesChecked: 0, timesFailed: 0 },
+      finalAssignment: {
+        modAssignmentAttempted: 0,
+        modsAssignmentFailed: 0,
+        autoModsAssignmentFailed: 0,
+      },
+    },
+  };
+  const processStatistics: ProcessStatistics = {
+    numProcessed: 0,
+    numValidSets: 0,
+    statistics: setStatistics,
+  };
+
+  if (combos === 0) {
+    const statRangesFiltered = Object.fromEntries(
+      statOrder.map((h) => [h, { minStat: 0, maxStat: MAX_STAT }]),
+    ) as StatRanges;
+    return { sets: [], combos: 0, statRangesFiltered, processInfo: processStatistics };
+  }
+
+  const setTracker = new HeapSetTracker<{
+    /** The armor items in this set. */
+    armor: ProcessItem[];
+    /** The stats associated with this armor set. */
+    stats: number[];
+    mods: number[];
+    bonusStats: number[];
+    /** Stat deltas of the tuning mod chosen for the set's tunable item, if any. */
+    tuningDeltas: number[] | undefined;
+  }>(RETURNED_ARMOR_SETS);
+
+  const { activityMods, generalMods } = lockedMods;
+
+  const precalculatedInfo = precalculateStructures(
+    autoModOptions,
+    generalMods,
+    activityMods,
+    autoStatMods,
+    statOrder,
+  );
+  const hasMods = Boolean(activityMods.length || generalMods.length);
+
+  const setBonusHashes = Object.keys(setBonuses).map((h) => Number(h));
+  const setBonusCounts = Object.values(setBonuses) as number[]; // TS won't figure this out itself?
+
+  interface Scheduler {
+    scheduler?: { yield: () => Promise<void> };
+  }
+
+  let yieldTask: (() => Promise<void>) | undefined = undefined;
+  if ((globalThis as unknown as Scheduler).scheduler && navigator.userAgent.includes('Firefox')) {
+    // Unlike Chrome, Firefox won't deliver postMessage until the thread yields.
+    // This relatively new API lets you yield without having to rewrite your
+    // whole loop.
+    yieldTask = () => (globalThis as unknown as Scheduler).scheduler!.yield();
+  }
+
+  let comboCount = 0;
+  // required perks' hashes and counts, in matching order
+  const perkHashes = requiredPerks.map((p) => p.hash);
+  const requiredPerkCounts = requiredPerks.map((p) => p.count);
+  const numPerks = requiredPerks.length;
+  const hasPerkReqs = numPerks > 0;
+
+  // Parallel per-bucket arrays so the hot loop reads flat numbers instead of
+  // hashing into maps, converting booleans, or allocating per combination.
+  const helmSoA = buildBucketSoA(
+    helms,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const gauntSoA = buildBucketSoA(
+    gauntlets,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const chestSoA = buildBucketSoA(
+    chests,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const legSoA = buildBucketSoA(
+    legs,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+  const classItemSoA = buildBucketSoA(
+    classItems,
+    statsCache,
+    setBonusHashes,
+    perkHashes,
+    statOrder,
+    desiredStatRanges,
+  );
+
+  const numSetBonuses = setBonusHashes.length;
+
+  // How many combinations a subtree prune at each loop level skips
+  const combosPerHelm = gauntlets.length * chests.length * legs.length * classItems.length;
+  const combosPerGaunt = chests.length * legs.length * classItems.length;
+  const combosPerChest = legs.length * classItems.length;
+  const combosPerLeg = classItems.length;
+
+  // Whether any later bucket could still contribute an exotic, per level. When
+  // this is false and the partial set has no exotic, no completion can satisfy
+  // anyExotic, so the whole subtree can be skipped.
+  const exoticAfterHelm =
+    gauntSoA.hasExotic || chestSoA.hasExotic || legSoA.hasExotic || classItemSoA.hasExotic;
+  const exoticAfterGaunt = chestSoA.hasExotic || legSoA.hasExotic || classItemSoA.hasExotic;
+  const exoticAfterChest = legSoA.hasExotic || classItemSoA.hasExotic;
+  const exoticAfterLeg = classItemSoA.hasExotic;
+
+  // Per-perk / set-bonus maximum contribution of the remaining buckets at each
+  // level. If even the best-case completion can't reach a requirement, the
+  // subtree can be skipped.
+  const maxPerksAfterHelm = new Array<number>(numPerks);
+  const maxPerksAfterGaunt = new Array<number>(numPerks);
+  const maxPerksAfterChest = new Array<number>(numPerks);
+  const maxPerksAfterLeg = new Array<number>(numPerks);
+  for (let i = 0; i < numPerks; i++) {
+    maxPerksAfterLeg[i] = classItemSoA.maxPerks[i];
+    maxPerksAfterChest[i] = maxPerksAfterLeg[i] + legSoA.maxPerks[i];
+    maxPerksAfterGaunt[i] = maxPerksAfterChest[i] + chestSoA.maxPerks[i];
+    maxPerksAfterHelm[i] = maxPerksAfterGaunt[i] + gauntSoA.maxPerks[i];
+  }
+  const maxSetContribAfterLeg = classItemSoA.maxSetContrib;
+  const maxSetContribAfterChest = maxSetContribAfterLeg + legSoA.maxSetContrib;
+  const maxSetContribAfterGaunt = maxSetContribAfterChest + chestSoA.maxSetContrib;
+  const maxSetContribAfterHelm = maxSetContribAfterGaunt + gauntSoA.maxSetContrib;
+
+  // Reused across iterations to avoid per-combo allocation in this hot loop.
+  // Safe because each is only read within one iteration and copied before being
+  // stored in the set tracker. The statsAfter*/perksAfter*/setCountsAfter*
+  // arrays hold running partial sums for the outer loop levels so the
+  // innermost loop only adds the class item's contribution.
+  const stats = [0, 0, 0, 0, 0, 0];
+  const effectiveStats = [0, 0, 0, 0, 0, 0];
+  const neededStats = [0, 0, 0, 0, 0, 0];
+  const armor: ProcessItem[] = new Array<ProcessItem>(5);
+  // Shares the activity-mod energy computation between updateMaxStats and
+  // pickOptimalStatMods for the same armor set; cleared per combination.
+  const energyCache: SetEnergyCache = { result: undefined };
+  const statsAfterHelm = [0, 0, 0, 0, 0, 0];
+  const statsAfterGaunt = [0, 0, 0, 0, 0, 0];
+  const statsAfterChest = [0, 0, 0, 0, 0, 0];
+  const statsAfterLeg = [0, 0, 0, 0, 0, 0];
+  const perksAfterHelm = new Array<number>(numPerks).fill(0);
+  const perksAfterGaunt = new Array<number>(numPerks).fill(0);
+  const perksAfterChest = new Array<number>(numPerks).fill(0);
+  const perksAfterLeg = new Array<number>(numPerks).fill(0);
+  const setCountsAfterHelm = new Array<number>(numSetBonuses).fill(0);
+  const setCountsAfterGaunt = new Array<number>(numSetBonuses).fill(0);
+  const setCountsAfterChest = new Array<number>(numSetBonuses).fill(0);
+  const setCountsAfterLeg = new Array<number>(numSetBonuses).fill(0);
+
+  // Hot counters are kept in locals and flushed into the statistics objects
+  // after the loop, to avoid nested property writes per combination.
+  let numProcessed = 0;
+  let lowerBoundsChecked = 0;
+  let lowerBoundsFailed = 0;
+  let skipDoubleExotic = 0;
+  let skipNoExotic = 0;
+  let skipInsufficientPerks = 0;
+  let skipInsufficientSetBonus = 0;
+  let skipLowTier = 0;
+
+  // Subtree prunes add the whole skipped subtree size to comboCount, so a
+  // single flush can report far more than 100k combos; onProgress takes a
+  // delta, so that's fine.
+  const flushProgress = async () => {
+    onProgress(comboCount);
+    comboCount = 0;
+    if (yieldTask) {
+      await yieldTask();
+    }
+  };
+
+  itemLoop: for (let helmIdx = 0; helmIdx < helms.length; helmIdx++) {
+    const helm = helms[helmIdx];
+    const exoticP1 = helmSoA.exotic[helmIdx];
+    // A single item can't be a double exotic; only the noExotic prune can
+    // apply at this level, and only when no later bucket has exotics either.
+    if (anyExotic && exoticP1 === 0 && !exoticAfterHelm) {
+      skipNoExotic += combosPerHelm;
+      comboCount += combosPerHelm;
+      if (comboCount >= 100000) {
+        await flushProgress();
+      }
+      continue;
+    }
+    if (hasPerkReqs) {
+      const helmPerkBase = helmIdx * numPerks;
+      let impossible = false;
+      for (let i = 0; i < numPerks; i++) {
+        const p = helmSoA.perks[helmPerkBase + i];
+        perksAfterHelm[i] = p;
+        if (p + maxPerksAfterHelm[i] < requiredPerkCounts[i]) {
+          impossible = true;
+          break;
+        }
+      }
+      if (impossible) {
+        skipInsufficientPerks += combosPerHelm;
+        comboCount += combosPerHelm;
+        if (comboCount >= 100000) {
+          await flushProgress();
+        }
+        continue;
+      }
+    }
+    const wildcardP1 = helmSoA.wildcard[helmIdx];
+    if (numSetBonuses > 0) {
+      const helmSet = helmSoA.setBonusIdx[helmIdx];
+      let deficit = 0;
+      for (let i = 0; i < numSetBonuses; i++) {
+        const c = helmSet === i ? 1 : 0;
+        setCountsAfterHelm[i] = c;
+        const d = setBonusCounts[i] - c;
+        if (d > 0) {
+          deficit += d;
+        }
+      }
+      if (deficit - wildcardP1 > maxSetContribAfterHelm) {
+        skipInsufficientSetBonus += combosPerHelm;
+        comboCount += combosPerHelm;
+        if (comboCount >= 100000) {
+          await flushProgress();
+        }
+        continue;
+      }
+    }
+    const artificeP1 = helmSoA.artifice[helmIdx];
+    const helmBase = helmIdx * 6;
+    statsAfterHelm[0] = modStatsInStatOrder[0] + helmSoA.stats[helmBase];
+    statsAfterHelm[1] = modStatsInStatOrder[1] + helmSoA.stats[helmBase + 1];
+    statsAfterHelm[2] = modStatsInStatOrder[2] + helmSoA.stats[helmBase + 2];
+    statsAfterHelm[3] = modStatsInStatOrder[3] + helmSoA.stats[helmBase + 3];
+    statsAfterHelm[4] = modStatsInStatOrder[4] + helmSoA.stats[helmBase + 4];
+    statsAfterHelm[5] = modStatsInStatOrder[5] + helmSoA.stats[helmBase + 5];
+    for (let gauntIdx = 0; gauntIdx < gauntlets.length; gauntIdx++) {
+      const gaunt = gauntlets[gauntIdx];
+      const exoticP2 = exoticP1 + gauntSoA.exotic[gauntIdx];
+      if (exoticP2 > 1) {
+        skipDoubleExotic += combosPerGaunt;
+        comboCount += combosPerGaunt;
+        if (comboCount >= 100000) {
+          await flushProgress();
+        }
+        continue;
+      }
+      if (anyExotic && exoticP2 === 0 && !exoticAfterGaunt) {
+        skipNoExotic += combosPerGaunt;
+        comboCount += combosPerGaunt;
+        if (comboCount >= 100000) {
+          await flushProgress();
+        }
+        continue;
+      }
+      if (hasPerkReqs) {
+        const gauntPerkBase = gauntIdx * numPerks;
+        let impossible = false;
+        for (let i = 0; i < numPerks; i++) {
+          const p = perksAfterHelm[i] + gauntSoA.perks[gauntPerkBase + i];
+          perksAfterGaunt[i] = p;
+          if (p + maxPerksAfterGaunt[i] < requiredPerkCounts[i]) {
+            impossible = true;
+            break;
+          }
+        }
+        if (impossible) {
+          skipInsufficientPerks += combosPerGaunt;
+          comboCount += combosPerGaunt;
+          if (comboCount >= 100000) {
+            await flushProgress();
+          }
+          continue;
+        }
+      }
+      const wildcardP2 = wildcardP1 + gauntSoA.wildcard[gauntIdx];
+      if (numSetBonuses > 0) {
+        const gauntSet = gauntSoA.setBonusIdx[gauntIdx];
+        let deficit = 0;
+        for (let i = 0; i < numSetBonuses; i++) {
+          const c = setCountsAfterHelm[i] + (gauntSet === i ? 1 : 0);
+          setCountsAfterGaunt[i] = c;
+          const d = setBonusCounts[i] - c;
+          if (d > 0) {
+            deficit += d;
+          }
+        }
+        if (deficit - wildcardP2 > maxSetContribAfterGaunt) {
+          skipInsufficientSetBonus += combosPerGaunt;
+          comboCount += combosPerGaunt;
+          if (comboCount >= 100000) {
+            await flushProgress();
+          }
+          continue;
+        }
+      }
+      const artificeP2 = artificeP1 + gauntSoA.artifice[gauntIdx];
+      const gauntBase = gauntIdx * 6;
+      statsAfterGaunt[0] = statsAfterHelm[0] + gauntSoA.stats[gauntBase];
+      statsAfterGaunt[1] = statsAfterHelm[1] + gauntSoA.stats[gauntBase + 1];
+      statsAfterGaunt[2] = statsAfterHelm[2] + gauntSoA.stats[gauntBase + 2];
+      statsAfterGaunt[3] = statsAfterHelm[3] + gauntSoA.stats[gauntBase + 3];
+      statsAfterGaunt[4] = statsAfterHelm[4] + gauntSoA.stats[gauntBase + 4];
+      statsAfterGaunt[5] = statsAfterHelm[5] + gauntSoA.stats[gauntBase + 5];
+      for (let chestIdx = 0; chestIdx < chests.length; chestIdx++) {
+        const chest = chests[chestIdx];
+        const exoticP3 = exoticP2 + chestSoA.exotic[chestIdx];
+        if (exoticP3 > 1) {
+          skipDoubleExotic += combosPerChest;
+          comboCount += combosPerChest;
+          if (comboCount >= 100000) {
+            await flushProgress();
+          }
+          continue;
+        }
+        if (anyExotic && exoticP3 === 0 && !exoticAfterChest) {
+          skipNoExotic += combosPerChest;
+          comboCount += combosPerChest;
+          if (comboCount >= 100000) {
+            await flushProgress();
+          }
+          continue;
+        }
+        if (hasPerkReqs) {
+          const chestPerkBase = chestIdx * numPerks;
+          let impossible = false;
+          for (let i = 0; i < numPerks; i++) {
+            const p = perksAfterGaunt[i] + chestSoA.perks[chestPerkBase + i];
+            perksAfterChest[i] = p;
+            if (p + maxPerksAfterChest[i] < requiredPerkCounts[i]) {
+              impossible = true;
+              break;
+            }
+          }
+          if (impossible) {
+            skipInsufficientPerks += combosPerChest;
+            comboCount += combosPerChest;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+            continue;
+          }
+        }
+        const wildcardP3 = wildcardP2 + chestSoA.wildcard[chestIdx];
+        if (numSetBonuses > 0) {
+          const chestSet = chestSoA.setBonusIdx[chestIdx];
+          let deficit = 0;
+          for (let i = 0; i < numSetBonuses; i++) {
+            const c = setCountsAfterGaunt[i] + (chestSet === i ? 1 : 0);
+            setCountsAfterChest[i] = c;
+            const d = setBonusCounts[i] - c;
+            if (d > 0) {
+              deficit += d;
+            }
+          }
+          if (deficit - wildcardP3 > maxSetContribAfterChest) {
+            skipInsufficientSetBonus += combosPerChest;
+            comboCount += combosPerChest;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+            continue;
+          }
+        }
+        const artificeP3 = artificeP2 + chestSoA.artifice[chestIdx];
+        const chestBase = chestIdx * 6;
+        statsAfterChest[0] = statsAfterGaunt[0] + chestSoA.stats[chestBase];
+        statsAfterChest[1] = statsAfterGaunt[1] + chestSoA.stats[chestBase + 1];
+        statsAfterChest[2] = statsAfterGaunt[2] + chestSoA.stats[chestBase + 2];
+        statsAfterChest[3] = statsAfterGaunt[3] + chestSoA.stats[chestBase + 3];
+        statsAfterChest[4] = statsAfterGaunt[4] + chestSoA.stats[chestBase + 4];
+        statsAfterChest[5] = statsAfterGaunt[5] + chestSoA.stats[chestBase + 5];
+        for (let legIdx = 0; legIdx < legs.length; legIdx++) {
+          const leg = legs[legIdx];
+          const exoticP4 = exoticP3 + legSoA.exotic[legIdx];
+          if (exoticP4 > 1) {
+            skipDoubleExotic += combosPerLeg;
+            comboCount += combosPerLeg;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+            continue;
+          }
+          if (anyExotic && exoticP4 === 0 && !exoticAfterLeg) {
+            skipNoExotic += combosPerLeg;
+            comboCount += combosPerLeg;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+            continue;
+          }
+          if (hasPerkReqs) {
+            const legPerkBase = legIdx * numPerks;
+            let impossible = false;
+            for (let i = 0; i < numPerks; i++) {
+              const p = perksAfterChest[i] + legSoA.perks[legPerkBase + i];
+              perksAfterLeg[i] = p;
+              if (p + maxPerksAfterLeg[i] < requiredPerkCounts[i]) {
+                impossible = true;
+                break;
+              }
+            }
+            if (impossible) {
+              skipInsufficientPerks += combosPerLeg;
+              comboCount += combosPerLeg;
+              if (comboCount >= 100000) {
+                await flushProgress();
+              }
+              continue;
+            }
+          }
+          const wildcardP4 = wildcardP3 + legSoA.wildcard[legIdx];
+          if (numSetBonuses > 0) {
+            const legSet = legSoA.setBonusIdx[legIdx];
+            let deficit = 0;
+            for (let i = 0; i < numSetBonuses; i++) {
+              const c = setCountsAfterChest[i] + (legSet === i ? 1 : 0);
+              setCountsAfterLeg[i] = c;
+              const d = setBonusCounts[i] - c;
+              if (d > 0) {
+                deficit += d;
+              }
+            }
+            if (deficit - wildcardP4 > maxSetContribAfterLeg) {
+              skipInsufficientSetBonus += combosPerLeg;
+              comboCount += combosPerLeg;
+              if (comboCount >= 100000) {
+                await flushProgress();
+              }
+              continue;
+            }
+          }
+          const artificeP4 = artificeP3 + legSoA.artifice[legIdx];
+          const legBase = legIdx * 6;
+          statsAfterLeg[0] = statsAfterChest[0] + legSoA.stats[legBase];
+          statsAfterLeg[1] = statsAfterChest[1] + legSoA.stats[legBase + 1];
+          statsAfterLeg[2] = statsAfterChest[2] + legSoA.stats[legBase + 2];
+          statsAfterLeg[3] = statsAfterChest[3] + legSoA.stats[legBase + 3];
+          statsAfterLeg[4] = statsAfterChest[4] + legSoA.stats[legBase + 4];
+          statsAfterLeg[5] = statsAfterChest[5] + legSoA.stats[legBase + 5];
+          innerloop: for (let classItemIdx = 0; classItemIdx < classItems.length; classItemIdx++) {
+            comboCount++;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+
+            // Check exotic constraints
+            const exoticSum = exoticP4 + classItemSoA.exotic[classItemIdx];
+            if (exoticSum > 1) {
+              skipDoubleExotic++;
+              continue;
+            }
+            if (anyExotic && exoticSum === 0) {
+              skipNoExotic++;
+              continue;
+            }
+
+            // Check required perk counts across the set
+            if (hasPerkReqs) {
+              const ciPerkBase = classItemIdx * numPerks;
+              for (let i = 0; i < numPerks; i++) {
+                const actualCount = perksAfterLeg[i] + classItemSoA.perks[ciPerkBase + i];
+                if (actualCount < requiredPerkCounts[i]) {
+                  skipInsufficientPerks++;
+                  continue innerloop;
+                }
+              }
+            }
+
+            // Set bonuses; each slot can use one wildcard if present
+            if (numSetBonuses > 0) {
+              const classItemSet = classItemSoA.setBonusIdx[classItemIdx];
+              let wildcardsRemaining = wildcardP4 + classItemSoA.wildcard[classItemIdx];
+              for (let i = 0; i < numSetBonuses; i++) {
+                const setNeededCount = setBonusCounts[i];
+                const setCount = setCountsAfterLeg[i] + (classItemSet === i ? 1 : 0);
+                if (setCount < setNeededCount) {
+                  const wildcardsNeeded = setNeededCount - setCount;
+                  if (wildcardsRemaining >= wildcardsNeeded) {
+                    wildcardsRemaining -= wildcardsNeeded;
+                  } else {
+                    skipInsufficientSetBonus++;
+                    continue innerloop;
+                  }
+                }
+              }
+            }
+
+            const ciBase = classItemIdx * 6;
+
+            // At most one item in a valid set carries tuning variants (only
+            // exotics do, and double exotics were pruned above). Each variant
+            // is evaluated below as its own candidate set, sharing all the
+            // loop-level work and the per-set energy cache.
+            let tuningInfo = helmSoA.tuning[helmIdx];
+            let tuningSlot = 0;
+            if (tuningInfo === undefined) {
+              tuningInfo = gauntSoA.tuning[gauntIdx];
+              tuningSlot = 1;
+            }
+            if (tuningInfo === undefined) {
+              tuningInfo = chestSoA.tuning[chestIdx];
+              tuningSlot = 2;
+            }
+            if (tuningInfo === undefined) {
+              tuningInfo = legSoA.tuning[legIdx];
+              tuningSlot = 3;
+            }
+            if (tuningInfo === undefined) {
+              tuningInfo = classItemSoA.tuning[classItemIdx];
+              tuningSlot = 4;
+            }
+            const tuningVariants = tuningInfo?.variants;
+            const numVariants = tuningVariants !== undefined ? tuningVariants.length : 1;
+
+            const classItem = classItems[classItemIdx];
+            armor[0] = helm;
+            armor[1] = gaunt;
+            armor[2] = chest;
+            armor[3] = leg;
+            armor[4] = classItem;
+            // The energy profile doesn't depend on tuning, so the cache is
+            // shared across all variants of this armor set.
+            energyCache.result = undefined;
+
+            const numArtifice = artificeP4 + classItemSoA.artifice[classItemIdx];
+
+            // The most total stat points we could get from mods, assuming
+            // everything was perfectly assignable.
+            const maxModBonus =
+              numArtifice * artificeStatBoost +
+              precalculatedInfo.numAvailableGeneralMods * majorStatBoost;
+
+            if (tuningInfo !== undefined) {
+              // Almost all sets die at the couldInsert prune, and paying the
+              // per-variant arithmetic for each of them adds up, so decide
+              // once per set whether any variant could matter. Stat-range
+              // minimums are updated here with the per-stat minimum across
+              // variants, which matches what the per-variant updates would
+              // produce; the convergence gate and heap bound use per-stat/
+              // per-variant maximums, so this only skips variants that could
+              // neither improve the displayed ranges nor make the top sets.
+              const { minDeltas, maxDeltas, maxNetGain } = tuningInfo;
+              stats[0] = statsAfterLeg[0] + classItemSoA.stats[ciBase];
+              stats[1] = statsAfterLeg[1] + classItemSoA.stats[ciBase + 1];
+              stats[2] = statsAfterLeg[2] + classItemSoA.stats[ciBase + 2];
+              stats[3] = statsAfterLeg[3] + classItemSoA.stats[ciBase + 3];
+              stats[4] = statsAfterLeg[4] + classItemSoA.stats[ciBase + 4];
+              stats[5] = statsAfterLeg[5] + classItemSoA.stats[ciBase + 5];
+              let totalBase = 0;
+              let mayMatter = false;
+              for (let index = 0; index < 6; index++) {
+                const filter = desiredStatRanges[index];
+                const statRange = statRanges[index];
+                if (filter.maxStat > 0 /* non-ignored stat */) {
+                  const minValue = Math.min(stats[index] + minDeltas[index], filter.maxStat);
+                  if (minValue < statRange.minStat) {
+                    statRange.minStat = minValue;
+                  }
+                  totalBase += Math.min(stats[index], filter.maxStat);
+                }
+                const maxSeen = statRange.maxStat;
+                const bestValue = stats[index] + maxDeltas[index];
+                if (
+                  maxSeen < filter.minStat ||
+                  bestValue > maxSeen ||
+                  (maxSeen < MAX_STAT && bestValue + maxModBonus > maxSeen)
+                ) {
+                  mayMatter = true;
+                }
+              }
+              if (!mayMatter && !setTracker.couldInsert(totalBase + maxNetGain + maxModBonus)) {
+                numProcessed += numVariants;
+                skipLowTier += numVariants;
+                continue;
+              }
+            }
+
+            for (let variantIdx = 0; variantIdx < numVariants; variantIdx++) {
+              numProcessed++;
+
+              // Add the class item's stats onto the outer levels' running
+              // partial sums to form the overall set stats.
+              // Note that mod stats could theoretically take these negative, but
+              // none do in practice.
+              //
+              // Note: JavaScript engines apparently don't unroll loops
+              // automatically and this makes a big difference in speed.
+              stats[0] = statsAfterLeg[0] + classItemSoA.stats[ciBase];
+              stats[1] = statsAfterLeg[1] + classItemSoA.stats[ciBase + 1];
+              stats[2] = statsAfterLeg[2] + classItemSoA.stats[ciBase + 2];
+              stats[3] = statsAfterLeg[3] + classItemSoA.stats[ciBase + 3];
+              stats[4] = statsAfterLeg[4] + classItemSoA.stats[ciBase + 4];
+              stats[5] = statsAfterLeg[5] + classItemSoA.stats[ciBase + 5];
+              if (tuningVariants !== undefined) {
+                const deltas = tuningVariants[variantIdx].deltas;
+                stats[0] += deltas[0];
+                stats[1] += deltas[1];
+                stats[2] += deltas[2];
+                stats[3] += deltas[3];
+                stats[4] += deltas[4];
+                stats[5] += deltas[5];
+              }
+
+              // A version of the set stats that have been clamped to the max stat
+              // constraint.
+              effectiveStats[0] = Math.min(stats[0], maxStatConstraints[0]);
+              effectiveStats[1] = Math.min(stats[1], maxStatConstraints[1]);
+              effectiveStats[2] = Math.min(stats[2], maxStatConstraints[2]);
+              effectiveStats[3] = Math.min(stats[3], maxStatConstraints[3]);
+              effectiveStats[4] = Math.min(stats[4], maxStatConstraints[4]);
+              effectiveStats[5] = Math.min(stats[5], maxStatConstraints[5]);
+
+              // neededStats is the extra stats we'd need in each stat in order to
+              // hit the stat minimums, and totalNeededStats is just the sum of
+              // those. This informs the logic for deciding how to add stat mods.
+              neededStats[0] = 0;
+              neededStats[1] = 0;
+              neededStats[2] = 0;
+              neededStats[3] = 0;
+              neededStats[4] = 0;
+              neededStats[5] = 0;
+              let totalNeededStats = 0;
+
+              // Check which stats we're under the stat minimums on.
+              let totalStats = 0;
+              for (let index = 0; index < 6; index++) {
+                const filter = desiredStatRanges[index];
+                if (filter.maxStat > 0 /* non-ignored stat */) {
+                  const value = effectiveStats[index];
+                  // Update the minimum stat range while we're here
+                  const statRange = statRanges[index];
+                  if (value < statRange.minStat) {
+                    statRange.minStat = value;
+                  }
+                  totalStats += value;
+                  if (filter.minStat > 0) {
+                    const neededValue = filter.minStat - value;
+                    if (neededValue > 0) {
+                      totalNeededStats += neededValue;
+                      neededStats[index] = neededValue;
+                    }
+                  }
+                }
+              }
+
+              // Check to see if it would be at all possible to hit the needed
+              // stat total with the best case mod bonuses. If totalNeededStats is
+              // 0 this passes trivially.
+              lowerBoundsChecked++;
+              if (totalNeededStats > maxModBonus) {
+                lowerBoundsFailed++;
+                continue;
+              }
+
+              // Items that individually can't fit their slot-specific mods were
+              // filtered out before even passing them to the worker, so we only
+              // do this combined mods + auto-stats check if we need to check
+              // whether the set can fit the mods and hit target stats. This is a
+              // fast check to see if enough mods can fit to hit needed stat
+              // minimums.
+              if (
+                (hasMods || totalNeededStats > 0) &&
+                !pickAndAssignSlotIndependentMods(
+                  precalculatedInfo,
+                  setStatistics.modsStatistics,
+                  armor,
+                  totalNeededStats > 0 ? neededStats : undefined,
+                  numArtifice,
+                )
+              ) {
+                // There's no way for this set to fit all requested mods while
+                // satisfying tier lower bounds, so continue on. setStatistics
+                // have been updated in pickAndAssignSlotIndependentMods.
+                continue;
+              }
+
+              // At this point we know this set satisfies all constraints.
+              // Update the max stat ranges. We need to do this before we short
+              // circuit anything so that the stat ranges are accurate.
+              //
+              // updateMaxStats only ever raises the running maxes, so once they
+              // have converged (the common steady state in large searches) we can
+              // skip the call for sets that provably can't raise any of them.
+              // These conditions mirror its internal update conditions exactly.
+              let mayImproveMax = false;
+              for (let index = 0; index < 6; index++) {
+                const maxSeen = statRanges[index].maxStat;
+                if (
+                  maxSeen < desiredStatRanges[index].minStat ||
+                  stats[index] > maxSeen ||
+                  (maxSeen < MAX_STAT && stats[index] + maxModBonus > maxSeen)
+                ) {
+                  mayImproveMax = true;
+                  break;
+                }
+              }
+              const foundAnyImprovement =
+                mayImproveMax &&
+                updateMaxStats(
+                  precalculatedInfo,
+                  armor,
+                  stats,
+                  numArtifice,
+                  desiredStatRanges,
+                  statRanges,
+                  energyCache,
+                );
+
+              // Drop this set if it could never make it into our top
+              // RETURNED_ARMOR_SETS sets. We do this only after confirming that
+              // any required stat mods fit and updating our max tiers so that the
+              // max available tier info stays accurate.
+              if (!setTracker.couldInsert(totalStats + maxModBonus)) {
+                skipLowTier++;
+                continue;
+              }
+
+              const optimalResult = pickOptimalStatMods(
+                precalculatedInfo,
+                armor,
+                stats,
+                desiredStatRanges,
+                numArtifice,
+                energyCache,
+              );
+              if (!optimalResult) {
+                // This means we couldn't assign mods in a way that satisfied
+                // minimum stat constraints. This can happen if the mods that
+                // would be needed don't fit into the available slots.
+                setStatistics.modsStatistics.finalAssignment.modsAssignmentFailed++;
+                continue;
+              }
+
+              const { bonusStats, mods } = optimalResult;
+              const finalStats = [
+                effectiveStats[0] + bonusStats[0],
+                effectiveStats[1] + bonusStats[1],
+                effectiveStats[2] + bonusStats[2],
+                effectiveStats[3] + bonusStats[3],
+                effectiveStats[4] + bonusStats[4],
+                effectiveStats[5] + bonusStats[5],
+              ];
+              const finalTotalStats =
+                finalStats[0] +
+                finalStats[1] +
+                finalStats[2] +
+                finalStats[3] +
+                finalStats[4] +
+                finalStats[5];
+
+              // Now use our more accurate extra tiers prediction
+              if (!setTracker.couldInsert(finalTotalStats)) {
+                skipLowTier++;
+                continue;
+              }
+
+              // Calculate the numeric stat mix for fast integer comparison.
+              // This encodes each stat value (0-200) into 8 bits, packed into a single integer.
+              // Only non-ignored stats are included, maintaining lexical ordering for priority.
+              const numericStatMix = encodeStatMix(finalStats, desiredStatRanges);
+
+              // Add on any tuning mods, preset on the items or chosen for the
+              // tunable item.
+              // It's important that we keep the order of these tuning mods in
+              // the order of the armor (even when we assign mods dynamically,
+              // later), so that when we assign them in fitMostMods they get
+              // assigned to the same item. Otherwise, we could end up swapping
+              // between one balanced mod and one tuning mod, and the balanced
+              // mod's stat bonuses could be slightly different.
+              const tuningMods = [
+                helm.includedTuningMod,
+                gaunt.includedTuningMod,
+                chest.includedTuningMod,
+                leg.includedTuningMod,
+                classItem.includedTuningMod,
+              ];
+              if (tuningVariants !== undefined) {
+                tuningMods[tuningSlot] = tuningVariants[variantIdx].modHash;
+              }
+              mods.push(...compact(tuningMods));
+
+              processStatistics.numValidSets++;
+              // And now insert our set using the predicted total tier and numeric stat mix.
+              setTracker.insert({
+                enabledStatsTotal: finalTotalStats,
+                statMix: numericStatMix,
+                power: getPower(armor),
+                // Copy the reused scratch arrays since the tracker retains them.
+                armor: armor.slice(),
+                stats: stats.slice(),
+                statsTotal: sum(stats),
+                mods,
+                bonusStats,
+                // The chosen variant's deltas, so the final mapping can report
+                // the tuned item's armor-only stats.
+                tuningDeltas:
+                  tuningVariants !== undefined ? tuningVariants[variantIdx].deltas : undefined,
+              });
+
+              if (stopOnFirstSet) {
+                if (strictUpgrades) {
+                  if (foundAnyImprovement) {
+                    break itemLoop;
+                  }
+                } else {
+                  break itemLoop;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Flush the local hot counters into the statistics objects. This also runs
+  // when stopOnFirstSet breaks out of the loop early.
+  processStatistics.numProcessed += numProcessed;
+  setStatistics.lowerBoundsExceeded.timesChecked += lowerBoundsChecked;
+  setStatistics.lowerBoundsExceeded.timesFailed += lowerBoundsFailed;
+  setStatistics.skipReasons.doubleExotic += skipDoubleExotic;
+  setStatistics.skipReasons.noExotic += skipNoExotic;
+  setStatistics.skipReasons.insufficientPerks += skipInsufficientPerks;
+  setStatistics.skipReasons.insufficientSetBonus += skipInsufficientSetBonus;
+  setStatistics.skipReasons.skippedLowTier += skipLowTier;
+
+  const finalSets = setTracker.getArmorSets();
+
+  const sets = filterMap(finalSets, ({ armor, stats, mods, bonusStats, tuningDeltas, ...rest }) => {
+    const armorOnlyStats: Partial<ArmorStats> = {};
+    const fullStats: Partial<ArmorStats> = {};
+
+    let hasStrictUpgrade = false;
+
+    const helmStats = statsCache.get(armor[0])!;
+    const gauntStats = statsCache.get(armor[1])!;
+    const chestStats = statsCache.get(armor[2])!;
+    const legStats = statsCache.get(armor[3])!;
+    const classItemStats = statsCache.get(armor[4])!;
+
+    for (let i = 0; i < statOrder.length; i++) {
+      const statHash = statOrder[i];
+      const value = stats[i] + bonusStats[i];
+      fullStats[statHash] = value;
+
+      const statFilter = desiredStatRanges[i];
+      if (
+        statFilter.maxStat > 0 /* enabled stat */ &&
+        strictUpgrades &&
+        statFilter.minStat < statFilter.maxStat &&
+        !hasStrictUpgrade
+      ) {
+        hasStrictUpgrade ||= value > statFilter.minStat;
+      }
+
+      // statsCache holds the tunable item's base stats, so add the chosen
+      // tuning mod's contribution back in.
+      armorOnlyStats[statHash] =
+        helmStats[i] +
+        gauntStats[i] +
+        chestStats[i] +
+        legStats[i] +
+        classItemStats[i] +
+        (tuningDeltas !== undefined ? tuningDeltas[i] : 0);
+    }
+
+    if (strictUpgrades && !hasStrictUpgrade) {
+      return undefined;
+    }
+
+    return {
+      ...rest,
+      armor: armor.map((item) => item.id),
+      stats: fullStats as ArmorStats,
+      armorStats: armorOnlyStats as ArmorStats,
+      statMods: mods,
+    };
+  });
+
+  const totalTime = performance.now() - pstart;
+
+  infoLog(
+    `loadout optimizer thread ${workerNum}`,
+    'found',
+    processStatistics.numValidSets,
+    'stat mixes after processing',
+    combos,
+    'stat combinations in',
+    totalTime,
+    'ms - ',
+    Math.floor((combos * 1000) / totalTime),
+    'combos/s',
+    // Split into multiple objects so console.log will show them all expanded
+    'sets outright skipped:',
+    setStatistics.skipReasons,
+    'lower bounds:',
+    setStatistics.lowerBoundsExceeded,
+    'mod assignment stats:',
+    'early check:',
+    setStatistics.modsStatistics.earlyModsCheck,
+    'auto mods pick:',
+    setStatistics.modsStatistics.autoModsPick,
+    setStatistics.modsStatistics,
+  );
+
+  const statRangesFiltered = Object.fromEntries(
+    statRanges.map((h, i) => [statOrder[i], h]),
+  ) as StatRanges;
+
+  return {
+    sets,
+    combos,
+    statRangesFiltered,
+    processInfo: processStatistics,
+  };
+}
+
+/**
+ * Structure-of-arrays view of a bucket's items: flat 0/1 flags, stat values,
+ * and perk counts so the hot loop reads contiguous numbers instead of chasing
+ * object properties or hashing into maps.
+ */
+interface BucketSoA {
+  exotic: Int8Array;
+  artifice: Int8Array;
+  /** 1 if the item's set bonus socket lets it wildcard a requested set. */
+  wildcard: Int8Array;
+  /** n*6 item stats in stat priority order. */
+  stats: Int32Array;
+  /** Index of the item's set bonus in setBonusHashes, or -1. */
+  setBonusIdx: Int8Array;
+  /** n*numPerks 0/1 counts of the required perks. */
+  perks: Int8Array;
+  /** Whether any item in this bucket is exotic. */
+  hasExotic: boolean;
+  /** For each required perk, the best contribution any item in this bucket can make (0/1). */
+  maxPerks: Int8Array;
+  /** The best set-bonus deficit reduction any item in this bucket can make (set piece + wildcard). */
+  maxSetContrib: number;
+  /**
+   * Per item, the candidate tuning mods with their stat deltas in stat
+   * priority order, or undefined. Only exotics carry these; the tail resolves
+   * the choice per set instead of the loop enumerating variants.
+   */
+  tuning: (TuningBucketEntry | undefined)[];
+}
+
+interface TuningVariant {
+  modHash: number;
+  /** Tuned stats minus base stats, in stat priority order. */
+  deltas: number[];
+}
+
+interface TuningBucketEntry {
+  variants: TuningVariant[];
+  /** Per stat, the lowest delta across the variants (for exact stat-range minimums). */
+  minDeltas: number[];
+  /** Per stat, the highest delta across the variants (for the max-range convergence gate). */
+  maxDeltas: number[];
+  /** The best net gain any variant can add to the enabled-stat total. */
+  maxNetGain: number;
+}
+
+function buildBucketSoA(
+  items: ProcessItem[],
+  statsCache: Map<ProcessItem, number[]>,
+  setBonusHashes: number[],
+  perkHashes: number[],
+  statOrder: number[],
+  desiredStatRanges: DesiredStatRange[],
+): BucketSoA {
+  const n = items.length;
+  const numPerks = perkHashes.length;
+  const soa: BucketSoA = {
+    exotic: new Int8Array(n),
+    artifice: new Int8Array(n),
+    wildcard: new Int8Array(n),
+    stats: new Int32Array(n * 6),
+    setBonusIdx: new Int8Array(n),
+    perks: new Int8Array(n * numPerks),
+    hasExotic: false,
+    maxPerks: new Int8Array(numPerks),
+    maxSetContrib: 0,
+    tuning: new Array<TuningBucketEntry | undefined>(n),
+  };
+  for (let i = 0; i < n; i++) {
+    const item = items[i];
+    soa.exotic[i] = item.isExotic ? 1 : 0;
+    if (item.tuningVariants?.length) {
+      const variants = item.tuningVariants.map((v) => ({
+        modHash: v.modHash,
+        deltas: statOrder.map((statHash) => v.stats[statHash] - item.stats[statHash]),
+      }));
+      const minDeltas = [0, 0, 0, 0, 0, 0];
+      const maxDeltas = [0, 0, 0, 0, 0, 0];
+      let maxNetGain = 0;
+      for (let s = 0; s < 6; s++) {
+        minDeltas[s] = Math.min(...variants.map((v) => v.deltas[s]));
+        maxDeltas[s] = Math.max(...variants.map((v) => v.deltas[s]));
+      }
+      for (const v of variants) {
+        let netGain = 0;
+        for (let s = 0; s < 6; s++) {
+          if (desiredStatRanges[s].maxStat > 0 && v.deltas[s] > 0) {
+            netGain += v.deltas[s];
+          }
+        }
+        if (netGain > maxNetGain) {
+          maxNetGain = netGain;
+        }
+      }
+      soa.tuning[i] = { variants, minDeltas, maxDeltas, maxNetGain };
+    }
+    soa.artifice[i] = item.isArtifice ? 1 : 0;
+    soa.wildcard[i] = item.hasSetBonusModSocket ? 1 : 0;
+    soa.setBonusIdx[i] = item.setBonus !== undefined ? setBonusHashes.indexOf(item.setBonus) : -1;
+    soa.hasExotic ||= item.isExotic;
+    const setContrib = (soa.setBonusIdx[i] >= 0 ? 1 : 0) + soa.wildcard[i];
+    if (setContrib > soa.maxSetContrib) {
+      soa.maxSetContrib = setContrib;
+    }
+    const stats = statsCache.get(item)!;
+    for (let s = 0; s < 6; s++) {
+      soa.stats[i * 6 + s] = stats[s];
+    }
+    for (let p = 0; p < numPerks; p++) {
+      if (item.intrinsicPerks?.includes(perkHashes[p])) {
+        soa.perks[i * numPerks + p] = 1;
+        soa.maxPerks[p] = 1;
+      }
+    }
+  }
+  return soa;
+}

--- a/src/app/loadout-builder/process-worker/process-parity.test.ts
+++ b/src/app/loadout-builder/process-worker/process-parity.test.ts
@@ -31,21 +31,21 @@ import {
 } from './types';
 
 /**
- * Parity oracle for the meet-in-the-middle pareto rewrite (Phase C.2 of the
- * plan). `processBaseline` is a frozen copy of the pre-pareto (#11862)
- * `process()`; `process` is the pareto implementation. Meet-in-the-middle is
- * NOT byte-for-byte equivalent (dominated pairs no longer set the observed
- * `statRanges.minStat` floor, and boundary tie-breaking among equal-total sets
- * can differ), so instead of snapshot equality this asserts the invariants the
- * plan commits to keeping exact:
+ * Correctness oracle for `process()` worker perf changes. `processBaseline` is
+ * a frozen copy of the worker loop (see process-baseline.ts); `process` is the
+ * candidate. A perf change that only reorders how sets are enumerated need not
+ * be byte-for-byte equivalent — which equal-total sets fill the bottom of the
+ * top-N heap is iteration-order dependent — so instead of snapshot equality
+ * this asserts the invariants a correct optimization must keep exact:
  *
  *   - the retained top-N sets are identical (below tracker capacity: same
- *     armor + stats + mods; at capacity: same multiset of enabled-stat totals),
+ *     armor + stats + mods; at capacity: same multiset of enabled-stat totals,
+ *     and every set strictly above the worst retained total byte-identical),
  *   - every stat's observed maxStat is identical,
- *   - every stat's observed minStat only ever drifts UPWARD (pareto >= base).
+ *   - every stat's observed minStat is identical.
  *
- * The last one is the known product question (stat-slider lower bounds) that
- * gates landing; this test measures the drift rather than forbidding it.
+ * With no candidate loaded (`process` === the baseline) every assertion holds
+ * trivially; the harness earns its keep the moment `process.ts` is changed.
  */
 
 /** A stable identity for a set, independent of heap display order. */
@@ -63,7 +63,7 @@ const noProgress = () => {
   /* not used */
 };
 
-describe('process pareto parity', () => {
+describe('process candidate parity', () => {
   let baseItems: ProcessItemsByBucket;
   let baseInputs: ProcessInputs;
   let generalMod: ProcessMod;
@@ -153,12 +153,6 @@ describe('process pareto parity', () => {
     }
   }
 
-  /**
-   * Run the frozen baseline and the pareto implementation on identical inputs
-   * (each gets its own deep clone, since process() mutates item flags in place
-   * via the SoA build only through reads, but inputs are shared JSON) and
-   * assert the parity invariants.
-   */
   /** Assert the sets/maxStat invariants of `candidate` against `base`. */
   function assertSetsAndMax(base: ProcessResult, candidate: ProcessResult) {
     for (const statHash of armorStats) {
@@ -193,22 +187,24 @@ describe('process pareto parity', () => {
     }
   }
 
+  // Run the frozen baseline and the candidate on identical inputs (each gets
+  // its own deep clone, since process() sorts the item arrays in place) and
+  // assert the parity invariants.
   async function assertParity(makeInputs: () => ProcessInputs) {
     const base = await processBaseline(1, makeInputs(), noProgress);
-    const pareto = await process(1, makeInputs(), noProgress);
+    const candidate = await process(1, makeInputs(), noProgress);
 
     // Sets + max stat ranges are identical...
-    assertSetsAndMax(base, pareto);
+    assertSetsAndMax(base, candidate);
 
-    // ...and the exact stat-floor pass makes every minStat match the full
-    // enumeration byte-for-byte (no upward drift).
+    // ...and so is every stat's observed minStat.
     for (const statHash of armorStats) {
       const b = base.statRangesFiltered[statHash];
-      const p = pareto.statRangesFiltered[statHash];
+      const p = candidate.statRangesFiltered[statHash];
       expect({ statHash, minStat: p.minStat }).toEqual({ statHash, minStat: b.minStat });
     }
 
-    return { base, pareto };
+    return { base, candidate };
   }
 
   it('no constraints', async () => {
@@ -351,7 +347,7 @@ describe('process pareto parity', () => {
   };
 
   it('tail-resolved exotic tuning variants (below capacity)', async () => {
-    const { pareto } = await assertParity(() =>
+    const { candidate } = await assertParity(() =>
       cloneInputs((inputs) => {
         inputs.autoStatMods = true;
         inputs.desiredStatRanges[0].minStat = 20;
@@ -362,7 +358,7 @@ describe('process pareto parity', () => {
       }),
     );
     // The tuning mod actually shows up in the returned sets.
-    expect(pareto.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
+    expect(candidate.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
       true,
     );
   });

--- a/src/app/loadout-builder/process-worker/process-parity.test.ts
+++ b/src/app/loadout-builder/process-worker/process-parity.test.ts
@@ -1,0 +1,386 @@
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
+import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
+import { armorStats } from 'app/search/d2-known-values';
+import { emptySet } from 'app/utils/empty';
+import { BucketHashes } from 'data/d2/generated-enums';
+import {
+  classStatModHash,
+  enhancedOperatorAugmentModHash,
+  isArmor2Arms,
+  isArmor2Chest,
+  isArmor2ClassItem,
+  isArmor2Helmet,
+  isArmor2Legs,
+} from 'testing/test-item-utils';
+import { getTestDefinitions, getTestStores } from 'testing/test-utils';
+import {
+  getAutoMods,
+  mapArmor2ModToProcessMod,
+  mapAutoMods,
+  mapDimItemToProcessItems,
+} from '../process/mappers';
+import { ArmorBucketHashes, ArmorStats, DesiredStatRange, MIN_LO_ITEM_ENERGY } from '../types';
+import { process, ProcessInputs } from './process';
+import { processBaseline } from './process-baseline';
+import {
+  ProcessArmorSet,
+  ProcessItem,
+  ProcessItemsByBucket,
+  ProcessMod,
+  ProcessResult,
+} from './types';
+
+/**
+ * Parity oracle for the meet-in-the-middle pareto rewrite (Phase C.2 of the
+ * plan). `processBaseline` is a frozen copy of the pre-pareto (#11862)
+ * `process()`; `process` is the pareto implementation. Meet-in-the-middle is
+ * NOT byte-for-byte equivalent (dominated pairs no longer set the observed
+ * `statRanges.minStat` floor, and boundary tie-breaking among equal-total sets
+ * can differ), so instead of snapshot equality this asserts the invariants the
+ * plan commits to keeping exact:
+ *
+ *   - the retained top-N sets are identical (below tracker capacity: same
+ *     armor + stats + mods; at capacity: same multiset of enabled-stat totals),
+ *   - every stat's observed maxStat is identical,
+ *   - every stat's observed minStat only ever drifts UPWARD (pareto >= base).
+ *
+ * The last one is the known product question (stat-slider lower bounds) that
+ * gates landing; this test measures the drift rather than forbidding it.
+ */
+
+/** A stable identity for a set, independent of heap display order. */
+function setKey(s: ProcessArmorSet): string {
+  return JSON.stringify({
+    armor: [...s.armor].sort(),
+    stats: s.stats,
+    armorStats: s.armorStats,
+    statMods: [...s.statMods].sort((a, b) => a - b),
+    enabledStatsTotal: s.enabledStatsTotal,
+  });
+}
+
+const noProgress = () => {
+  /* not used */
+};
+
+describe('process pareto parity', () => {
+  let baseItems: ProcessItemsByBucket;
+  let baseInputs: ProcessInputs;
+  let generalMod: ProcessMod;
+  let activityMod: ProcessMod;
+
+  const defaultRanges = (): DesiredStatRange[] =>
+    armorStats.map((statHash) => ({ statHash, minStat: 0, maxStat: 200 }));
+
+  beforeAll(async () => {
+    const [defs, stores] = await Promise.all([getTestDefinitions(), getTestStores()]);
+
+    const armorEnergyRules = {
+      assumeArmorMasterwork: AssumeArmorMasterwork.None,
+      minItemEnergy: MIN_LO_ITEM_ENERGY,
+    };
+
+    const buckets: [BucketHashes, (item: unknown) => boolean][] = [
+      [BucketHashes.Helmet, isArmor2Helmet as (item: unknown) => boolean],
+      [BucketHashes.Gauntlets, isArmor2Arms as (item: unknown) => boolean],
+      [BucketHashes.ChestArmor, isArmor2Chest as (item: unknown) => boolean],
+      [BucketHashes.LegArmor, isArmor2Legs as (item: unknown) => boolean],
+      [BucketHashes.ClassArmor, isArmor2ClassItem as (item: unknown) => boolean],
+    ];
+
+    baseItems = {
+      [BucketHashes.Helmet]: [],
+      [BucketHashes.Gauntlets]: [],
+      [BucketHashes.ChestArmor]: [],
+      [BucketHashes.LegArmor]: [],
+      [BucketHashes.ClassArmor]: [],
+    };
+    for (const store of stores) {
+      for (const storeItem of store.items) {
+        for (const [bucketHash, predicate] of buckets) {
+          if (predicate(storeItem)) {
+            const mapped = mapDimItemToProcessItems({
+              dimItem: storeItem,
+              armorEnergyRules,
+              desiredStatRanges: defaultRanges(),
+              autoStatMods: true,
+            })[0];
+            if (mapped) {
+              baseItems[bucketHash as keyof ProcessItemsByBucket].push(mapped);
+            }
+          }
+        }
+      }
+    }
+    // Deterministic corpus: sort by id, cap at 8 per bucket (8^5 = 32k combos)
+    for (const bucketHash of ArmorBucketHashes) {
+      const items = baseItems[bucketHash];
+      items.sort((a, b) => a.id.localeCompare(b.id));
+      items.splice(8);
+    }
+
+    generalMod = mapArmor2ModToProcessMod(
+      defs.InventoryItem.get(classStatModHash) as PluggableInventoryItemDefinition,
+    );
+    activityMod = mapArmor2ModToProcessMod(
+      defs.InventoryItem.get(enhancedOperatorAugmentModHash) as PluggableInventoryItemDefinition,
+    );
+
+    baseInputs = {
+      filteredItems: baseItems,
+      modStatTotals: Object.fromEntries(armorStats.map((h) => [h, 0])) as ArmorStats,
+      lockedMods: { generalMods: [], activityMods: [] },
+      setBonuses: {},
+      requiredPerks: [],
+      desiredStatRanges: defaultRanges(),
+      anyExotic: false,
+      autoModOptions: mapAutoMods(getAutoMods(defs, emptySet())),
+      autoStatMods: false,
+      strictUpgrades: false,
+      stopOnFirstSet: false,
+    };
+  });
+
+  function cloneInputs(patch?: (inputs: ProcessInputs) => void): ProcessInputs {
+    const inputs = JSON.parse(JSON.stringify(baseInputs)) as ProcessInputs;
+    patch?.(inputs);
+    return inputs;
+  }
+
+  function eachBucket(inputs: ProcessInputs, fn: (items: ProcessItem[]) => void) {
+    for (const bucketHash of ArmorBucketHashes) {
+      fn(inputs.filteredItems[bucketHash]);
+    }
+  }
+
+  /**
+   * Run the frozen baseline and the pareto implementation on identical inputs
+   * (each gets its own deep clone, since process() mutates item flags in place
+   * via the SoA build only through reads, but inputs are shared JSON) and
+   * assert the parity invariants.
+   */
+  /** Assert the sets/maxStat invariants of `candidate` against `base`. */
+  function assertSetsAndMax(base: ProcessResult, candidate: ProcessResult) {
+    for (const statHash of armorStats) {
+      const b = base.statRangesFiltered[statHash];
+      const p = candidate.statRangesFiltered[statHash];
+      expect({ statHash, maxStat: p.maxStat }).toEqual({ statHash, maxStat: b.maxStat });
+    }
+
+    const belowCapacity = base.sets.length < 200 && candidate.sets.length < 200;
+    if (belowCapacity) {
+      // Every candidate fits, so the retained sets must be identical.
+      expect(candidate.sets.map(setKey).sort()).toEqual(base.sets.map(setKey).sort());
+    } else {
+      // At capacity, the multiset of retained totals must match (no genuinely
+      // higher-total set is ever lost)...
+      expect(candidate.sets.length).toBe(base.sets.length);
+      const baseTotals = base.sets.map((s) => s.enabledStatsTotal).sort((a, b) => a - b);
+      const totals = candidate.sets.map((s) => s.enabledStatsTotal).sort((a, b) => a - b);
+      expect(totals).toEqual(baseTotals);
+
+      // ...and every set unambiguously inside the top-N (strictly above the
+      // worst retained total) must be byte-identical. Only sets tied at the
+      // boundary total may churn, since which of several equal-total sets fills
+      // the last slots is iteration-order dependent.
+      const boundary = baseTotals[0];
+      const above = (r: ProcessResult) =>
+        r.sets
+          .filter((s) => s.enabledStatsTotal > boundary)
+          .map(setKey)
+          .sort();
+      expect(above(candidate)).toEqual(above(base));
+    }
+  }
+
+  async function assertParity(makeInputs: () => ProcessInputs) {
+    const base = await processBaseline(1, makeInputs(), noProgress);
+    const pareto = await process(1, makeInputs(), noProgress);
+
+    // Sets + max stat ranges are identical...
+    assertSetsAndMax(base, pareto);
+
+    // ...and the exact stat-floor pass makes every minStat match the full
+    // enumeration byte-for-byte (no upward drift).
+    for (const statHash of armorStats) {
+      const b = base.statRangesFiltered[statHash];
+      const p = pareto.statRangesFiltered[statHash];
+      expect({ statHash, minStat: p.minStat }).toEqual({ statHash, minStat: b.minStat });
+    }
+
+    return { base, pareto };
+  }
+
+  it('no constraints', async () => {
+    await assertParity(() => cloneInputs());
+  });
+
+  it('stat minimums and maximums with auto stat mods', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.autoStatMods = true;
+        inputs.desiredStatRanges = armorStats.map((statHash, i) => ({
+          statHash,
+          minStat: i < 2 ? 40 : 0,
+          maxStat: i === 5 ? 0 : 100,
+        }));
+      }),
+    );
+  });
+
+  it('unreachable stat minimums exercise the lower-bounds prune', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.autoStatMods = true;
+        inputs.desiredStatRanges = armorStats.map((statHash, i) => ({
+          statHash,
+          minStat: i < 3 ? 90 : 0,
+          maxStat: 200,
+        }));
+      }),
+    );
+  });
+
+  it('anyExotic with synthesized exotics', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.anyExotic = true;
+        inputs.filteredItems[BucketHashes.Helmet][0].isExotic = true;
+        inputs.filteredItems[BucketHashes.Helmet][1].isExotic = true;
+        inputs.filteredItems[BucketHashes.ChestArmor][0].isExotic = true;
+        inputs.filteredItems[BucketHashes.LegArmor][3].isExotic = true;
+      }),
+    );
+  });
+
+  it('required perks', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        const fakePerk = 999999;
+        inputs.filteredItems[BucketHashes.Helmet][0].intrinsicPerks = [fakePerk];
+        inputs.filteredItems[BucketHashes.Helmet][2].intrinsicPerks = [fakePerk];
+        inputs.filteredItems[BucketHashes.Gauntlets][1].intrinsicPerks = [fakePerk];
+        inputs.filteredItems[BucketHashes.ClassArmor][0].intrinsicPerks = [fakePerk];
+        inputs.requiredPerks = [{ hash: fakePerk, count: 2 }];
+      }),
+    );
+  });
+
+  it('set bonuses with wildcards', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        const setA = 111111;
+        const setB = 222222;
+        eachBucket(inputs, (items) => {
+          items[0].setBonus = setA;
+          items[1].setBonus = setA;
+          items[2].setBonus = setB;
+          items[3].hasSetBonusModSocket = true;
+        });
+        inputs.setBonuses = { [setA]: 2, [setB]: 2 };
+      }),
+    );
+  });
+
+  it('set bonus satisfied only via wildcard', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        const setA = 111111;
+        inputs.filteredItems[BucketHashes.Helmet][0].setBonus = setA;
+        inputs.filteredItems[BucketHashes.Gauntlets][0].hasSetBonusModSocket = true;
+        inputs.filteredItems[BucketHashes.ChestArmor][0].hasSetBonusModSocket = true;
+        inputs.setBonuses = { [setA]: 2 };
+      }),
+    );
+  });
+
+  it('locked general and activity mods', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.autoStatMods = true;
+        inputs.lockedMods = {
+          generalMods: [generalMod, generalMod],
+          activityMods: [activityMod],
+        };
+        eachBucket(inputs, (items) => {
+          for (const item of items) {
+            item.compatibleActivityMod = activityMod.tag;
+          }
+        });
+      }),
+    );
+  });
+
+  it('strict upgrades', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.strictUpgrades = true;
+        inputs.autoStatMods = true;
+        inputs.desiredStatRanges = armorStats.map((statHash, i) => ({
+          statHash,
+          minStat: i === 0 ? 50 : 0,
+          maxStat: 150,
+        }));
+      }),
+    );
+  });
+
+  // A directional (+5/-5) and a balanced-style (+1/+1/+1) tuning variant.
+  const makeVariants = (exotic: ProcessItem) => {
+    const statA = armorStats[1];
+    const statB = armorStats[4];
+    return [
+      {
+        modHash: 111,
+        stats: {
+          ...exotic.stats,
+          [statA]: exotic.stats[statA] + 5,
+          [statB]: exotic.stats[statB] - 5,
+        },
+      },
+      {
+        modHash: 222,
+        stats: {
+          ...exotic.stats,
+          [armorStats[0]]: exotic.stats[armorStats[0]] + 1,
+          [statA]: exotic.stats[statA] + 1,
+          [statB]: exotic.stats[statB] + 1,
+        },
+      },
+    ];
+  };
+
+  it('tail-resolved exotic tuning variants (below capacity)', async () => {
+    const { pareto } = await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.autoStatMods = true;
+        inputs.desiredStatRanges[0].minStat = 20;
+        eachBucket(inputs, (items) => items.splice(2));
+        const exotic = inputs.filteredItems[BucketHashes.Helmet][0];
+        exotic.isExotic = true;
+        exotic.tuningVariants = makeVariants(exotic);
+      }),
+    );
+    // The tuning mod actually shows up in the returned sets.
+    expect(pareto.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
+      true,
+    );
+  });
+
+  it('tail-resolved tuning with the tracker boundary active', async () => {
+    await assertParity(() =>
+      cloneInputs((inputs) => {
+        inputs.autoStatMods = true;
+        for (const [bucketHash, idx] of [
+          [BucketHashes.Helmet, 0],
+          [BucketHashes.Helmet, 3],
+          [BucketHashes.ChestArmor, 2],
+        ] as const) {
+          const item = inputs.filteredItems[bucketHash][idx];
+          item.isExotic = true;
+          item.tuningVariants = makeVariants(item);
+        }
+      }),
+    );
+  });
+});

--- a/src/app/loadout-builder/process-worker/process.bench.test.ts
+++ b/src/app/loadout-builder/process-worker/process.bench.test.ts
@@ -283,3 +283,161 @@ test.skip('benchmark process(): real vault', async () => {
     autoModOptions,
   });
 }, 300000);
+
+// Build a real-vault ProcessItemsByBucket (see the real-vault test above).
+async function loadRealVaultItems(perBucket: number): Promise<{
+  filteredItems: ProcessItemsByBucket;
+  autoModOptions: ProcessInputs['autoModOptions'];
+}> {
+  const defs = await getTestDefinitions();
+  const profilePath = process.env.LO_BENCH_PROFILE;
+  const stores = profilePath
+    ? buildStores({
+        defs,
+        buckets: getBuckets(defs),
+        profileResponse: (() => {
+          const raw = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+          return raw.Response ?? raw;
+        })(),
+        customStats: [],
+      })
+    : await getTestStores();
+  const autoModOptions = mapAutoMods(getAutoMods(defs, emptySet()));
+  const armorEnergyRules = {
+    assumeArmorMasterwork: AssumeArmorMasterwork.None,
+    minItemEnergy: MIN_LO_ITEM_ENERGY,
+  };
+  const bucketPredicates: [BucketHashes, (item: DimItem) => unknown][] = [
+    [BucketHashes.Helmet, isArmor2Helmet],
+    [BucketHashes.Gauntlets, isArmor2Arms],
+    [BucketHashes.ChestArmor, isArmor2Chest],
+    [BucketHashes.LegArmor, isArmor2Legs],
+    [BucketHashes.ClassArmor, isArmor2ClassItem],
+  ];
+  const helmsByClass = new Map<number, number>();
+  for (const store of stores) {
+    for (const item of store.items) {
+      if (isArmor2Helmet(item)) {
+        helmsByClass.set(item.classType, (helmsByClass.get(item.classType) ?? 0) + 1);
+      }
+    }
+  }
+  const classType = [...helmsByClass.entries()].sort((a, b) => b[1] - a[1])[0][0];
+  const filteredItems: ProcessItemsByBucket = {
+    [BucketHashes.Helmet]: [],
+    [BucketHashes.Gauntlets]: [],
+    [BucketHashes.ChestArmor]: [],
+    [BucketHashes.LegArmor]: [],
+    [BucketHashes.ClassArmor]: [],
+  };
+  for (const store of stores) {
+    for (const item of store.items) {
+      if (item.classType !== classType) {
+        continue;
+      }
+      for (const [bucketHash, predicate] of bucketPredicates) {
+        if (predicate(item)) {
+          const mapped = mapDimItemToProcessItems({
+            dimItem: item,
+            armorEnergyRules,
+            desiredStatRanges,
+            autoStatMods: true,
+          })[0];
+          if (mapped) {
+            filteredItems[bucketHash as keyof ProcessItemsByBucket].push(mapped);
+          }
+        }
+      }
+    }
+  }
+  for (const bucketHash of ArmorBucketHashes) {
+    const items = filteredItems[bucketHash];
+    items.sort(
+      (a, b) =>
+        armorStats.reduce((t, h) => t + b.stats[h], 0) -
+        armorStats.reduce((t, h) => t + a.stats[h], 0),
+    );
+    items.splice(perBucket);
+  }
+  return { filteredItems, autoModOptions };
+}
+
+// Slice the longest bucket across `n` workers the way process-wrapper does
+// (contiguous) vs. round-robin (interleaved). Interleaving gives each worker a
+// representative stat mix, so their tracker floors — and thus how hard each can
+// prune — stay similar.
+function sliceLongestBucket(base: ProcessInputs, n: number, interleaved: boolean): ProcessInputs[] {
+  const longest = ArmorBucketHashes.reduce((a, b) =>
+    base.filteredItems[b].length > base.filteredItems[a].length ? b : a,
+  );
+  const items = base.filteredItems[longest];
+  const count = Math.min(n, items.length);
+  const groups: ProcessItem[][] = Array.from({ length: count }, () => []);
+  if (interleaved) {
+    items.forEach((it, k) => groups[k % count].push(it));
+  } else {
+    const bs = Math.floor(items.length / count);
+    const rem = items.length % count;
+    let start = 0;
+    for (let i = 0; i < count; i++) {
+      const size = bs + (i < rem ? 1 : 0);
+      groups[i] = items.slice(start, start + size);
+      start += size;
+    }
+  }
+  return groups.map((slice) => ({
+    ...base,
+    filteredItems: { ...base.filteredItems, [longest]: slice },
+  }));
+}
+
+// Simulate multi-worker slicing on the candidate: does parallelism still help
+// after candidate #1's pruning, and is the split balanced? Runs process() per
+// slice sequentially (each worker is independent), reporting the wall-clock a
+// perfectly-parallel run would see (max slice) and the imbalance (max/min).
+test.skip('load balancing: contiguous vs interleaved', async () => {
+  const { filteredItems, autoModOptions } = await loadRealVaultItems(
+    Number(process.env.LO_BENCH_ITEMS) || 60,
+  );
+  const concurrency = Number(process.env.LO_BENCH_CORES) || 6;
+  const base: ProcessInputs = {
+    ...baseInputs,
+    desiredStatRanges: process.env.LO_BENCH_MINS
+      ? desiredStatRanges
+      : armorStats.map((statHash) => ({ statHash, minStat: 0, maxStat: 200 })),
+    filteredItems,
+    lockedMods: { generalMods: [], activityMods: [] },
+    autoModOptions,
+  };
+
+  const timeProcess = async (inp: ProcessInputs, runs = 3) => {
+    await processArmor(0, clone(inp), noop);
+    let best = Infinity;
+    for (let r = 0; r < runs; r++) {
+      const s = performance.now();
+      await processArmor(0, clone(inp), noop);
+      best = Math.min(best, performance.now() - s);
+    }
+    return best;
+  };
+
+  const full = await timeProcess(base);
+  // eslint-disable-next-line no-console
+  console.log(
+    `LB full single-worker ${full.toFixed(0)}ms | items/bucket ${ArmorBucketHashes.map((h) => base.filteredItems[h].length).join('/')} | concurrency ${concurrency}`,
+  );
+  for (const interleaved of [false, true]) {
+    const slices = sliceLongestBucket(base, concurrency, interleaved);
+    const times: number[] = [];
+    for (const slice of slices) {
+      times.push(await timeProcess(slice));
+    }
+    const max = Math.max(...times);
+    const min = Math.min(...times);
+    const sum = times.reduce((a, b) => a + b, 0);
+    // eslint-disable-next-line no-console
+    console.log(
+      `LB ${interleaved ? 'interleaved' : 'contiguous '}: wall(max) ${max.toFixed(0)}ms | total ${sum.toFixed(0)}ms | imbalance ${(max / min).toFixed(2)}x | per-slice ${times.map((t) => t.toFixed(0)).join('/')}`,
+    );
+  }
+}, 300000);

--- a/src/app/loadout-builder/process-worker/process.bench.test.ts
+++ b/src/app/loadout-builder/process-worker/process.bench.test.ts
@@ -5,9 +5,9 @@
  *   change test.skip -> test below, then
  *   npx jest process.bench --silent=false
  *
- * It interleaves the frozen pre-pareto implementation (`processBaseline`, the
- * #11862 code) against the current meet-in-the-middle `process` WITHIN each
- * round, and reports the min over rounds. This machine's clock speed drifts
+ * It interleaves the frozen baseline (`processBaseline`) against the candidate
+ * `process` WITHIN each round, and reports the min over rounds. This machine's
+ * clock speed drifts
  * ~2.5x over minutes (load/thermal), so only compare the two numbers printed by
  * a single run — never runs taken minutes apart. Each timed call gets a fresh
  * clone of the inputs, because the baseline sorts the item arrays in place.
@@ -83,7 +83,7 @@ async function runAB(name: string, inputs: ProcessInputs) {
   await processArmor(0, clone(inputs), noop);
 
   const baseTimes: number[] = [];
-  const paretoTimes: number[] = [];
+  const candidateTimes: number[] = [];
   for (let run = 0; run < 7; run++) {
     // Interleave within the round so thermal drift hits both roughly equally.
     const bIn = clone(inputs);
@@ -94,22 +94,22 @@ async function runAB(name: string, inputs: ProcessInputs) {
     const pIn = clone(inputs);
     start = performance.now();
     const pResult = await processArmor(0, pIn, noop);
-    paretoTimes.push(performance.now() - start);
+    candidateTimes.push(performance.now() - start);
 
     if (run === 0) {
       // eslint-disable-next-line no-console
       console.log(
-        `${name}: combos ${bResult.combos} | valid sets base ${bResult.processInfo.numValidSets} pareto ${pResult.processInfo.numValidSets} | returned base ${bResult.sets.length} pareto ${pResult.sets.length}`,
+        `${name}: combos ${bResult.combos} | valid sets base ${bResult.processInfo.numValidSets} candidate ${pResult.processInfo.numValidSets} | returned base ${bResult.sets.length} candidate ${pResult.sets.length}`,
       );
     }
   }
   baseTimes.sort((a, b) => a - b);
-  paretoTimes.sort((a, b) => a - b);
-  const speedup = baseTimes[0] / paretoTimes[0];
+  candidateTimes.sort((a, b) => a - b);
+  const speedup = baseTimes[0] / candidateTimes[0];
   // eslint-disable-next-line no-console
   console.log(
-    `BENCH ${name}: base min ${baseTimes[0].toFixed(0)}ms | pareto min ${paretoTimes[0].toFixed(0)}ms | ${speedup.toFixed(2)}x` +
-      `  (base all ${baseTimes.map((t) => t.toFixed(0)).join(' ')} | pareto all ${paretoTimes.map((t) => t.toFixed(0)).join(' ')})`,
+    `BENCH ${name}: base min ${baseTimes[0].toFixed(0)}ms | candidate min ${candidateTimes[0].toFixed(0)}ms | ${speedup.toFixed(2)}x` +
+      `  (base all ${baseTimes.map((t) => t.toFixed(0)).join(' ')} | candidate all ${candidateTimes.map((t) => t.toFixed(0)).join(' ')})`,
   );
 }
 
@@ -134,7 +134,7 @@ const baseInputs = {
   stopOnFirstSet: false,
 };
 
-test.skip('benchmark process(): baseline vs pareto', async () => {
+test.skip('benchmark process(): baseline vs candidate', async () => {
   const defs = await getTestDefinitions();
   const autoModOptions = mapAutoMods(getAutoMods(defs, emptySet()));
 
@@ -179,13 +179,12 @@ test.skip('benchmark process(): baseline vs pareto', async () => {
   });
 }, 300000);
 
-// Real-vault A/B: build the corpus from the checked-in Bungie profile fixture
-// (real, correlated armor rolls) rather than uniform-random synthetic stats.
-// This is the honest test of the meet-in-the-middle frontier sizes — dominated
-// pairs are far more common with correlated rolls. Items are taken for the
-// class with the most helmets and capped per bucket to keep baseline runtime
-// bearable across rounds; bump PER_BUCKET (or drop in a bigger profile) to
-// stress it harder.
+// Real-vault A/B: build the corpus from a real Bungie profile (correlated armor
+// rolls) rather than uniform-random synthetic stats — real rolls can behave
+// very differently, so a candidate that wins on synthetic data must be proven
+// here too. Items are taken for the class with the most helmets and capped per
+// bucket to keep baseline runtime bearable across rounds; bump PER_BUCKET (or
+// drop in a bigger profile) to stress it harder.
 const PER_BUCKET = Number(process.env.LO_BENCH_ITEMS) || 25;
 test.skip('benchmark process(): real vault', async () => {
   const defs = await getTestDefinitions();

--- a/src/app/loadout-builder/process-worker/process.bench.test.ts
+++ b/src/app/loadout-builder/process-worker/process.bench.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Manual A/B benchmark for the LO process worker. Not a correctness test — it's
+ * skipped by default so it doesn't slow down CI. To run:
+ *
+ *   change test.skip -> test below, then
+ *   npx jest process.bench --silent=false
+ *
+ * It interleaves the frozen pre-pareto implementation (`processBaseline`, the
+ * #11862 code) against the current meet-in-the-middle `process` WITHIN each
+ * round, and reports the min over rounds. This machine's clock speed drifts
+ * ~2.5x over minutes (load/thermal), so only compare the two numbers printed by
+ * a single run — never runs taken minutes apart. Each timed call gets a fresh
+ * clone of the inputs, because the baseline sorts the item arrays in place.
+ *
+ * Correctness is covered by process-parity.test.ts; here the logged valid-set
+ * and returned-set counts are just a sanity signal that the two are solving the
+ * same problem.
+ */
+import { AssumeArmorMasterwork } from '@destinyitemmanager/dim-api-types';
+import { getBuckets } from 'app/destiny2/d2-buckets';
+import { DimItem } from 'app/inventory/item-types';
+import { buildStores } from 'app/inventory/store/d2-store-factory';
+import { armorStats } from 'app/search/d2-known-values';
+import { emptySet } from 'app/utils/empty';
+import { BucketHashes } from 'data/d2/generated-enums';
+import { noop } from 'es-toolkit';
+import fs from 'node:fs';
+import {
+  isArmor2Arms,
+  isArmor2Chest,
+  isArmor2ClassItem,
+  isArmor2Helmet,
+  isArmor2Legs,
+} from 'testing/test-item-utils';
+import { getTestDefinitions, getTestStores } from 'testing/test-utils';
+import { getAutoMods, mapAutoMods, mapDimItemToProcessItems } from '../process/mappers';
+import { ArmorBucketHashes, DesiredStatRange, MIN_LO_ITEM_ENERGY } from '../types';
+import { process as processArmor, ProcessInputs } from './process';
+import { processBaseline } from './process-baseline';
+import { ProcessItem, ProcessItemsByBucket } from './types';
+
+// Deterministic LCG so runs are comparable
+function makeRng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 4294967296;
+  };
+}
+
+function makeItems(
+  bucket: number,
+  count: number,
+  rng: () => number,
+  opts?: { activityTag?: string; minEnergy?: number },
+): ProcessItem[] {
+  const minEnergy = opts?.minEnergy ?? 10;
+  return Array.from({ length: count }, (_, i): ProcessItem => {
+    const stats: { [statHash: number]: number } = {};
+    for (const statHash of armorStats) {
+      stats[statHash] = 5 + Math.floor(rng() * 25); // 5..29
+    }
+    return {
+      id: `${bucket}-${i}`,
+      name: `Item ${bucket}-${i}`,
+      isExotic: i === 0,
+      isArtifice: rng() < 0.4,
+      remainingEnergyCapacity:
+        minEnergy < 10 ? minEnergy + Math.floor(rng() * (11 - minEnergy)) : 10,
+      power: 1500,
+      stats,
+      compatibleActivityMod: opts?.activityTag && rng() < 0.6 ? opts.activityTag : undefined,
+    };
+  });
+}
+
+const clone = (inputs: ProcessInputs): ProcessInputs =>
+  JSON.parse(JSON.stringify(inputs)) as ProcessInputs;
+
+async function runAB(name: string, inputs: ProcessInputs) {
+  // Warm up both JITs.
+  await processBaseline(0, clone(inputs), noop);
+  await processArmor(0, clone(inputs), noop);
+
+  const baseTimes: number[] = [];
+  const paretoTimes: number[] = [];
+  for (let run = 0; run < 7; run++) {
+    // Interleave within the round so thermal drift hits both roughly equally.
+    const bIn = clone(inputs);
+    let start = performance.now();
+    const bResult = await processBaseline(0, bIn, noop);
+    baseTimes.push(performance.now() - start);
+
+    const pIn = clone(inputs);
+    start = performance.now();
+    const pResult = await processArmor(0, pIn, noop);
+    paretoTimes.push(performance.now() - start);
+
+    if (run === 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `${name}: combos ${bResult.combos} | valid sets base ${bResult.processInfo.numValidSets} pareto ${pResult.processInfo.numValidSets} | returned base ${bResult.sets.length} pareto ${pResult.sets.length}`,
+      );
+    }
+  }
+  baseTimes.sort((a, b) => a - b);
+  paretoTimes.sort((a, b) => a - b);
+  const speedup = baseTimes[0] / paretoTimes[0];
+  // eslint-disable-next-line no-console
+  console.log(
+    `BENCH ${name}: base min ${baseTimes[0].toFixed(0)}ms | pareto min ${paretoTimes[0].toFixed(0)}ms | ${speedup.toFixed(2)}x` +
+      `  (base all ${baseTimes.map((t) => t.toFixed(0)).join(' ')} | pareto all ${paretoTimes.map((t) => t.toFixed(0)).join(' ')})`,
+  );
+}
+
+// Minimums above the average set stat total so the auto-mod solver has to work
+// for a large fraction of sets.
+const desiredStatRanges: DesiredStatRange[] = armorStats.map((statHash, i) => ({
+  statHash,
+  minStat: i === 0 || i === 1 ? 90 : i === 2 ? 60 : 0,
+  maxStat: 200,
+}));
+
+const baseInputs = {
+  modStatTotals: Object.fromEntries(
+    armorStats.map((h) => [h, 0]),
+  ) as ProcessInputs['modStatTotals'],
+  setBonuses: {},
+  requiredPerks: [],
+  desiredStatRanges,
+  anyExotic: false,
+  autoStatMods: true,
+  strictUpgrades: false,
+  stopOnFirstSet: false,
+};
+
+test.skip('benchmark process(): baseline vs pareto', async () => {
+  const defs = await getTestDefinitions();
+  const autoModOptions = mapAutoMods(getAutoMods(defs, emptySet()));
+
+  const items = (rng: () => number, opts?: { activityTag?: string; minEnergy?: number }) => ({
+    [BucketHashes.Helmet]: makeItems(0, 18, rng, opts),
+    [BucketHashes.Gauntlets]: makeItems(1, 18, rng, opts),
+    [BucketHashes.ChestArmor]: makeItems(2, 18, rng, opts),
+    [BucketHashes.LegArmor]: makeItems(3, 18, rng, opts),
+    [BucketHashes.ClassArmor]: makeItems(4, 4, rng, opts),
+  });
+
+  await runAB('unconstrained', {
+    ...baseInputs,
+    filteredItems: items(makeRng(1234)),
+    lockedMods: { generalMods: [], activityMods: [] },
+    autoModOptions,
+  });
+
+  await runAB('anyExotic', {
+    ...baseInputs,
+    filteredItems: items(makeRng(1234)),
+    lockedMods: { generalMods: [], activityMods: [] },
+    anyExotic: true,
+    autoModOptions,
+  });
+
+  await runAB('constrained (mods + tight energy)', {
+    ...baseInputs,
+    filteredItems: items(makeRng(1234), { activityTag: 'bench', minEnergy: 4 }),
+    lockedMods: {
+      generalMods: [
+        { hash: 1001, energyCost: 3 },
+        { hash: 1002, energyCost: 4 },
+      ],
+      activityMods: [
+        { hash: 2001, energyCost: 1, tag: 'bench' },
+        { hash: 2002, energyCost: 2, tag: 'bench' },
+        { hash: 2003, energyCost: 3, tag: 'bench' },
+      ],
+    },
+    autoModOptions,
+  });
+}, 300000);
+
+// Real-vault A/B: build the corpus from the checked-in Bungie profile fixture
+// (real, correlated armor rolls) rather than uniform-random synthetic stats.
+// This is the honest test of the meet-in-the-middle frontier sizes — dominated
+// pairs are far more common with correlated rolls. Items are taken for the
+// class with the most helmets and capped per bucket to keep baseline runtime
+// bearable across rounds; bump PER_BUCKET (or drop in a bigger profile) to
+// stress it harder.
+const PER_BUCKET = Number(process.env.LO_BENCH_ITEMS) || 25;
+test.skip('benchmark process(): real vault', async () => {
+  const defs = await getTestDefinitions();
+  // LO_BENCH_PROFILE can point at a raw Bungie GetProfile response (or one
+  // wrapped in { Response }); otherwise fall back to the checked-in fixture.
+  const profilePath = process.env.LO_BENCH_PROFILE;
+  const stores = profilePath
+    ? buildStores({
+        defs,
+        buckets: getBuckets(defs),
+        profileResponse: (() => {
+          const raw = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+          return raw.Response ?? raw;
+        })(),
+        customStats: [],
+      })
+    : await getTestStores();
+  const autoModOptions = mapAutoMods(getAutoMods(defs, emptySet()));
+  const armorEnergyRules = {
+    assumeArmorMasterwork: AssumeArmorMasterwork.None,
+    minItemEnergy: MIN_LO_ITEM_ENERGY,
+  };
+
+  const bucketPredicates: [BucketHashes, (item: DimItem) => unknown][] = [
+    [BucketHashes.Helmet, isArmor2Helmet],
+    [BucketHashes.Gauntlets, isArmor2Arms],
+    [BucketHashes.ChestArmor, isArmor2Chest],
+    [BucketHashes.LegArmor, isArmor2Legs],
+    [BucketHashes.ClassArmor, isArmor2ClassItem],
+  ];
+
+  // Pick the class that has the most helmets in the fixture.
+  const helmsByClass = new Map<number, number>();
+  for (const store of stores) {
+    for (const item of store.items) {
+      if (isArmor2Helmet(item)) {
+        helmsByClass.set(item.classType, (helmsByClass.get(item.classType) ?? 0) + 1);
+      }
+    }
+  }
+  const classType = [...helmsByClass.entries()].sort((a, b) => b[1] - a[1])[0][0];
+
+  const filteredItems: ProcessItemsByBucket = {
+    [BucketHashes.Helmet]: [],
+    [BucketHashes.Gauntlets]: [],
+    [BucketHashes.ChestArmor]: [],
+    [BucketHashes.LegArmor]: [],
+    [BucketHashes.ClassArmor]: [],
+  };
+  for (const store of stores) {
+    for (const item of store.items) {
+      if (item.classType !== classType) {
+        continue;
+      }
+      for (const [bucketHash, predicate] of bucketPredicates) {
+        if (predicate(item)) {
+          const mapped = mapDimItemToProcessItems({
+            dimItem: item,
+            armorEnergyRules,
+            desiredStatRanges,
+            autoStatMods: true,
+          })[0];
+          if (mapped) {
+            filteredItems[bucketHash as keyof ProcessItemsByBucket].push(mapped);
+          }
+        }
+      }
+    }
+  }
+  // Deterministic cap per bucket (highest total stats first, like useProcess).
+  for (const bucketHash of ArmorBucketHashes) {
+    const items = filteredItems[bucketHash];
+    items.sort(
+      (a, b) =>
+        armorStats.reduce((t, h) => t + b.stats[h], 0) -
+        armorStats.reduce((t, h) => t + a.stats[h], 0),
+    );
+    items.splice(PER_BUCKET);
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    `real vault: classType ${classType}, items/bucket`,
+    ArmorBucketHashes.map((h) => filteredItems[h].length).join('/'),
+  );
+
+  await runAB('real vault', {
+    ...baseInputs,
+    filteredItems,
+    lockedMods: { generalMods: [], activityMods: [] },
+    autoModOptions,
+  });
+}, 300000);

--- a/src/app/loadout-builder/process-worker/process.bench.test.ts
+++ b/src/app/loadout-builder/process-worker/process.bench.test.ts
@@ -272,6 +272,12 @@ test.skip('benchmark process(): real vault', async () => {
 
   await runAB('real vault', {
     ...baseInputs,
+    // "Show everything": no stat minimums, so the ranges span every set — the
+    // slow case that range-seeding targets. Set LO_BENCH_MINS=1 to keep the
+    // 90/90/60 minimums instead.
+    desiredStatRanges: process.env.LO_BENCH_MINS
+      ? desiredStatRanges
+      : armorStats.map((statHash) => ({ statHash, minStat: 0, maxStat: 200 })),
     filteredItems,
     lockedMods: { generalMods: [], activityMods: [] },
     autoModOptions,

--- a/src/app/loadout-builder/process-worker/process.bench.test.ts
+++ b/src/app/loadout-builder/process-worker/process.bench.test.ts
@@ -22,6 +22,7 @@ import { DimItem } from 'app/inventory/item-types';
 import { buildStores } from 'app/inventory/store/d2-store-factory';
 import { armorStats } from 'app/search/d2-known-values';
 import { emptySet } from 'app/utils/empty';
+import { DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { BucketHashes } from 'data/d2/generated-enums';
 import { noop } from 'es-toolkit';
 import fs from 'node:fs';
@@ -38,6 +39,13 @@ import { ArmorBucketHashes, DesiredStatRange, MIN_LO_ITEM_ENERGY } from '../type
 import { process as processArmor, ProcessInputs } from './process';
 import { processBaseline } from './process-baseline';
 import { ProcessItem, ProcessItemsByBucket } from './types';
+
+// A raw Bungie GetProfile response, or one wrapped in { Response }.
+function readProfileFixture(profilePath: string): DestinyProfileResponse {
+  const raw = JSON.parse(fs.readFileSync(profilePath, 'utf-8')) as
+    DestinyProfileResponse | { Response: DestinyProfileResponse };
+  return 'Response' in raw ? raw.Response : raw;
+}
 
 // Deterministic LCG so runs are comparable
 function makeRng(seed: number) {
@@ -188,17 +196,14 @@ test.skip('benchmark process(): baseline vs candidate', async () => {
 const PER_BUCKET = Number(process.env.LO_BENCH_ITEMS) || 25;
 test.skip('benchmark process(): real vault', async () => {
   const defs = await getTestDefinitions();
-  // LO_BENCH_PROFILE can point at a raw Bungie GetProfile response (or one
-  // wrapped in { Response }); otherwise fall back to the checked-in fixture.
+  // LO_BENCH_PROFILE can point at a profile fixture; otherwise fall back to
+  // the checked-in one.
   const profilePath = process.env.LO_BENCH_PROFILE;
   const stores = profilePath
     ? buildStores({
         defs,
         buckets: getBuckets(defs),
-        profileResponse: (() => {
-          const raw = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
-          return raw.Response ?? raw;
-        })(),
+        profileResponse: readProfileFixture(profilePath),
         customStats: [],
       })
     : await getTestStores();
@@ -295,10 +300,7 @@ async function loadRealVaultItems(perBucket: number): Promise<{
     ? buildStores({
         defs,
         buckets: getBuckets(defs),
-        profileResponse: (() => {
-          const raw = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
-          return raw.Response ?? raw;
-        })(),
+        profileResponse: readProfileFixture(profilePath),
         customStats: [],
       })
     : await getTestStores();
@@ -374,7 +376,9 @@ function sliceLongestBucket(base: ProcessInputs, n: number, interleaved: boolean
   const count = Math.min(n, items.length);
   const groups: ProcessItem[][] = Array.from({ length: count }, () => []);
   if (interleaved) {
-    items.forEach((it, k) => groups[k % count].push(it));
+    for (const [k, it] of items.entries()) {
+      groups[k % count].push(it);
+    }
   } else {
     const bs = Math.floor(items.length / count);
     const rem = items.length % count;

--- a/src/app/loadout-builder/process-worker/process.test.ts
+++ b/src/app/loadout-builder/process-worker/process.test.ts
@@ -24,18 +24,21 @@ import { process, ProcessInputs } from './process';
 import { ProcessItem, ProcessItemsByBucket, ProcessMod, ProcessResult } from './types';
 
 /**
- * Equivalence harness for the whole process() worker loop. The snapshots were
- * generated before the loop optimizations and pin down everything the UI can
- * observe, so optimized versions of the loop must reproduce them exactly.
+ * Equivalence harness for the whole process() worker loop. The snapshots pin
+ * down everything the UI can observe: sets and stat ranges must survive any
+ * optimization unchanged. The pruning counters (numProcessed, comboLocalSkips,
+ * lowerBoundsExceeded) are pinned too so accidental pruning regressions show
+ * up; they move when the pruning strategy intentionally changes, in which
+ * case regenerate with -u and check that only counter lines changed.
  *
  * Deliberately excluded from the digest: numValidSets, skippedLowTier and
  * modsStatistics, because they depend on how full the top-200 heap is when a
  * set is considered, i.e. on iteration order, which optimizations are allowed
  * to change. The four combo-local skip reasons are summed rather than listed
  * because subtree-level pruning may reclassify a combo that fails several
- * checks at once; only the total is invariant. Sets are sorted by content
- * rather than kept in display order, because sets fully tied on all the
- * tracker's ordering keys may be displayed in any order among themselves.
+ * checks at once. Sets are sorted by content rather than kept in display
+ * order, because sets fully tied on all the tracker's ordering keys may be
+ * displayed in any order among themselves.
  */
 function digest(result: ProcessResult) {
   const { skipReasons } = result.processInfo.statistics;
@@ -368,9 +371,10 @@ describe('process equivalence', () => {
     // With the full corpus the top-200 tracker fills up and most variant
     // evaluations are skipped by the per-set pre-gate, which must not change
     // anything observable. Which same-total sets sit at the heap boundary is
-    // iteration-order dependent, so compare order-independent invariants:
-    // the multiset of retained totals, the stat ranges, and the number of
-    // candidates considered.
+    // iteration-order dependent, and expanded variants are separate branches
+    // with tighter subtree bounds so the two formulations prune differently;
+    // compare order-independent invariants: the multiset of retained totals
+    // and the stat ranges.
     const markExotics = (inputs: ProcessInputs) => {
       inputs.autoStatMods = true;
       inputs.filteredItems[BucketHashes.Helmet][0].isExotic = true;
@@ -409,7 +413,6 @@ describe('process equivalence', () => {
       expandedDigest.sets.map((s) => s.enabledStatsTotal).sort(),
     );
     expect(tailDigest.statRangesFiltered).toEqual(expandedDigest.statRangesFiltered);
-    expect(tailDigest.numProcessed).toBe(expandedDigest.numProcessed);
     expect(tailDigest.sets.some((s) => s.statMods.includes(111) || s.statMods.includes(222))).toBe(
       true,
     );

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -307,6 +307,167 @@ export async function process(
   const maxSetContribAfterGaunt = maxSetContribAfterChest + chestSoA.maxSetContrib;
   const maxSetContribAfterHelm = maxSetContribAfterGaunt + gauntSoA.maxSetContrib;
 
+  // ---------- Stat-total suffix bounds for branch-and-bound subtree pruning ----------
+  // Per bucket: the highest/lowest base value each stat can contribute, and
+  // whether the bucket has an artifice item (worth one artifice mod).
+  const statBoundsOf = (soa: BucketSoA, n: number) => {
+    const max = [0, 0, 0, 0, 0, 0];
+    const min = [MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT];
+    // Lowest value each stat can reach including the worst exotic tuning delta,
+    // matching how the tail lowers minStat. (Legendary tuning is already in the
+    // base stats.) Used to seed the exact stat floor.
+    const floorMin = [MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT, MAX_STAT];
+    let hasArtifice = false;
+    // The single highest enabled-stat total any one item reaches — a tighter
+    // upper bound than summing the per-stat maxes (which come from different,
+    // stat-specialized items no single completion can combine).
+    let maxTotal = 0;
+    for (let i = 0; i < n; i++) {
+      const b = i * 6;
+      const entry = soa.tuning[i];
+      let itemTotal = 0;
+      for (let s = 0; s < 6; s++) {
+        const v = soa.stats[b + s];
+        if (v > max[s]) {
+          max[s] = v;
+        }
+        if (v < min[s]) {
+          min[s] = v;
+        }
+        const fv = entry ? v + entry.minDeltas[s] : v;
+        if (fv < floorMin[s]) {
+          floorMin[s] = fv;
+        }
+        if (maxStatConstraints[s] > 0) {
+          itemTotal += v;
+        }
+      }
+      if (itemTotal > maxTotal) {
+        maxTotal = itemTotal;
+      }
+      hasArtifice ||= soa.artifice[i] === 1;
+    }
+    return { max, min, floorMin, hasArtifice, maxTotal };
+  };
+  const addVec = (a: number[], b: number[]) => {
+    const out = [0, 0, 0, 0, 0, 0];
+    for (let s = 0; s < 6; s++) {
+      out[s] = a[s] + b[s];
+    }
+    return out;
+  };
+  const helmB = statBoundsOf(helmSoA, helms.length);
+  const gauntB = statBoundsOf(gauntSoA, gauntlets.length);
+  const chestB = statBoundsOf(chestSoA, chests.length);
+  const legB = statBoundsOf(legSoA, legs.length);
+  const classB = statBoundsOf(classItemSoA, classItems.length);
+  // Suffix stat bounds = the summed bounds of every bucket after this level, so
+  // the best/worst any completion could reach.
+  const maxStatsAfterLeg = classB.max;
+  const minStatsAfterLeg = classB.min;
+  const maxStatsAfterChest = addVec(legB.max, maxStatsAfterLeg);
+  const minStatsAfterChest = addVec(legB.min, minStatsAfterLeg);
+  const maxStatsAfterGaunt = addVec(chestB.max, maxStatsAfterChest);
+  const minStatsAfterGaunt = addVec(chestB.min, minStatsAfterChest);
+  const maxTotalAfterLeg = classB.maxTotal;
+  const maxTotalAfterChest = maxTotalAfterLeg + legB.maxTotal;
+  const maxTotalAfterGaunt = maxTotalAfterChest + chestB.maxTotal;
+  const maxTotalAfterHelm = maxTotalAfterGaunt + gauntB.maxTotal;
+  const maxStatsAfterHelm = addVec(gauntB.max, maxStatsAfterGaunt);
+  const minStatsAfterHelm = addVec(gauntB.min, minStatsAfterGaunt);
+  const artificeAfterLeg = classB.hasArtifice ? 1 : 0;
+  const artificeAfterChest = artificeAfterLeg + (legB.hasArtifice ? 1 : 0);
+  const artificeAfterGaunt = artificeAfterChest + (chestB.hasArtifice ? 1 : 0);
+  const artificeAfterHelm = artificeAfterGaunt + (gauntB.hasArtifice ? 1 : 0);
+
+  // Legendary tuning is already baked into each item's stats (the mapper
+  // expands a tunable legendary into one item per tuning mod), so the base-stat
+  // bounds above already cover it. Exotics instead defer their tuning choice to
+  // the tail via tuningVariants, and a valid set has at most one exotic — so a
+  // single global headroom (the best/worst delta any exotic variant offers)
+  // keeps the bounds valid whichever exotic ends up tuning.
+  const maxTuningDelta = [0, 0, 0, 0, 0, 0];
+  const minTuningDelta = [0, 0, 0, 0, 0, 0];
+  let maxTuningNetGain = 0;
+  for (const soa of [helmSoA, gauntSoA, chestSoA, legSoA, classItemSoA]) {
+    for (const entry of soa.tuning) {
+      if (entry) {
+        for (let s = 0; s < 6; s++) {
+          if (entry.maxDeltas[s] > maxTuningDelta[s]) {
+            maxTuningDelta[s] = entry.maxDeltas[s];
+          }
+          if (entry.minDeltas[s] < minTuningDelta[s]) {
+            minTuningDelta[s] = entry.minDeltas[s];
+          }
+        }
+        if (entry.maxNetGain > maxTuningNetGain) {
+          maxTuningNetGain = entry.maxNetGain;
+        }
+      }
+    }
+  }
+
+  const generalModsBonus = precalculatedInfo.numAvailableGeneralMods * majorStatBoost;
+  const maxStatValue = MAX_STAT;
+
+  // A set can affect the output in only three ways: enter the top-N tracker,
+  // raise an observed max stat range, or lower an observed min stat range. If no
+  // completion of the buckets after this level could do any of them, the whole
+  // subtree can be skipped without changing results. This works on any data
+  // (unlike item domination) because the tracker floor and the stat ranges
+  // saturate as good/extreme sets are seen. `partialStats`/`partialArtifice` are
+  // the mod stats plus the items chosen so far.
+  const canPruneSubtree = (
+    suffixMax: number[],
+    suffixMin: number[],
+    suffixArtifice: number,
+    suffixMaxTotal: number,
+    partialStats: number[],
+    partialArtifice: number,
+  ): boolean => {
+    const bonusBound = (partialArtifice + suffixArtifice) * artificeStatBoost + generalModsBonus;
+    let upperTotal = 0;
+    let partialTotal = 0;
+    for (let i = 0; i < 6; i++) {
+      if (maxStatConstraints[i] > 0) {
+        upperTotal += Math.min(
+          partialStats[i] + suffixMax[i] + maxTuningDelta[i],
+          maxStatConstraints[i],
+        );
+        partialTotal += partialStats[i];
+      }
+    }
+    // Tightest valid total upper bound: the per-stat-clamped sum, or the partial
+    // plus the best single-item totals of the remaining buckets — whichever is
+    // lower. The latter is far tighter on stat-specialized real armor.
+    const boundTotal = Math.min(upperTotal, partialTotal + suffixMaxTotal);
+    if (setTracker.couldInsert(boundTotal + bonusBound + maxTuningNetGain)) {
+      return false;
+    }
+    for (let i = 0; i < 6; i++) {
+      const statRange = statRanges[i];
+      // Could any completion raise this max stat range? Mirrors updateMaxStats:
+      // bump maxStat to the filter minimum, or to an achievable value above the
+      // observed max.
+      if (
+        statRange.maxStat < desiredStatRanges[i].minStat ||
+        Math.min(maxStatValue, partialStats[i] + suffixMax[i] + maxTuningDelta[i] + bonusBound) >
+          statRange.maxStat
+      ) {
+        return false;
+      }
+      // Could any completion lower this min stat range?
+      if (
+        maxStatConstraints[i] > 0 &&
+        Math.min(partialStats[i] + suffixMin[i] + minTuningDelta[i], maxStatConstraints[i]) <
+          statRange.minStat
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   // Reused across iterations to avoid per-combo allocation in this hot loop.
   // Safe because each is only read within one iteration and copied before being
   // stored in the set tracker. The statsAfter*/perksAfter*/setCountsAfter*
@@ -353,6 +514,113 @@ export async function process(
       await yieldTask();
     }
   };
+
+  // ---------- Seed exact stat ranges up front ----------
+  // When the search spans every combination — no exotic/perk/set-bonus
+  // requirement and no stat minimums, so every set is valid and contributes to
+  // the ranges — the exact min and max ranges can be computed directly instead
+  // of by visiting every set: each stat's minimum is the summed lowest per-bucket
+  // contribution, and its maximum is what the mod solver reaches on the set that
+  // maximizes it. Seeding these makes the subtree range checks non-blocking, so
+  // the tracker-floor prune can skip almost the whole search. Correctness never
+  // depends on the seed (the loop's bounds still compute the true ranges) — only
+  // speed: the min seed is exact, and the max seed is a guaranteed-achievable
+  // lower bound the loop refines upward.
+  // minStat is tracked over every coarsely-valid set regardless of stat
+  // minimums, so it can be seeded whenever no exotic/perk/set-bonus requirement
+  // couples the buckets. maxStat is tracked only over sets that hit the stat
+  // minimums, so seeding it additionally needs there to be no minimums.
+  const canSeedMin = !anyExotic && numPerks === 0 && numSetBonuses === 0;
+  const canSeedMax = canSeedMin && desiredStatRanges.every((r) => r.minStat === 0);
+  if (canSeedMin) {
+    for (let i = 0; i < 6; i++) {
+      if (maxStatConstraints[i] > 0) {
+        const floor =
+          modStatsInStatOrder[i] +
+          helmB.floorMin[i] +
+          gauntB.floorMin[i] +
+          chestB.floorMin[i] +
+          legB.floorMin[i] +
+          classB.floorMin[i];
+        const clamped = Math.min(floor, maxStatConstraints[i]);
+        if (clamped < statRanges[i].minStat) {
+          statRanges[i].minStat = clamped;
+        }
+      }
+    }
+  }
+  if (canSeedMax) {
+    const soas = [helmSoA, gauntSoA, chestSoA, legSoA, classItemSoA];
+    const buckets = [helms, gauntlets, chests, legs, classItems];
+    for (let i = 0; i < 6; i++) {
+      if (maxStatConstraints[i] === 0) {
+        continue;
+      }
+      // Build the stat-i-maximizing set, keeping at most one exotic so it's a
+      // real valid set (else its max would overstate what's achievable).
+      let exoticUsed = false;
+      let valid = true;
+      for (let b = 0; b < 5; b++) {
+        const soa = soas[b];
+        const items = buckets[b];
+        let bestIdx = 0;
+        let bestVal = -1;
+        let bestNonExoticIdx = -1;
+        let bestNonExoticVal = -1;
+        for (let k = 0; k < items.length; k++) {
+          const v = soa.stats[k * 6 + i];
+          if (v > bestVal) {
+            bestVal = v;
+            bestIdx = k;
+          }
+          if (soa.exotic[k] === 0 && v > bestNonExoticVal) {
+            bestNonExoticVal = v;
+            bestNonExoticIdx = k;
+          }
+        }
+        let pick = bestIdx;
+        if (soa.exotic[bestIdx] === 1) {
+          if (exoticUsed) {
+            if (bestNonExoticIdx >= 0) {
+              pick = bestNonExoticIdx;
+            } else {
+              valid = false;
+              break;
+            }
+          } else {
+            exoticUsed = true;
+          }
+        }
+        armor[b] = items[pick];
+      }
+      if (!valid) {
+        continue;
+      }
+      let numArtifice = 0;
+      for (let s = 0; s < 6; s++) {
+        stats[s] = modStatsInStatOrder[s];
+      }
+      for (let b = 0; b < 5; b++) {
+        const itStats = statsCache.get(armor[b])!;
+        for (let s = 0; s < 6; s++) {
+          stats[s] += itStats[s];
+        }
+        if (armor[b].isArtifice) {
+          numArtifice++;
+        }
+      }
+      energyCache.result = undefined;
+      updateMaxStats(
+        precalculatedInfo,
+        armor,
+        stats,
+        numArtifice,
+        desiredStatRanges,
+        statRanges,
+        energyCache,
+      );
+    }
+  }
 
   itemLoop: for (let helmIdx = 0; helmIdx < helms.length; helmIdx++) {
     const helm = helms[helmIdx];
@@ -416,6 +684,23 @@ export async function process(
     statsAfterHelm[3] = modStatsInStatOrder[3] + helmSoA.stats[helmBase + 3];
     statsAfterHelm[4] = modStatsInStatOrder[4] + helmSoA.stats[helmBase + 4];
     statsAfterHelm[5] = modStatsInStatOrder[5] + helmSoA.stats[helmBase + 5];
+    if (
+      canPruneSubtree(
+        maxStatsAfterHelm,
+        minStatsAfterHelm,
+        artificeAfterHelm,
+        maxTotalAfterHelm,
+        statsAfterHelm,
+        artificeP1,
+      )
+    ) {
+      skipLowTier += combosPerHelm;
+      comboCount += combosPerHelm;
+      if (comboCount >= 100000) {
+        await flushProgress();
+      }
+      continue;
+    }
     for (let gauntIdx = 0; gauntIdx < gauntlets.length; gauntIdx++) {
       const gaunt = gauntlets[gauntIdx];
       const exoticP2 = exoticP1 + gauntSoA.exotic[gauntIdx];
@@ -484,6 +769,23 @@ export async function process(
       statsAfterGaunt[3] = statsAfterHelm[3] + gauntSoA.stats[gauntBase + 3];
       statsAfterGaunt[4] = statsAfterHelm[4] + gauntSoA.stats[gauntBase + 4];
       statsAfterGaunt[5] = statsAfterHelm[5] + gauntSoA.stats[gauntBase + 5];
+      if (
+        canPruneSubtree(
+          maxStatsAfterGaunt,
+          minStatsAfterGaunt,
+          artificeAfterGaunt,
+          maxTotalAfterGaunt,
+          statsAfterGaunt,
+          artificeP2,
+        )
+      ) {
+        skipLowTier += combosPerGaunt;
+        comboCount += combosPerGaunt;
+        if (comboCount >= 100000) {
+          await flushProgress();
+        }
+        continue;
+      }
       for (let chestIdx = 0; chestIdx < chests.length; chestIdx++) {
         const chest = chests[chestIdx];
         const exoticP3 = exoticP2 + chestSoA.exotic[chestIdx];
@@ -552,6 +854,23 @@ export async function process(
         statsAfterChest[3] = statsAfterGaunt[3] + chestSoA.stats[chestBase + 3];
         statsAfterChest[4] = statsAfterGaunt[4] + chestSoA.stats[chestBase + 4];
         statsAfterChest[5] = statsAfterGaunt[5] + chestSoA.stats[chestBase + 5];
+        if (
+          canPruneSubtree(
+            maxStatsAfterChest,
+            minStatsAfterChest,
+            artificeAfterChest,
+            maxTotalAfterChest,
+            statsAfterChest,
+            artificeP3,
+          )
+        ) {
+          skipLowTier += combosPerChest;
+          comboCount += combosPerChest;
+          if (comboCount >= 100000) {
+            await flushProgress();
+          }
+          continue;
+        }
         for (let legIdx = 0; legIdx < legs.length; legIdx++) {
           const leg = legs[legIdx];
           const exoticP4 = exoticP3 + legSoA.exotic[legIdx];
@@ -620,6 +939,23 @@ export async function process(
           statsAfterLeg[3] = statsAfterChest[3] + legSoA.stats[legBase + 3];
           statsAfterLeg[4] = statsAfterChest[4] + legSoA.stats[legBase + 4];
           statsAfterLeg[5] = statsAfterChest[5] + legSoA.stats[legBase + 5];
+          if (
+            canPruneSubtree(
+              maxStatsAfterLeg,
+              minStatsAfterLeg,
+              artificeAfterLeg,
+              maxTotalAfterLeg,
+              statsAfterLeg,
+              artificeP4,
+            )
+          ) {
+            skipLowTier += combosPerLeg;
+            comboCount += combosPerLeg;
+            if (comboCount >= 100000) {
+              await flushProgress();
+            }
+            continue;
+          }
           innerloop: for (let classItemIdx = 0; classItemIdx < classItems.length; classItemIdx++) {
             comboCount++;
             if (comboCount >= 100000) {

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -409,6 +409,9 @@ export async function process(
 
   const generalModsBonus = precalculatedInfo.numAvailableGeneralMods * majorStatBoost;
   const maxStatValue = MAX_STAT;
+  // Scratch for canPruneSubtree's per-stat reserved-mod amounts (avoids a
+  // per-call allocation in this frequently-called prune).
+  const reservedScratch = [0, 0, 0, 0, 0, 0];
 
   // A set can affect the output in only three ways: enter the top-N tracker,
   // raise an observed max stat range, or lower an observed min stat range. If no
@@ -444,14 +447,32 @@ export async function process(
     if (setTracker.couldInsert(boundTotal + bonusBound + maxTuningNetGain)) {
       return false;
     }
+    // Stat mods that must be spent bringing other stats up to their minimums
+    // (best case: each other stat at its subtree max) can't also boost stat i,
+    // so the max-range bound reserves them. All zero when there are no minimums.
+    let totalReserved = 0;
+    for (let j = 0; j < 6; j++) {
+      const filter = desiredStatRanges[j];
+      let r = 0;
+      if (filter.maxStat > 0 && filter.minStat > 0) {
+        const best = Math.min(maxStatValue, partialStats[j] + suffixMax[j] + maxTuningDelta[j]);
+        if (filter.minStat > best) {
+          r = filter.minStat - best;
+        }
+      }
+      reservedScratch[j] = r;
+      totalReserved += r;
+    }
     for (let i = 0; i < 6; i++) {
       const statRange = statRanges[i];
       // Could any completion raise this max stat range? Mirrors updateMaxStats:
       // bump maxStat to the filter minimum, or to an achievable value above the
-      // observed max.
+      // observed max. Mods reserved for the other minimums can't boost stat i.
+      const reservedForOthers = totalReserved - reservedScratch[i];
+      const modBudget = bonusBound > reservedForOthers ? bonusBound - reservedForOthers : 0;
       if (
         statRange.maxStat < desiredStatRanges[i].minStat ||
-        Math.min(maxStatValue, partialStats[i] + suffixMax[i] + maxTuningDelta[i] + bonusBound) >
+        Math.min(maxStatValue, partialStats[i] + suffixMax[i] + maxTuningDelta[i] + modBudget) >
           statRange.maxStat
       ) {
         return false;
@@ -526,13 +547,14 @@ export async function process(
   // depends on the seed (the loop's bounds still compute the true ranges) — only
   // speed: the min seed is exact, and the max seed is a guaranteed-achievable
   // lower bound the loop refines upward.
-  // minStat is tracked over every coarsely-valid set regardless of stat
-  // minimums, so it can be seeded whenever no exotic/perk/set-bonus requirement
-  // couples the buckets. maxStat is tracked only over sets that hit the stat
-  // minimums, so seeding it additionally needs there to be no minimums.
-  const canSeedMin = !anyExotic && numPerks === 0 && numSetBonuses === 0;
-  const canSeedMax = canSeedMin && desiredStatRanges.every((r) => r.minStat === 0);
-  if (canSeedMin) {
+  // Seed the exact ranges whenever no exotic/perk/set-bonus requirement couples
+  // the buckets. minStat is tracked over every coarsely-valid set, so its summed
+  // per-bucket floor is exact. maxStat is tracked only over sets that meet the
+  // stat minimums, so each candidate max set is put through the same mod gate
+  // the main loop uses and seeds the max only if it meets them (trivially true
+  // when there are no minimums).
+  const canSeed = !anyExotic && numPerks === 0 && numSetBonuses === 0;
+  if (canSeed) {
     for (let i = 0; i < 6; i++) {
       if (maxStatConstraints[i] > 0) {
         const floor =
@@ -548,8 +570,6 @@ export async function process(
         }
       }
     }
-  }
-  if (canSeedMax) {
     const soas = [helmSoA, gauntSoA, chestSoA, legSoA, classItemSoA];
     const buckets = [helms, gauntlets, chests, legs, classItems];
     for (let i = 0; i < 6; i++) {
@@ -609,7 +629,37 @@ export async function process(
           numArtifice++;
         }
       }
+      // Put the candidate through the main loop's mod gate: it contributes to
+      // maxStat only if it can fit mods to meet the stat minimums.
+      let totalNeededStats = 0;
+      for (let s = 0; s < 6; s++) {
+        neededStats[s] = 0;
+        const filter = desiredStatRanges[s];
+        if (filter.maxStat > 0 && filter.minStat > 0) {
+          const need = filter.minStat - Math.min(stats[s], maxStatConstraints[s]);
+          if (need > 0) {
+            totalNeededStats += need;
+            neededStats[s] = need;
+          }
+        }
+      }
+      const maxModBonus = numArtifice * artificeStatBoost + generalModsBonus;
+      if (totalNeededStats > maxModBonus) {
+        continue;
+      }
       energyCache.result = undefined;
+      if (
+        (hasMods || totalNeededStats > 0) &&
+        !pickAndAssignSlotIndependentMods(
+          precalculatedInfo,
+          setStatistics.modsStatistics,
+          armor,
+          totalNeededStats > 0 ? neededStats : undefined,
+          numArtifice,
+        )
+      ) {
+        continue;
+      }
       updateMaxStats(
         precalculatedInfo,
         armor,

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -2,7 +2,7 @@ import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { DimItem } from 'app/inventory/item-types';
 import { ModMap } from 'app/loadout/mod-assignment-utils';
 import { armorStats } from 'app/search/d2-known-values';
-import { mapValues, partitionEvenly } from 'app/utils/collections';
+import { mapValues } from 'app/utils/collections';
 import { getMaxParallelCores } from 'app/utils/parallel-cores';
 import { proxy, releaseProxy, wrap } from 'comlink';
 import { BucketHashes } from 'data/d2/generated-enums';
@@ -290,7 +290,31 @@ function sliceInputForConcurrency(
     return [input];
   }
 
-  return partitionEvenly(itemsToSlice, concurrency).map((itemsSlice) => ({
+  // Each worker runs an independent search with its own top-N tracker, and how
+  // hard it can prune depends on how good the items it holds are. Contiguous
+  // slices would hand one worker all the best items and another all the worst,
+  // so the workers finish at very different times and the weak ones prune
+  // poorly. Instead, sort the sliced bucket high-stat-first (the order the
+  // worker itself uses) and deal the items round-robin, so every worker gets a
+  // stratified spread and their trackers — and runtimes — stay comparable.
+  const enabledStatHashes = input.desiredStatRanges
+    .filter((r) => r.maxStat > 0)
+    .map((r) => r.statHash);
+  const enabledTotal = (item: ProcessItem) => {
+    let total = 0;
+    for (const statHash of enabledStatHashes) {
+      total += item.stats[statHash] ?? 0;
+    }
+    return total;
+  };
+  const sorted = [...itemsToSlice].sort((a, b) => enabledTotal(b) - enabledTotal(a));
+  const count = Math.min(concurrency, sorted.length);
+  const slices: ProcessItem[][] = Array.from({ length: count }, () => []);
+  for (let i = 0; i < sorted.length; i++) {
+    slices[i % count].push(sorted[i]);
+  }
+
+  return slices.map((itemsSlice) => ({
     ...input,
     filteredItems: {
       ...input.filteredItems,

--- a/src/app/loadout-builder/process/process-wrapper.ts
+++ b/src/app/loadout-builder/process/process-wrapper.ts
@@ -46,7 +46,37 @@ function createWorker() {
     instance.terminate();
   };
 
-  return { worker, cleanup };
+  return { worker, cleanup, uses: 0 };
+}
+
+type PooledWorker = ReturnType<typeof createWorker>;
+
+// Retire a warm worker after this many runs and let the next acquire spin up a
+// fresh one. Bounds any slow accumulation across a long session (e.g. comlink
+// callback proxies) at a negligible cost — one spin-up per this many runs.
+const WORKER_MAX_USES = 50;
+
+// Creating a worker spawns a thread and parses the worker bundle — tens of ms
+// that used to be paid on every run, and which now dominate the wall clock for
+// searches whose compute is only a few ms. Workers are stateless between runs
+// (process() takes all its input each call), so keep a warm pool: a worker
+// returns to the pool when its run finishes cleanly, and is only terminated when
+// a run is cancelled (so its stale work stops) or errors (so a broken worker is
+// never reused).
+const idleWorkers: PooledWorker[] = [];
+let warmPoolLimit = 0;
+
+function acquireWorker(): PooledWorker {
+  return idleWorkers.pop() ?? createWorker();
+}
+
+function releaseWorker(pooled: PooledWorker) {
+  pooled.uses++;
+  if (idleWorkers.length < warmPoolLimit && pooled.uses < WORKER_MAX_USES) {
+    idleWorkers.push(pooled);
+  } else {
+    pooled.cleanup();
+  }
 }
 
 export type RunProcessResult = Omit<ProcessResult, 'sets'> & {
@@ -172,32 +202,51 @@ export function runProcess({
   const inputSlices = sliceInputForConcurrency(input, longestItemsBucketHash, concurrency);
 
   let progressTotal = 0;
+  warmPoolLimit = concurrency;
 
   for (let i = 0; i < inputSlices.length; i++) {
-    const { worker, cleanup: cleanupWorker } = createWorker();
-    let cleanupRef: (() => void) | undefined = cleanupWorker;
-    const existingCleanup = cleanup;
-    const cleanupThisWorker = () => {
-      cleanupRef?.();
-      cleanupRef = undefined;
-    };
-    cleanup = () => {
-      existingCleanup();
-      cleanupThisWorker();
-    };
+    const pooled = acquireWorker();
     const input = inputSlices[i];
+    // `settled` guards the one-time disposition of this worker — whichever of
+    // completion, error, or cancellation happens first wins.
+    let settled = false;
     const handleProgress = proxy((completed: number) => {
-      if (cleanupRef === undefined) {
+      if (settled) {
         return;
       }
       progressTotal += completed;
       onProgress?.(progressTotal, numCombinations);
     });
+    const existingCleanup = cleanup;
+    // Cancellation (a newer run supersedes this one): terminate so the stale
+    // computation stops, and don't return the worker to the pool.
+    const cancel = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      pooled.cleanup();
+    };
+    cleanup = () => {
+      existingCleanup();
+      cancel();
+    };
     const workerPromise = (async () => {
       try {
-        return await worker.process(i + 1, input, handleProgress);
-      } finally {
-        cleanupThisWorker();
+        const result = await pooled.worker.process(i + 1, input, handleProgress);
+        // Clean completion: hand the warm worker back for the next run.
+        if (!settled) {
+          settled = true;
+          releaseWorker(pooled);
+        }
+        return result;
+      } catch (e) {
+        // Error (or the reject from a cancel-driven terminate): never pool it.
+        if (!settled) {
+          settled = true;
+          pooled.cleanup();
+        }
+        throw e;
       }
     })();
     workerPromises.push(workerPromise);


### PR DESCRIPTION
11862:
<img width="444" height="32" alt="image" src="https://github.com/user-attachments/assets/1db32038-60da-4252-9758-eb2c52798b06" />
11868:
<img width="441" height="29" alt="image" src="https://github.com/user-attachments/assets/7521a533-7126-4189-80f7-0f890379af90" />


Builds on #11860 and #11862. Speeds up the LO process worker by pruning the combination search, balancing work across cores, and reusing workers between runs. Measured on a real vault via an A/B harness (details below); results are verified byte-for-byte identical to the current worker.

## Results

A/B of the new `process()` vs the frozen #11862 `process()`, same inputs, min of 7 interleaved rounds, on a real vault (my own, via a GetProfile export):

| search | before | after |
|---|---|---|
| "show everything" (no stat minimums) | 6.6 s | **12 ms (~530x)** |
| with 90/90/60 minimums | 7.9 s | **0.84 s (9.5x)** |
| synthetic (uniform-random smoke test) | — | 3.0x / 1.2x / 3.2x |

Worker load balancing, simulated 6-way split, real vault with minimums: contiguous wall 4.5 s (imbalance 1.57x) -> interleaved wall **3.8 s (1.26x)**.

## What changed

**Branch-and-bound subtree pruning (`process.ts`).** A set can only affect the output three ways: enter the top-N tracker, raise an observed max stat range, or lower a min stat range. Each level of the nested item loop now skips whole subtrees when no completion could do any of those. Two things make this work on real, stat-specialized armor (where earlier domination-based attempts failed):

- The tracker-floor bound uses each remaining bucket's best single-item enabled-stat **total**, not the sum of per-stat maxes — the latter is wildly loose on real rolls (each stat's max comes from a different piece no set combines) and never prunes.
- The stat ranges otherwise force visiting nearly every set, so the exact ranges are **seeded up front** (min from summed per-bucket floors; max from the mod solver on each stat's maximizing set) so the in-loop range checks stop blocking. When stat minimums are set, the max-range bound also reserves the mods needed to hit the *other* minimums, so it stays tight.

Correctness never depends on the seeds — the loop's bounds still compute the true ranges; the seeds only let pruning start immediately.

**Interleaved worker slices (`process-wrapper.ts`).** Each worker prunes against its own top-N tracker, so contiguous slices handed one worker the best items and another the worst — very unbalanced. Now the sliced bucket is sorted high-stat-first and dealt round-robin, so every worker gets a stratified spread. Result-identical (slices still partition; results still merge).

**Warm worker pool (`process-wrapper.ts`).** Workers were created and terminated every run — spawning a thread and parsing the worker bundle each time, which now dominates the wall clock for the fast searches above. Workers are stateless between runs, so they are pooled: returned on clean completion, terminated only on cancel (stale work stops) or error (never reuse a broken worker).

## Correctness

New `process-parity.test.ts` runs the candidate against a frozen copy of the #11862 worker (`process-baseline.ts`) across 11 scenarios (exotic/perk/set-bonus constraints, stat minimums, auto stat mods, exotic tuning) and asserts the retained top-N sets, and every stat's min **and** max range, are byte-identical. All green. The one drift vs the old snapshot test is iteration-count statistics (numProcessed / skip reasons), which any pruning changes.

`process.bench.test.ts` (skipped by default) is the A/B harness used for the numbers above, with a real-vault mode via `LO_BENCH_PROFILE` and a load-balancing simulation.

Changelog: The Loadout Optimizer is dramatically faster, especially "show all sets" searches.