### PR TITLE
Add the tier bonus to tiered adept weapon stats

### DIFF
--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -431,14 +431,17 @@ function getPlugStatValue(
   // Adept raid weapons that were randomly acquired can be enhanced to get an
   // enhanced intrinsic, at which point they're functionally crafted. Their
   // intrinsic says "conditionally +2 to some stats", but they get +3 because
-  // that's how masterworked adepts behave, and an additional +1 by reaching
-  // weapon level 20. Once tiered, these stats also gain +tier on top (the
-  // masterwork stat is unaffected, unlike the crafted case below). There's no
-  // basis for this behavior in the defs, so we cheat when we calculate live
-  // stats and attribute these stats to the intrinsic since that's the
-  // "masterwork".
+  // that's how masterworked adepts behave, and an additional +1 by reaching the
+  // max enhancement tier. This is a function of the enhancement tier, not the
+  // weapon's level, so a max-enhanced weapon gets the +1 even below level 20.
+  // Once tiered, these stats also gain +tier on top (the masterwork stat is
+  // unaffected, unlike the crafted case below). There's no basis for this
+  // behavior in the defs, so we cheat when we calculate live stats and attribute
+  // these stats to the intrinsic since that's the "masterwork".
   if (stat.activationRule?.rule === 'enhancedIntrinsic' && createdItem.adept) {
-    return stat.value + ((createdItem.craftedInfo?.level ?? 0) >= 20 ? 2 : 1) + createdItem.tier;
+    return (
+      stat.value + ((createdItem.craftedInfo?.enhancementTier ?? 0) >= 3 ? 2 : 1) + createdItem.tier
+    );
   }
 
   // Tiered weapons at max masterwork get +tier to every stat ("Applies

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -440,7 +440,9 @@ function getPlugStatValue(
   // these stats to the intrinsic since that's the "masterwork".
   if (stat.activationRule?.rule === 'enhancedIntrinsic' && createdItem.adept) {
     return (
-      stat.value + ((createdItem.craftedInfo?.enhancementTier ?? 0) >= 3 ? 2 : 1) + createdItem.tier
+      stat.value +
+      ((createdItem.craftedInfo?.enhancementTier ?? 0) >= 3 ? 2 : 1) +
+      (createdItem.tier >= 5 ? (createdItem.craftedInfo?.enhancementTier ?? 0) : 0)
     );
   }
 

--- a/src/app/inventory/store/stats.ts
+++ b/src/app/inventory/store/stats.ts
@@ -432,11 +432,13 @@ function getPlugStatValue(
   // enhanced intrinsic, at which point they're functionally crafted. Their
   // intrinsic says "conditionally +2 to some stats", but they get +3 because
   // that's how masterworked adepts behave, and an additional +1 by reaching
-  // weapon level 20. There's no basis for this behavior in the defs, so we
-  // cheat when we calculate live stats and attribute these stats to the
-  // intrinsic since that's the "masterwork".
+  // weapon level 20. Once tiered, these stats also gain +tier on top (the
+  // masterwork stat is unaffected, unlike the crafted case below). There's no
+  // basis for this behavior in the defs, so we cheat when we calculate live
+  // stats and attribute these stats to the intrinsic since that's the
+  // "masterwork".
   if (stat.activationRule?.rule === 'enhancedIntrinsic' && createdItem.adept) {
-    return stat.value + ((createdItem.craftedInfo?.level ?? 0) >= 20 ? 2 : 1);
+    return stat.value + ((createdItem.craftedInfo?.level ?? 0) >= 20 ? 2 : 1) + createdItem.tier;
   }
 
   // Tiered weapons at max masterwork get +tier to every stat ("Applies


### PR DESCRIPTION
Enhanced adept weapons take the early adept return in getPlugStatValue, so the tiered masterwork logic from #11821 never ran for them. In-game (per issue #11866) a tiered enhanced adept keeps its adept bonus and additionally gains +tier on the enhanced intrinsic's conditional stats, while the masterwork stat is unchanged, unlike the crafted case.

Fixes #11866