### PR TITLE
Fix exotic armor ornament unlock detection

### DIFF
--- a/src/app/inventory/selectors.ts
+++ b/src/app/inventory/selectors.ts
@@ -6,12 +6,19 @@ import { tuningSocketReusablePlugSetHash } from 'app/loadout-builder/types';
 import { d2ManifestSelector } from 'app/manifest/selectors';
 import { createCollectibleFinder } from 'app/records/collectible-matching';
 import { filterUnlockedPlugs } from 'app/records/plugset-helpers';
+import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { RootState } from 'app/store/types';
 import { emptyArray, emptyObject, emptySet } from 'app/utils/empty';
 import { currySelector } from 'app/utils/selectors';
+import { getSocketsByCategoryHash } from 'app/utils/socket-utils';
 import { DestinyItemPlug, DestinyProfileResponse } from 'bungie-api-ts/destiny2';
 import { D2CalculatedSeason } from 'data/d2/d2-season-info';
-import { BucketHashes, ItemCategoryHashes, TraitHashes } from 'data/d2/generated-enums';
+import {
+  BucketHashes,
+  ItemCategoryHashes,
+  SocketCategoryHashes,
+  TraitHashes,
+} from 'data/d2/generated-enums';
 import { createSelector } from 'reselect';
 import { getBuckets as getBucketsD1 } from '../destiny1/d1-buckets';
 import { getBuckets as getBucketsD2 } from '../destiny2/d2-buckets';
@@ -351,6 +358,33 @@ function gatherUnlockedPlugSetItems(
 
   return unlockedPlugs;
 }
