### PR TITLE
Revert "Merge pull request #11861 from DestinyItemManager/lo-wait-for…

### DIFF
--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -182,7 +182,7 @@ export default memo(function LoadoutBuilder({
     [resolvedMods, autoStatMods],
   );
 
-  const { vendorItems, vendorItemsLoading } = useLoVendorItems(selectedStoreId);
+  const { vendorItems } = useLoVendorItems(selectedStoreId);
   const armorItems = useArmorItems(classType, vendorItems);
 
   const { modMap: lockedModMap, unassignedMods } = useMemo(
@@ -285,9 +285,6 @@ export default memo(function LoadoutBuilder({
     anyExotic: lockedExoticHash === LOCKED_EXOTIC_ANY_EXOTIC,
     autoStatMods,
     strictUpgrades: Boolean(strictUpgradesStatConstraints && !mergedConstraintsImplyStrictUpgrade),
-    // Vendor items get merged into the process inputs once they load, so
-    // starting before that just wastes a run that immediately gets restarted.
-    pauseProcessing: vendorItemsLoading,
   });
 
   const resultSets = result?.sets;

--- a/src/app/loadout-builder/loadout-builder-vendors.ts
+++ b/src/app/loadout-builder/loadout-builder-vendors.ts
@@ -44,11 +44,10 @@ export function useLoVendorItems(selectedStoreId: string) {
   const vendorItems = useSelector(loVendorItemsSelector(selectedStoreId));
   const vendors = useSelector(vendorsByCharacterSelector);
 
-  const vendorItemsLoading = useLoadVendors(account, selectedStoreId);
+  useLoadVendors(account, selectedStoreId);
 
   return {
     vendorItems,
-    vendorItemsLoading,
     error: vendors[selectedStoreId]?.error,
   };
 }

--- a/src/app/loadout-builder/process/useProcess.ts
+++ b/src/app/loadout-builder/process/useProcess.ts
@@ -63,7 +63,6 @@ export function useProcess({
   anyExotic,
   autoStatMods,
   strictUpgrades,
-  pauseProcessing,
 }: {
   selectedStore: DimStore;
   filteredItems: ItemsByBucket;
@@ -76,12 +75,6 @@ export function useProcess({
   anyExotic: boolean;
   autoStatMods: boolean;
   strictUpgrades: boolean;
-  /**
-   * Hold off starting a new process run while the item inputs are still
-   * settling (e.g. vendor items are loading), so the first run isn't
-   * immediately thrown away and restarted.
-   */
-  pauseProcessing: boolean;
 }) {
   const [{ result, processing, totalCombos, completedCombos, startTime, resultStoreId }, setState] =
     useState<ProcessState>({
@@ -111,10 +104,6 @@ export function useProcess({
   const inputsRef = useRef<ProcessInputs>(undefined);
 
   useEffect(() => {
-    if (pauseProcessing) {
-      // When this flips back, the effect re-runs and starts the process.
-      return;
-    }
     const doProcess = async () => {
       const handleProgress = (completed: number, total: number) => {
         const now = Date.now();
@@ -210,14 +199,11 @@ export function useProcess({
     autoModDefs,
     strictUpgrades,
     firstTime,
-    pauseProcessing,
   ]);
 
   return {
     result: resultStoreId === selectedStore.id ? result : null,
-    // While paused, a run is imminent, so report it as processing to keep the
-    // UI from showing a "no results" state.
-    processing: processing || pauseProcessing,
+    processing,
     startTime,
     totalCombos,
     completedCombos,

--- a/src/app/vendors/actions.ts
+++ b/src/app/vendors/actions.ts
@@ -31,14 +31,6 @@ export const loadedError = createAction('vendors/LOADED_ERROR')<{
   error: Error;
 }>();
 
-/**
- * The load kicked off by loadAllVendors has settled, successfully or not,
- * including the follow-up per-vendor item component fetches.
- */
-export const finishedLoading = createAction('vendors/FINISHED_LOADING')<{
-  characterId: string;
-}>();
-
 export const setShowUnacquiredOnly = createAction('vendors/SHOW_UNCOLLECTED_ONLY')<boolean>();
 
 export function loadAllVendors(
@@ -160,7 +152,6 @@ export function loadAllVendors(
       const error = convertToError(e);
       dispatch(loadedError({ characterId, error }));
     } finally {
-      dispatch(finishedLoading({ characterId }));
       infoLog(
         'Vendors',
         [

--- a/src/app/vendors/hooks.ts
+++ b/src/app/vendors/hooks.ts
@@ -2,25 +2,19 @@ import { DestinyAccount } from 'app/accounts/destiny-account';
 import { loadingTracker } from 'app/shell/loading-tracker';
 import { refresh$ } from 'app/shell/refresh-events';
 import { useThunkDispatch } from 'app/store/thunk-dispatch';
-import { RootState } from 'app/store/types';
 import { useEventBusListener } from 'app/utils/hooks';
 import { useCallback, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import { loadAllVendors } from './actions';
 
 /**
  * Loads all vendors for the given account+character, and tries refreshing them
  * when the app refreshes.
- *
- * Returns whether the initial load is still settling (including the follow-up
- * per-vendor item component fetches). Refreshes don't re-enter the loading
- * state, since existing vendor data stays usable while it updates.
  */
 export function useLoadVendors(
   account: DestinyAccount,
   storeId: string | undefined,
   active = true,
-): boolean {
+) {
   const dispatch = useThunkDispatch();
   useEffect(() => {
     if (storeId && active) {
@@ -36,9 +30,4 @@ export function useLoadVendors(
       }
     }, [account, active, dispatch, storeId]),
   );
-
-  const fullyLoaded = useSelector((state: RootState) =>
-    storeId ? Boolean(state.vendors.vendorsByCharacter[storeId]?.fullyLoaded) : false,
-  );
-  return Boolean(storeId && active) && !fullyLoaded;
 }

--- a/src/app/vendors/reducer.ts
+++ b/src/app/vendors/reducer.ts
@@ -16,12 +16,6 @@ export interface VendorsState {
       /** ms epoch time */
       lastLoaded?: number;
       error?: Error;
-      /**
-       * Whether the first load has settled, including the follow-up per-vendor
-       * item component fetches. Stays true across refreshes, since the
-       * existing data remains usable while it updates.
-       */
-      fullyLoaded?: boolean;
     };
   }>;
   showUnacquiredOnly: boolean;
@@ -51,7 +45,6 @@ export const vendors: Reducer<VendorsState, VendorsAction | AccountsAction> = (
           vendorsResponse: vendorsResponse,
           lastLoaded: Date.now(),
           error: undefined,
-          fullyLoaded: state.vendorsByCharacter[characterId]?.fullyLoaded,
         };
         if (oldItemComponents) {
           draft.vendorsByCharacter[characterId].vendorsResponse!.itemComponents = oldItemComponents;
@@ -95,20 +88,6 @@ export const vendors: Reducer<VendorsState, VendorsAction | AccountsAction> = (
           [characterId]: {
             ...state.vendorsByCharacter[characterId],
             error,
-          },
-        },
-      };
-    }
-
-    case getType(actions.finishedLoading): {
-      const { characterId } = action.payload;
-      return {
-        ...state,
-        vendorsByCharacter: {
-          ...state.vendorsByCharacter,
-          [characterId]: {
-            ...state.vendorsByCharacter[characterId],
-            fullyLoaded: true,
           },
         },
       };


### PR DESCRIPTION
Loading vendors is slow - for me at least, much slower than calculating LO sets. And when it does load, we'll cancel and restart the job anyway. I don't think we need to delay results for this.

Changelog: Loadout Optimizer no longer waits for vendors to load.

This reverts commit 64f84d49284b1b208700e84bdc70713e83ad9a56, reversing changes made to ff4bf9c74bde2de23c19bb419c0be7e294ee137f.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
