### PR TITLE
Search set bonuses

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -611,6 +611,7 @@
     },
     "Scaled": "Scaled",
     "SearchAMod": "Search for mod name or description",
+    "SearchASetBonus": "Search for set bonus name, perk name or description",
     "SearchAnExotic": "Search for exotic name or description",
     "SelectModsCount": "{{selected}}/{{maxSelectable}}",
     "SelectModsCountActivityMods": "{{selected}}/{{maxSelectable}} Activity Mods",

--- a/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.m.scss
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.m.scss
@@ -2,14 +2,8 @@
 
 .container {
   --set-bonus-icon-size: 34px;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(504px, 1fr));
   padding: 10px 10px 16px 10px;
   gap: 14px;
-
-  @include phone-portrait {
-    grid-template-columns: 1fr;
-  }
 }
 
 .setBonuses {

--- a/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.tsx
+++ b/src/app/loadout-builder/filter/LoadoutOptimizerSetBonus.tsx
@@ -1,5 +1,6 @@
 import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
+import { languageSelector } from 'app/dim-api/selectors';
 import Sheet from 'app/dim-ui/Sheet';
 import { SheetHorizontalScrollContainer } from 'app/dim-ui/SheetHorizontalScrollContainer';
 import { TileGrid, TileGridTile } from 'app/dim-ui/TileGrid';
@@ -12,10 +13,17 @@ import { setBonusModToSet } from 'app/loadout/known-values';
 import LoadoutEditSection from 'app/loadout/loadout-edit/LoadoutEditSection';
 import { isLoadoutBuilderItem } from 'app/loadout/loadout-item-utils';
 import { useD2Definitions } from 'app/manifest/selectors';
+import { SearchInput } from 'app/search/SearchInput';
+import { startWordRegexp } from 'app/search/text-utils';
 import { useIsPhonePortrait } from 'app/shell/selectors';
+import { isiOSBrowser } from 'app/utils/browsers';
 import { filterMap, mapValues, minOf } from 'app/utils/collections';
 import { getActiveSetBonusHash, getSetBonusModSocket } from 'app/utils/socket-utils';
-import { DestinyClass, DestinyItemSetPerkDefinition } from 'bungie-api-ts/destiny2';
+import {
+  DestinyClass,
+  DestinyEquipableItemSetDefinition,
+  DestinyItemSetPerkDefinition,
+} from 'bungie-api-ts/destiny2';
 import { sum } from 'es-toolkit';
 import { Dispatch, memo, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -178,10 +186,11 @@ export function SetBonusPicker({
   onClose: () => void;
 }) {
   const defs = useD2Definitions()!;
+  const isPhonePortrait = useIsPhonePortrait();
 
-  // TODO search functionality
-  // const language = useSelector(languageSelector);
-  // const [query, setQuery] = useState('');
+  const language = useSelector(languageSelector);
+  const [query, setQuery] = useState('');
+
   const [setBonuses, setSetBonuses] = useState(initialSetBonuses);
 
   const allItems = useSelector(allItemsSelector);
@@ -191,10 +200,30 @@ export function SetBonusPicker({
     [defs, allItems, vendorItems, classType],
   );
 
-  // Only allow choosing set bonuses the user has items for
-  const sets = Object.keys(possibleSetBonuses)
-    .map((h) => defs.EquipableItemSet.get(parseInt(h, 10)))
-    .filter((set) => !set.redacted);
+  const sets = useMemo(() => {
+    const allSets = Object.keys(possibleSetBonuses)
+      .map((h) => defs.EquipableItemSet.get(parseInt(h, 10)))
+      .filter((set) => !set.redacted);
+
+    if (!query.length) {
+      return allSets;
+    }
+
+    const regexp = startWordRegexp(query, language);
+    const searchFilter = (set: DestinyEquipableItemSetDefinition) =>
+      regexp.test(set.displayProperties.name) ||
+      regexp.test(set.displayProperties.description) ||
+      set.setPerks.some((perk) => {
+        const perkDef = defs.SandboxPerk.get(perk.sandboxPerkHash);
+        return (
+          perkDef &&
+          (regexp.test(perkDef.displayProperties.name) ||
+            regexp.test(perkDef.displayProperties.description))
+        );
+      });
+
+    return allSets.filter((set) => searchFilter(set));
+  }, [query, possibleSetBonuses, defs, language]);
 
   const totalSelected = sum(Object.values(setBonuses));
 
@@ -235,18 +264,20 @@ export function SetBonusPicker({
     });
   };
 
+  // On iOS at least, focusing the keyboard pushes the content off the screen
+  const nativeAutoFocus = !isPhonePortrait && !isiOSBrowser();
+
   return (
     <Sheet
       header={
         <div>
           <h1>{t('LB.ChooseASetBonus')}</h1>
-          {/* TODO search functionality
           <SearchInput
             query={query}
             onQueryChanged={setQuery}
             placeholder={t('LB.SearchASetBonus')}
-            autoFocus
-          /> */}
+            autoFocus={nativeAutoFocus}
+          />
         </div>
       }
       footer={footer}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -597,7 +597,7 @@
     "RemoveStack": "Remove a copy of this mod",
     "Scaled": "Scaled",
     "SearchAMod": "Search for mod name or description",
-    "SearchASetBonus": "",
+    "SearchASetBonus": "Search for set bonus name, perk name or description",
     "SearchAnExotic": "Search for exotic name or description",
     "SelectExotic": "Select exotic",
     "SelectMods": "Select Mods",


### PR DESCRIPTION
Changelog: In Loadout Optimizer, set bonuses are now searchable. They also always show up in a single column instead of side-by-side.

<img width="756" height="720" alt="Screenshot 2026-07-13 at 11 38 14 PM" src="https://github.com/user-attachments/assets/c6a51473-ad4a-4c45-bd9f-5b2cebc37af1" />
