### PR TITLE
Replaces WEBPACK_SERVE with RSPACK_SERVE

### DIFF
--- a/config/webpack.ts
+++ b/config/webpack.ts
@@ -52,7 +52,7 @@ export default (env: Env) => {
     }
   });
 
-  if (env.dev && env.WEBPACK_SERVE && (!fs.existsSync('key.pem') || !fs.existsSync('cert.pem'))) {
+  if (env.dev && env.RSPACK_SERVE && (!fs.existsSync('key.pem') || !fs.existsSync('cert.pem'))) {
     console.log('Generating certificate');
     execSync('mkcert create-ca --validity 825');
     execSync('mkcert create-cert --validity 825 --key key.pem --cert cert.pem');


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Fixes an issue with the out-of-the-box configuration of the webpack.ts file where it incorrectly looks for the WEBPACK_SERVE environment variable instead of the RSPACK_SERVE one after the migration from webpack to rspack.