+
+/**
+ * Ornament hashes the account owns, according to exotic armor cosmetic
+ * sockets' live plug data. Since Universal Exotic Armor Ornaments, exotic
+ * ornament unlocks are no longer reported in the profile plug sets (only the
+ * Default Ornament appears there), so each item instance's reusablePlugs
+ * canInsert flag is the only ownership signal. These unlocks are account-wide,
+ * so any one instance is authoritative.
+ */
+export const unlockedExoticOrnamentsSelector = createSelector(allItemsSelector, (allItems) => {
+  const unlocked = new Set<number>();
+  for (const item of allItems) {
+    if (item.isExotic && item.bucket.inArmor && item.sockets) {
+      for (const socket of getSocketsByCategoryHash(
+        item.sockets,
+        SocketCategoryHashes.ArmorCosmetics,
+      )) {
+        for (const plug of socket.reusablePlugItems ?? []) {
+          if (plug.canInsert && !DEFAULT_ORNAMENTS.includes(plug.plugItemHash)) {
+            unlocked.add(plug.plugItemHash);
+          }
+        }
+      }
+    }
+  }
+  return unlocked;
+});
 
 /** gets all the dynamic strings from a profile response */
 export const dynamicStringsSelector = createSelector(profileResponseSelector, (profileResp) => {

--- a/src/app/item-popup/SocketDetails.tsx
+++ b/src/app/item-popup/SocketDetails.tsx
@@ -20,7 +20,7 @@ import { chainComparator, compareBy, reverseComparator } from 'app/utils/compara
 import { emptySet } from 'app/utils/empty';
 import { DestinyProfileResponse, PlugUiStyles, SocketPlugSources } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { BucketHashes, PlugCategoryHashes } from 'data/d2/generated-enums';
+import { BucketHashes, PlugCategoryHashes, SocketCategoryHashes } from 'data/d2/generated-enums';
 import { memo, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import '../inventory-page/StoreBucket.scss';
@@ -175,7 +175,12 @@ export default function SocketDetails({
   if (socket.reusablePlugItems) {
     for (const plugItem of socket.reusablePlugItems) {
       modHashes.add(plugItem.plugItemHash);
-      otherUnlockedPlugs.add(plugItem.plugItemHash);
+      // Armor cosmetic sockets list ornaments the account doesn't own, and
+      // canInsert is the only ownership signal for exotic ornaments since
+      // they're not reported in the profile plug sets.
+      if (plugItem.canInsert || socketCategory.hash !== SocketCategoryHashes.ArmorCosmetics) {
+        otherUnlockedPlugs.add(plugItem.plugItemHash);
+      }
     }
   }
 

--- a/src/app/loadout-drawer/loadout-apply.ts
+++ b/src/app/loadout-drawer/loadout-apply.ts
@@ -21,6 +21,7 @@ import { updateManualMoveTimestamp } from 'app/inventory/manual-moves';
 import {
   allItemsSelector,
   storesSelector,
+  unlockedExoticOrnamentsSelector,
   unlockedPlugSetItemsSelector,
 } from 'app/inventory/selectors';
 import { DimStore } from 'app/inventory/store-types';
@@ -302,11 +303,16 @@ function doApplyLoadout(
 
       // Filter out mods that no longer exist or that aren't unlocked on this character
       const unlockedPlugSetItems = once(() => unlockedPlugSetItemsSelector(store.id)(getState()));
+      // Exotic ornament unlocks only show up on item instances, not in the plug sets
+      const unlockedExoticOrnaments = once(() => unlockedExoticOrnamentsSelector(getState()));
       const checkMod = (h: number) => {
         const mod = defs.InventoryItem.get(h);
         return (
           Boolean(mod) &&
-          (unlockedPlugSetItems().has(h) || h === DEFAULT_SHADER || DEFAULT_ORNAMENTS.includes(h))
+          (unlockedPlugSetItems().has(h) ||
+            unlockedExoticOrnaments().has(h) ||
+            h === DEFAULT_SHADER ||
+            DEFAULT_ORNAMENTS.includes(h))
         );
       };
 

--- a/src/app/loadout/fashion/FashionDrawer.tsx
+++ b/src/app/loadout/fashion/FashionDrawer.tsx
@@ -7,7 +7,11 @@ import { t } from 'app/i18next-t';
 import ConnectedInventoryItem from 'app/inventory/ConnectedInventoryItem';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { DimItem, DimSocket, PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { allItemsSelector, unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
+import {
+  allItemsSelector,
+  unlockedExoticOrnamentsSelector,
+  unlockedPlugSetItemsSelector,
+} from 'app/inventory/selectors';
 import SocketDetails from 'app/item-popup/SocketDetails';
 import { ArmorBucketHashes } from 'app/loadout-builder/types';
 import { Loadout, ResolvedLoadoutItem } from 'app/loadout/loadout-types';
@@ -501,11 +505,16 @@ function FashionSocket({
   onRemovePlug: (bucketHash: number, modHash: number) => void;
 }) {
   const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
+  // Exotic ornament unlocks only show up on item instances, not in the plug sets
+  const unlockedExoticOrnaments = useSelector(unlockedExoticOrnamentsSelector);
   const handleOrnamentClick = socket && (() => onPickPlug({ item: exampleItem, socket }));
 
-  const unlockedPlugsWithoutTheDefault = new Set(
-    Array.from(unlockedPlugSetItems).filter((plugHash) => plugHash !== defaultPlug.hash),
-  );
+  const unlockedPlugsWithoutTheDefault = new Set<number>();
+  for (const plugHash of [...unlockedPlugSetItems, ...unlockedExoticOrnaments]) {
+    if (plugHash !== defaultPlug.hash) {
+      unlockedPlugsWithoutTheDefault.add(plugHash);
+    }
+  }
 
   const canSlotOrnament =
     socket?.plugSet?.plugs.some((plug) => unlockedPlugsWithoutTheDefault.has(plug.plugDef.hash)) ||

--- a/src/app/loadout/loadout-ui/FashionMods.tsx
+++ b/src/app/loadout/loadout-ui/FashionMods.tsx
@@ -2,7 +2,10 @@ import { PressTip } from 'app/dim-ui/PressTip';
 import { t } from 'app/i18next-t';
 import { DefItemIcon } from 'app/inventory/ItemIcon';
 import { PluggableInventoryItemDefinition } from 'app/inventory/item-types';
-import { unlockedPlugSetItemsSelector } from 'app/inventory/selectors';
+import {
+  unlockedExoticOrnamentsSelector,
+  unlockedPlugSetItemsSelector,
+} from 'app/inventory/selectors';
 import { useD2Definitions } from 'app/manifest/selectors';
 import { DEFAULT_ORNAMENTS, DEFAULT_SHADER } from 'app/search/d2-known-values';
 import clsx from 'clsx';
@@ -21,6 +24,8 @@ export function FashionMods({
 }) {
   const defs = useD2Definitions()!;
   const unlockedPlugSetItems = useSelector(unlockedPlugSetItemsSelector(storeId));
+  // Exotic ornament unlocks only show up on item instances, not in the plug sets
+  const unlockedExoticOrnaments = useSelector(unlockedExoticOrnamentsSelector);
   const isShader = (m: number) =>
     defs.InventoryItem.get(m)?.plug?.plugCategoryHash === PlugCategoryHashes.Shader;
   const shader = modsForBucket.find(isShader);
@@ -36,7 +41,9 @@ export function FashionMods({
     shader !== undefined && (shader === DEFAULT_SHADER || unlockedPlugSetItems.has(shader));
   const canSlotOrnament =
     ornament !== undefined &&
-    (DEFAULT_ORNAMENTS.includes(ornament) || unlockedPlugSetItems.has(ornament));
+    (DEFAULT_ORNAMENTS.includes(ornament) ||
+      unlockedPlugSetItems.has(ornament) ||
+      unlockedExoticOrnaments.has(ornament));
 
   return (
     <div className={clsx(styles.items, styles.unequipped)}>


### PR DESCRIPTION
Since the Universal Exotic Armor Ornaments change, exotic ornament unlocks are no longer reported in the profile plug sets (only the Default Ornament appears there). The only ownership signal is each exotic instance's live reusablePlugs canInsert flag, so gather account-wide ornament unlocks from those and consult them in the Fashion drawer, saved-loadout fashion display, and loadout apply. Also stop treating unowned ornaments in a cosmetic socket's live plug list as unlocked in the socket picker.

Changelog: Exotic armor ornaments are correctly shown as unlocked in Fashion and are no longer skipped when applying loadouts.

