### PR TITLE
Loadout Optimizer: remove optimizations that measured at noise

### DIFF
--- a/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
+++ b/src/app/loadout-builder/process-worker/auto-stat-mod-utils.ts
@@ -124,7 +124,7 @@ function packEnergyVector(capacities: number[]) {
 }
 
 /** Stat needs are 0-200, so 8 bits per stat packs all six exactly into 48 bits. */
-export function packStatNeeds(neededStats: number[]): number {
+function packStatNeeds(neededStats: number[]): number {
   return (
     neededStats[0] +
     neededStats[1] * 0x100 +
@@ -135,7 +135,7 @@ export function packStatNeeds(neededStats: number[]): number {
   );
 }
 
-export function buildContextKey(
+function buildContextKey(
   remainingEnergyCapacities: number[][],
   numArtificeMods: number,
   remainingTotalEnergy: number,

--- a/src/app/loadout-builder/process-worker/process-baseline.ts
+++ b/src/app/loadout-builder/process-worker/process-baseline.ts
@@ -19,7 +19,6 @@ import {
   pickAndAssignSlotIndependentMods,
   pickOptimalStatMods,
   precalculateStructures,
-  SetEnergyCache,
   updateMaxStats,
 } from './process-utils';
 import { encodeStatMix, HeapSetTracker } from './set-tracker';
@@ -284,9 +283,6 @@ export async function processBaseline(
   const effectiveStats = [0, 0, 0, 0, 0, 0];
   const neededStats = [0, 0, 0, 0, 0, 0];
   const armor: ProcessItem[] = new Array<ProcessItem>(5);
-  // Shares the activity-mod energy computation between updateMaxStats and
-  // pickOptimalStatMods for the same armor set; cleared per combination.
-  const energyCache: SetEnergyCache = { result: undefined };
   const statsAfterHelm = [0, 0, 0, 0, 0, 0];
   const statsAfterGaunt = [0, 0, 0, 0, 0, 0];
   const statsAfterChest = [0, 0, 0, 0, 0, 0];
@@ -669,9 +665,6 @@ export async function processBaseline(
             armor[2] = chest;
             armor[3] = leg;
             armor[4] = classItem;
-            // The energy profile doesn't depend on tuning, so the cache is
-            // shared across all variants of this armor set.
-            energyCache.result = undefined;
 
             const numArtifice = artificeP4 + classItemSoA.artifice[classItemIdx];
 
@@ -854,7 +847,6 @@ export async function processBaseline(
                   numArtifice,
                   desiredStatRanges,
                   statRanges,
-                  energyCache,
                 );
 
               // Drop this set if it could never make it into our top
@@ -872,7 +864,6 @@ export async function processBaseline(
                 stats,
                 desiredStatRanges,
                 numArtifice,
-                energyCache,
               );
               if (!optimalResult) {
                 // This means we couldn't assign mods in a way that satisfied

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -120,30 +120,6 @@ function getRemainingEnergiesPerAssignment(
   return { setEnergy, remainingEnergiesPerAssignment };
 }
 
-/**
- * Per-armor-set cache for the result of getRemainingEnergiesPerAssignment, so
- * updateMaxStats and pickOptimalStatMods compute it at most once per set. The
- * caller owns one instance and must clear `result` for each new armor set.
- */
-export interface SetEnergyCache {
-  result: ReturnType<typeof getRemainingEnergiesPerAssignment> | undefined;
-}
-
-function computeRemainingEnergies(
-  info: LoSessionInfo,
-  items: readonly ProcessItem[],
-  cache: SetEnergyCache | undefined,
-) {
-  if (cache?.result) {
-    return cache.result;
-  }
-  const result = getRemainingEnergiesPerAssignment(info.activityModPermutations, items);
-  if (cache) {
-    cache.result = result;
-  }
-  return result;
-}
-
 // How many extra points we need to add to each stat to hit the minimums. We
 // reuse a single array to avoid allocations.
 const requiredMinimumExtraStats = [0, 0, 0, 0, 0, 0];
@@ -165,8 +141,6 @@ export function updateMaxStats(
   desiredStatRanges: readonly DesiredStatRange[],
   /** Current stat ranges across all sets we've seen so far. */
   statRanges: MinMaxStat[], // mutated
-  /** Optional per-set cache shared with pickOptimalStatMods. */
-  energyCache?: SetEnergyCache,
 ): boolean {
   let foundAnyImprovement = false;
 
@@ -232,7 +206,10 @@ export function updateMaxStats(
       continue;
     }
 
-    remainingEnergyResult ??= computeRemainingEnergies(info, armor, energyCache);
+    remainingEnergyResult ??= getRemainingEnergiesPerAssignment(
+      info.activityModPermutations,
+      armor,
+    );
     const { remainingEnergiesPerAssignment, setEnergy } = remainingEnergyResult;
     const energyBudget = setEnergy - info.totalModEnergyCost;
 
@@ -410,13 +387,10 @@ export function pickOptimalStatMods(
   desiredStatRanges: DesiredStatRange[],
   /** Number of artifice items in the set, if the caller already knows it. */
   numArtificeMods?: number,
-  /** Optional per-set cache shared with updateMaxStats. */
-  energyCache?: SetEnergyCache,
 ): { mods: number[]; bonusStats: number[] } | undefined {
-  const { remainingEnergiesPerAssignment, setEnergy } = computeRemainingEnergies(
-    info,
+  const { remainingEnergiesPerAssignment, setEnergy } = getRemainingEnergiesPerAssignment(
+    info.activityModPermutations,
     items,
-    energyCache,
   );
   if (remainingEnergiesPerAssignment.length === 0) {
     // No valid activity mod assignments

--- a/src/app/loadout-builder/process-worker/process-utils.ts
+++ b/src/app/loadout-builder/process-worker/process-utils.ts
@@ -8,14 +8,7 @@ import {
   majorStatBoost,
   MinMaxStat,
 } from '../types';
-import {
-  AutoModsCache,
-  buildAutoModsMap,
-  buildContextKey,
-  chooseAutoMods,
-  ModsPick,
-  packStatNeeds,
-} from './auto-stat-mod-utils';
+import { AutoModsCache, buildAutoModsMap, chooseAutoMods, ModsPick } from './auto-stat-mod-utils';
 import { AutoModData, ModAssignmentStatistics, ProcessItem, ProcessMod } from './types';
 
 /**
@@ -40,11 +33,6 @@ export interface LoSessionInfo {
    * a few thousand energy multisets and a few hundred stat patterns each.
    */
   autoModsMemo: Map<number | string, Map<number, ModsPick[] | null>>;
-  /**
-   * Memoized maximum single-stat boosts for updateMaxStats, keyed like
-   * autoModsMemo, then by (statIndex, packed other-stat minimums).
-   */
-  maxBoostMemo: Map<number | string, Map<number, number>>;
 }
 
 export function precalculateStructures(
@@ -73,7 +61,6 @@ export function precalculateStructures(
       return acc;
     }, {}),
     autoModsMemo: new Map(),
-    maxBoostMemo: new Map(),
   };
 }
 
@@ -223,7 +210,6 @@ export function updateMaxStats(
     info.numAvailableGeneralMods * majorStatBoost + numArtificeMods * artificeStatBoost;
 
   let remainingEnergyResult: ReturnType<typeof getRemainingEnergiesPerAssignment> | undefined;
-  let boostMemo: Map<number, number> | undefined;
 
   // You wouldn't believe it, but Firefox is actually slow loading constants
   // from another module.
@@ -250,52 +236,31 @@ export function updateMaxStats(
     const { remainingEnergiesPerAssignment, setEnergy } = remainingEnergyResult;
     const energyBudget = setEnergy - info.totalModEnergyCost;
 
-    // The largest boost this stat can get (holding the other stats at their
-    // minimums) doesn't depend on the stat's current value or on the running
-    // max, so it can be memoized across sets that share the same energy
-    // profile and minimums.
-    if (boostMemo === undefined) {
-      const contextKey = buildContextKey(
-        remainingEnergiesPerAssignment,
-        numArtificeMods,
-        energyBudget,
-      );
-      boostMemo = info.maxBoostMemo.get(contextKey);
-      if (boostMemo === undefined) {
-        boostMemo = new Map();
-        info.maxBoostMemo.set(contextKey, boostMemo);
-      }
-    }
     const previousRequiredMinimum = requiredMinimumExtraStats[statIndex];
-    requiredMinimumExtraStats[statIndex] = 0;
-    const boostKey = statIndex * 0x1000000000000 + packStatNeeds(requiredMinimumExtraStats);
-    let maxBoost = boostMemo.get(boostKey);
-    if (maxBoost === undefined) {
-      // Binary search for the largest achievable boost. chooseAutoMods is
-      // monotonic in a single stat's requirement, so this is exact. -1 means
-      // even the base minimums can't be met.
-      let good = -1;
-      let high = maxSingleStatBonus;
-      while (good < high) {
-        const mid = (good + high + 1) >> 1;
-        requiredMinimumExtraStats[statIndex] = mid;
-        if (
-          chooseAutoMods(
-            info,
-            requiredMinimumExtraStats,
-            numArtificeMods,
-            remainingEnergiesPerAssignment,
-            energyBudget,
-          )
-        ) {
-          good = mid;
-        } else {
-          high = mid - 1;
-        }
+    // Binary search for the largest achievable boost. chooseAutoMods is
+    // monotonic in a single stat's requirement, so this is exact. -1 means
+    // even the base minimums can't be met. chooseAutoMods memoizes the
+    // underlying solves, so repeats across sets stay cheap.
+    let good = -1;
+    let high = maxSingleStatBonus;
+    while (good < high) {
+      const mid = (good + high + 1) >> 1;
+      requiredMinimumExtraStats[statIndex] = mid;
+      if (
+        chooseAutoMods(
+          info,
+          requiredMinimumExtraStats,
+          numArtificeMods,
+          remainingEnergiesPerAssignment,
+          energyBudget,
+        )
+      ) {
+        good = mid;
+      } else {
+        high = mid - 1;
       }
-      maxBoost = good;
-      boostMemo.set(boostKey, maxBoost);
     }
+    const maxBoost = good;
     requiredMinimumExtraStats[statIndex] = previousRequiredMinimum;
 
     // The first loop already raised the running max to at least `value`, so

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -20,7 +20,6 @@ import {
   pickAndAssignSlotIndependentMods,
   pickOptimalStatMods,
   precalculateStructures,
-  SetEnergyCache,
   updateMaxStats,
 } from './process-utils';
 import { encodeStatMix, HeapSetTracker } from './set-tracker';
@@ -382,9 +381,6 @@ export async function process(
   const effectiveStats = [0, 0, 0, 0, 0, 0];
   const neededStats = [0, 0, 0, 0, 0, 0];
   const armor: ProcessItem[] = new Array<ProcessItem>(5);
-  // Shares the activity-mod energy computation between updateMaxStats and
-  // pickOptimalStatMods for the same armor set; cleared per combination.
-  const energyCache: SetEnergyCache = { result: undefined };
   const statsAfterHelm = [0, 0, 0, 0, 0, 0];
   const statsAfterGaunt = [0, 0, 0, 0, 0, 0];
   const statsAfterChest = [0, 0, 0, 0, 0, 0];
@@ -821,9 +817,6 @@ export async function process(
             armor[2] = chest;
             armor[3] = leg;
             armor[4] = classItem;
-            // The energy profile doesn't depend on tuning, so the cache is
-            // shared across all variants of this armor set.
-            energyCache.result = undefined;
 
             const numArtifice = artificeP4 + classItemSoA.artifice[classItemIdx];
 
@@ -991,7 +984,6 @@ export async function process(
                   numArtifice,
                   desiredStatRanges,
                   statRanges,
-                  energyCache,
                 );
 
               // Drop this set if it could never make it into our top
@@ -1009,7 +1001,6 @@ export async function process(
                 stats,
                 desiredStatRanges,
                 numArtifice,
-                energyCache,
               );
               if (!optimalResult) {
                 // This means we couldn't assign mods in a way that satisfied
@@ -1554,7 +1545,6 @@ function seedExactStatRanges(
   const armor = new Array<ProcessItem>(5);
   const stats = [0, 0, 0, 0, 0, 0];
   const neededStats = [0, 0, 0, 0, 0, 0];
-  const energyCache: SetEnergyCache = { result: undefined };
   for (let i = 0; i < 6; i++) {
     if (maxStatConstraints[i] === 0) {
       continue;
@@ -1630,7 +1620,6 @@ function seedExactStatRanges(
     if (totalNeededStats > maxModBonus) {
       continue;
     }
-    energyCache.result = undefined;
     if (
       (hasMods || totalNeededStats > 0) &&
       !pickAndAssignSlotIndependentMods(
@@ -1643,14 +1632,6 @@ function seedExactStatRanges(
     ) {
       continue;
     }
-    updateMaxStats(
-      precalculatedInfo,
-      armor,
-      stats,
-      numArtifice,
-      desiredStatRanges,
-      statRanges,
-      energyCache,
-    );
+    updateMaxStats(precalculatedInfo, armor, stats, numArtifice, desiredStatRanges, statRanges);
   }
 }

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -958,33 +958,14 @@ export async function process(
               // At this point we know this set satisfies all constraints.
               // Update the max stat ranges. We need to do this before we short
               // circuit anything so that the stat ranges are accurate.
-              //
-              // updateMaxStats only ever raises the running maxes, so once they
-              // have converged (the common steady state in large searches) we can
-              // skip the call for sets that provably can't raise any of them.
-              // These conditions mirror its internal update conditions exactly.
-              let mayImproveMax = false;
-              for (let index = 0; index < 6; index++) {
-                const maxSeen = statRanges[index].maxStat;
-                if (
-                  maxSeen < desiredStatRanges[index].minStat ||
-                  stats[index] > maxSeen ||
-                  (maxSeen < MAX_STAT && stats[index] + maxModBonus > maxSeen)
-                ) {
-                  mayImproveMax = true;
-                  break;
-                }
-              }
-              const foundAnyImprovement =
-                mayImproveMax &&
-                updateMaxStats(
-                  precalculatedInfo,
-                  armor,
-                  stats,
-                  numArtifice,
-                  desiredStatRanges,
-                  statRanges,
-                );
+              const foundAnyImprovement = updateMaxStats(
+                precalculatedInfo,
+                armor,
+                stats,
+                numArtifice,
+                desiredStatRanges,
+                statRanges,
+              );
 
               // Drop this set if it could never make it into our top
               // RETURNED_ARMOR_SETS sets. We do this only after confirming that


### PR DESCRIPTION
Requires #11874 

Follow-up to the review feedback on #11868 about undoing optimizations that aren't meaningful. I ran an ablation study over the LO worker optimizations: each one was toggled off individually and benchmarked interleaved against the full configuration in the same run (5 rounds, min-over-rounds, so clock drift can't skew ratios), on synthetic corpora and a real vault profile, with the parity suite verifying every ablated configuration still produces identical results. Four optimizations measured at or below noise (0.96x to 1.05x) in every scenario, so this removes them, one commit each:

- **Remove the max-boost memo from `updateMaxStats`.** The internal MAX_STAT and single-stat upper-bound checks already keep the binary search rare, and `chooseAutoMods` memoizes the underlying solves, so the second memo layer never paid for itself. Also lets `buildContextKey`/`packStatNeeds` go private to `auto-stat-mod-utils`.
- **Remove the per-set energy assignment cache.** `updateMaxStats` and `pickOptimalStatMods` rarely both run for the same set, so the shared `SetEnergyCache` almost never got a hit, including in the locked-activity-mods scenario it was built for.
- **Drop the convergence gate before `updateMaxStats`.** It mirrored conditions the function already enforces internally.
- **Un-unroll the six-stat adds.** The manual unrolling stopped measuring once the adds moved into a small helper; the plain loop reads better.

Combined verification: parity and all loadout-builder tests pass, and the A/B bench against the frozen baseline is unchanged with all four removed together (15.9x/2.5x/10.0x vs the 15.0x/2.4x/10.2x reference on the same code shape), so there's no pairwise interaction between the removals.