### PR TITLE
Loadout Optimizer: sort energy vectors once at construction

### DIFF
--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.test.ts
@@ -68,21 +68,22 @@ describe('process-utils auto mod structure', () => {
     },
   );
 
-  test('chooseAutoMods memoizes across permuted-but-equal inputs and distinguishes different ones', () => {
+  test('chooseAutoMods memoizes across equal inputs and distinguishes different ones', () => {
     const autoModData = mapAutoMods(getAutoMods(defs, emptySet<number>()));
     const sessionInfo = precalculateStructures(autoModData, [], [], true, armorStats);
 
-    const pick = chooseAutoMods(sessionInfo, [10, 0, 0, 5, 0, 0], 2, [[3, 10, 0, 7, 4]], 24);
+    // Energy vectors are sorted descending at construction, and the memo keys
+    // rely on that.
+    const pick = chooseAutoMods(sessionInfo, [10, 0, 0, 5, 0, 0], 2, [[10, 7, 4, 3, 0]], 24);
     expect(pick).toBeDefined();
-    // Same energies as a different permutation must hit the same memo entry
-    // (energy vectors are multisets), returning the identical result array.
-    const permuted = chooseAutoMods(sessionInfo, [10, 0, 0, 5, 0, 0], 2, [[10, 7, 4, 3, 0]], 24);
-    expect(permuted).toBe(pick);
+    // A repeated ask must hit the memo, returning the identical result array.
+    const repeated = chooseAutoMods(sessionInfo, [10, 0, 0, 5, 0, 0], 2, [[10, 7, 4, 3, 0]], 24);
+    expect(repeated).toBe(pick);
     // Different needs must not falsely hit
-    const different = chooseAutoMods(sessionInfo, [15, 0, 0, 5, 0, 0], 2, [[3, 10, 0, 7, 4]], 24);
+    const different = chooseAutoMods(sessionInfo, [15, 0, 0, 5, 0, 0], 2, [[10, 7, 4, 3, 0]], 24);
     expect(different).not.toBe(pick);
     // ...and a fresh un-memoized session must agree with the memoized results
     const freshInfo = precalculateStructures(autoModData, [], [], true, armorStats);
-    expect(chooseAutoMods(freshInfo, [10, 0, 0, 5, 0, 0], 2, [[3, 10, 0, 7, 4]], 24)).toEqual(pick);
+    expect(chooseAutoMods(freshInfo, [10, 0, 0, 5, 0, 0], 2, [[10, 7, 4, 3, 0]], 24)).toEqual(pick);
   });
 });

--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -60,8 +60,8 @@ export function chooseAutoMods(
   remainingTotalEnergy: number,
 ): ModsPick[] | undefined {
   // For a fixed session, the result is a pure function of the arguments, and
-  // the energy vectors only matter as multisets (doGeneralModsFit sorts both
-  // sides), so memoize on a packed key. The binary searches in updateMaxStats
+  // the energy vectors only matter as multisets (they're sorted descending at
+  // construction), so memoize on a packed key. The binary searches in updateMaxStats
   // and greedyPickStatMods re-ask with only one neededStats entry changing,
   // and huge numbers of sets share the same energy profile, so hit rates are
   // very high in large searches. Callers must not mutate returned arrays.
@@ -111,12 +111,10 @@ export function chooseAutoMods(
 }
 
 /**
- * Pack one 5-item energy vector into a number. Sorts the vector in place
- * (descending), which is safe because all consumers treat these as multisets
- * and doGeneralModsFit re-sorts them anyway.
+ * Pack one 5-item energy vector into a number. Capacities must be sorted
+ * descending (done at construction) so equal multisets pack to equal keys.
  */
 function packEnergyVector(capacities: number[]) {
-  capacities.sort((a, b) => b - a);
   // Remaining energies are 0-10, well within 5 bits each
   let packed = 0;
   for (let i = 0; i < capacities.length; i++) {
@@ -176,10 +174,9 @@ function doGeneralModsFit(
     generalModCosts.sort((a, b) => b - a);
   }
 
-  return remainingEnergyCapacities.some((capacities) => {
-    capacities.sort((a, b) => b - a);
-    return generalModCosts.every((cost, index) => cost <= capacities[index]);
-  });
+  return remainingEnergyCapacities.some((capacities) =>
+    generalModCosts.every((cost, index) => cost <= capacities[index]),
+  );
 }
 
 /**

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -89,8 +89,8 @@ function getRemainingEnergiesPerAssignment(
   /** Total remaining energy capacity across the set */
   setEnergy: number;
   /**
-   * For each valid permutation, how much energy is left on per item? These
-   * lists are NOT sorted.
+   * For each valid permutation, how much energy is left on per item? Each list
+   * is sorted descending; consumers treat them as multisets.
    */
   remainingEnergiesPerAssignment: number[][];
 } {
@@ -124,6 +124,9 @@ function getRemainingEnergiesPerAssignment(
         remainingEnergyCapacities[i] -= activityMod.energyCost;
       }
     }
+    // Sort once at construction so key packing and fit checks can rely on the
+    // order instead of re-sorting per call.
+    remainingEnergyCapacities.sort((a, b) => b - a);
     remainingEnergiesPerAssignment.push(remainingEnergyCapacities);
   }
 
@@ -397,6 +400,9 @@ export function pickAndAssignSlotIndependentMods(
       remainingEnergyCapacities[idx] =
         item.remainingEnergyCapacity - (activityPermutation[idx]?.energyCost || 0);
     }
+    // Descending order is required for the greedy fit check below and assumed
+    // by chooseAutoMods' key packing.
+    remainingEnergyCapacities.sort((a, b) => b - a);
 
     if (neededStats) {
       const result = chooseAutoMods(
@@ -535,7 +541,8 @@ export function greedyPickStatMods(
   /** The total amount of energy left over in this set */
   totalModEnergyCapacity: number,
 ): ModsPick[] {
-  if (remainingEnergyCapacities[0].every((e) => e === 0) && numArtificeMods === 0) {
+  // Vectors are sorted descending, so a 0 in front means all-zero.
+  if (remainingEnergyCapacities[0][0] === 0 && numArtificeMods === 0) {
     return [];
   }
   let picks: ModsPick[] | undefined = chooseAutoMods(


### PR DESCRIPTION
Review feedback on #11860: the remaining-energy vectors were re-sorted on every packEnergyVector and doGeneralModsFit call even though they only matter as multisets. Sort them descending at the two construction sites instead, so everything downstream can assume the order.

This also fixes a latent bug: with locked general mods and no stat constraints, the fit check compared descending mod costs against slot-ordered energies, which could wrongly reject a set whose mods only fit in a different item order.

Changelog: Fixed the Loadout Optimizer wrongly rejecting some sets with locked general mods when no stat constraints were set.