### PR TITLE
Change color of vendor icon and clicking it opens the vendor

### DIFF
--- a/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSet.tsx
@@ -187,6 +187,7 @@ export default memo(function GeneratedSet({
               autoStatMods={autoStatMods}
               automaticallyPickedMods={autoModsPerItem[item.id]}
               energy={resultingItemEnergies[item.id]}
+              storeId={selectedStore.id}
             />
           ))}
         </div>

--- a/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
+++ b/src/app/loadout-builder/generated-sets/GeneratedSetItem.tsx
@@ -46,6 +46,7 @@ export default function GeneratedSetItem({
   autoStatMods,
   automaticallyPickedMods,
   energy,
+  storeId,
   lbDispatch,
 }: {
   item: DimItem;
@@ -54,6 +55,7 @@ export default function GeneratedSetItem({
   autoStatMods: boolean;
   automaticallyPickedMods?: number[];
   energy: { energyCapacity: number; energyUsed: number };
+  storeId: string;
   lbDispatch: Dispatch<LoadoutBuilderAction>;
 }) {
   const pinItem = (item: DimItem) => lbDispatch({ type: 'pinItem', item });
@@ -130,6 +132,7 @@ export default function GeneratedSetItem({
           automaticallyPickedMods={automaticallyPickedMods}
           onSocketClick={onSocketClick}
           size="small"
+          storeId={storeId}
         />
       </div>
     </div>

--- a/src/app/loadout/loadout-ui/Sockets.m.scss
+++ b/src/app/loadout/loadout-ui/Sockets.m.scss
@@ -24,7 +24,7 @@
   align-items: center;
   justify-content: center;
   > span {
-    color: var(--theme-accent-secondary);
+    color: var(--theme-accent-primary);
     font-size: calc(var(--item-icon-size) * 2 / 3);
   }
 }

--- a/src/app/loadout/loadout-ui/Sockets.tsx
+++ b/src/app/loadout/loadout-ui/Sockets.tsx
@@ -7,9 +7,11 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { modTypeTagByPlugCategoryHash } from 'app/search/specialty-modslots';
 import { AppIcon, shoppingCart } from 'app/shell/icons';
 import { isEventArmorRerollSocket, trustBungieVisibility } from 'app/utils/socket-utils';
+import { SingleVendorSheetContext } from 'app/vendors/single-vendor/SingleVendorSheetContainer';
 import { DestinyInventoryItemDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
 import { PlugCategoryHashes } from 'data/d2/generated-enums';
+import { use } from 'react';
 import { pickPlugPositions } from '../mod-assignment-utils';
 import PlugDef from './PlugDef';
 import * as styles from './Sockets.m.scss';
@@ -33,11 +35,13 @@ function Sockets({
   size,
   onSocketClick,
   automaticallyPickedMods,
+  storeId,
 }: {
   item: DimItem;
   lockedMods?: PluggableInventoryItemDefinition[];
   automaticallyPickedMods?: number[];
   size?: 'small';
+  storeId: string;
   onSocketClick?: (
     plugDef: PluggableInventoryItemDefinition,
     /** An allow-list of plug category hashes that can be inserted into this socket */
@@ -112,7 +116,11 @@ function Sockets({
   }
 
   return (
-    <div className={clsx(styles.lockedItems, { [styles.small]: size === 'small' })}>
+    <div
+      className={clsx(styles.lockedItems, {
+        [styles.small]: size === 'small',
+      })}
+    >
       {modsAndWhitelist.map(({ plugDef, whitelist, automaticallyPicked }, index) => (
         <PlugDef
           className={clsx({ [styles.automaticallyPicked]: automaticallyPicked })}
@@ -123,15 +131,16 @@ function Sockets({
           item={item}
         />
       ))}
-      {item.vendor && <VendorItemPlug item={item} />}
+      {item.vendor && <VendorItemPlug item={item} storeId={storeId} />}
     </div>
   );
 }
 
-function VendorItemPlug({ item }: { item: DimItem }) {
+function VendorItemPlug({ item, storeId }: { item: DimItem; storeId: string }) {
   const defs = useD2Definitions()!;
   const replacer = useDynamicStringReplacer(item.owner);
   const vendorDef = defs.Vendor.get(item.vendor!.vendorHash);
+  const showVendor = use(SingleVendorSheetContext)!;
   return (
     <PressTip
       elementType="span"
@@ -144,7 +153,15 @@ function VendorItemPlug({ item }: { item: DimItem }) {
         );
       }}
     >
-      <div className={clsx('item', styles.vendorItem)}>
+      <div
+        className={clsx('item', styles.vendorItem)}
+        onClick={() =>
+          showVendor?.({
+            characterId: storeId,
+            vendorHash: item.vendor!.vendorHash,
+          })
+        }
+      >
         <AppIcon icon={shoppingCart} />
       </div>
     </PressTip>

--- a/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
+++ b/src/app/loadout/mod-assignment-drawer/ModAssignmentDrawer.tsx
@@ -133,6 +133,7 @@ export default function ModAssignmentDrawer({
                     item={item}
                     lockedMods={itemModAssignments[item.id]}
                     onSocketClick={onUpdateMods ? onSocketClick : undefined}
+                    storeId={storeId}
                   />
                 </div>
               );


### PR DESCRIPTION
Changelog: Made vendor items in Loadout Optimizer a bit more visible, and clicking the shopping cart icon opens the relevant vendor in a sheet.

<img width="930" height="594" alt="Screenshot 2026-07-13 at 11 46 12 PM" src="https://github.com/user-attachments/assets/7bfc2d58-2b5d-495a-a64c-56c1e0710222" />
