### PR TITLE
Loadout Optimizer: don't memoize auto mod picks across multiple vectors

### DIFF
--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -65,9 +65,12 @@ export function chooseAutoMods(
   // and greedyPickStatMods re-ask with only one neededStats entry changing,
   // and huge numbers of sets share the same energy profile, so hit rates are
   // very high in large searches. Callers must not mutate returned arrays.
-  if (remainingTotalEnergy < 0) {
+  if (remainingTotalEnergy < 0 || remainingEnergyCapacities.length > 1) {
     // Negative budgets (impossible via the process loop) would corrupt the
     // packed key, and unlike a 0 budget they reject even cost-0 picks.
+    // Multiple energy vectors (locked activity mods with several valid
+    // assignments) would need string keys, and building those costs more than
+    // the solver saves: benchmarked ~1.9x slower than not memoizing at all.
     return recursivelyChooseMods(
       info.autoModOptions,
       info.generalModCosts,


### PR DESCRIPTION
With locked activity mods and several valid assignments, the memo key for chooseAutoMods falls back to a string, and building those keys costs more than the solver saves: an ablation benchmark measured the locked-mods scenario running 1.9x faster with the memo disabled entirely. Bypass the memo for multi-vector contexts so only the common single-vector case (plain number keys, where the memo is a 1.06-1.20x win) pays for caching.

Changelog: The Loadout Optimizer is up to 2x faster when activity mods are locked.