### PR TITLE
Add info about max core settings and why LO can be slow

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -712,7 +712,7 @@
     "ProcessingSets": "Finding highest stat sets...",
     "SaveAs": "Save as",
     "SetBonus": "Set Bonuses",
-    "SpeedReport": "Evaluated {{combos, number}} combinations in {{time}} seconds using {{cpus}} CPU cores.",
+    "SpeedReport": "Evaluated {{combos, number}} combinations in {{time}} seconds using {{cpus}} CPU cores. Adjust max cores in Settings.",
     "StatConstraints": "Stat Priorities & Ranges",
     "StatMax": "Max",
     "StatMin": "Min",

--- a/config/i18n.json
+++ b/config/i18n.json
@@ -724,7 +724,8 @@
     "UnlockItem": "Unpin Item",
     "IncreaseStatPriority": "Increase stat priority",
     "DecreaseStatPriority": "Decrease stat priority",
-    "IgnoreStat": "If unchecked, Loadout Optimizer will pretend this stat doesn't exist when building sets"
+    "IgnoreStat": "If unchecked, Loadout Optimizer will pretend this stat doesn't exist when building sets",
+    "WhySlow": "Why is this slow?"
   },
   "Loadouts": {
     "Abilities": "Abilities",

--- a/src/app/loadout-builder/LoadoutBuilder.tsx
+++ b/src/app/loadout-builder/LoadoutBuilder.tsx
@@ -7,6 +7,7 @@ import { D2ManifestDefinitions } from 'app/destiny2/d2-definitions';
 import { savedLoStatConstraintsByClassSelector } from 'app/dim-api/selectors';
 import CharacterSelect from 'app/dim-ui/CharacterSelect';
 import CollapsibleTitle from 'app/dim-ui/CollapsibleTitle';
+import ExternalLink from 'app/dim-ui/ExternalLink';
 import PageWithMenu from 'app/dim-ui/PageWithMenu';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
@@ -30,6 +31,7 @@ import { useD2Definitions } from 'app/manifest/selectors';
 import { searchFilterSelector } from 'app/search/items/item-search-filter';
 import { useSetSetting } from 'app/settings/hooks';
 import { AppIcon, disabledIcon, redoIcon, refreshIcon, undoIcon } from 'app/shell/icons';
+import { userGuideUrl } from 'app/shell/links';
 import { querySelector, useIsPhonePortrait } from 'app/shell/selectors';
 import { filterMap } from 'app/utils/collections';
 import { emptyArray, emptyObject } from 'app/utils/empty';
@@ -463,6 +465,12 @@ export default memo(function LoadoutBuilder({
   const remainingCombos = (totalCombos || 1) - completedCombos;
   const eta = remainingCombos / speed;
 
+  const whySlow = (
+    <ExternalLink href={userGuideUrl('Why-Loadout-Optimizer-is-slow-or-uses-a-lot-of-CPU')}>
+      {t('LoadoutBuilder.WhySlow')}
+    </ExternalLink>
+  );
+
   return (
     <PageWithMenu className={styles.page}>
       <PageWithMenu.Menu className={clsx(styles.menuContent, styles.wide)}>
@@ -504,6 +512,7 @@ export default memo(function LoadoutBuilder({
                       )}
                     </span>
                   )}
+                {whySlow}
               </div>
             </span>
           ) : (
@@ -514,6 +523,7 @@ export default memo(function LoadoutBuilder({
                   time: (result.processTime / 1000).toFixed(2),
                   cpus: getMaxParallelCores(),
                 })}
+                {whySlow}
               </span>
             )
           )}

--- a/src/app/loadout/loadout-ui/menu-hooks.tsx
+++ b/src/app/loadout/loadout-ui/menu-hooks.tsx
@@ -1,5 +1,6 @@
 import { LoadoutSort } from '@destinyitemmanager/dim-api-types';
 import { bungieBackgroundStyleAdvanced } from 'app/dim-ui/BungieImage';
+import ExternalLink from 'app/dim-ui/ExternalLink';
 import FilterPills, { Option } from 'app/dim-ui/FilterPills';
 import ColorDestinySymbols from 'app/dim-ui/destiny-symbols/ColorDestinySymbols';
 import { DimLanguage } from 'app/i18n';
@@ -16,6 +17,7 @@ import { DEFAULT_ORNAMENTS } from 'app/search/d2-known-values';
 import { ItemFilter } from 'app/search/filter-types';
 import { faCheckCircle, refreshIcon } from 'app/shell/icons';
 import AppIcon from 'app/shell/icons/AppIcon';
+import { userGuideUrl } from 'app/shell/links';
 import { isEmpty } from 'app/utils/collections';
 import { compareBy } from 'app/utils/comparators';
 import { emptyArray } from 'app/utils/empty';
@@ -257,6 +259,10 @@ function AnalysisProgress({
           {t('LoadoutAnalysis.Analyzed', { numLoadouts })}
         </>
       )}
+      {' - '}
+      <ExternalLink href={userGuideUrl('Why-Loadout-Optimizer-is-slow-or-uses-a-lot-of-CPU')}>
+        {t('LoadoutBuilder.WhySlow')}
+      </ExternalLink>
     </div>
   );
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -752,7 +752,7 @@
     "SaveAs": "Save as",
     "SetBonus": "Set Bonuses",
     "SetBonusModWarning": "This set contains an item with a configurable set bonus mod. Manually apply the correct mod to activate the desired set bonus.",
-    "SpeedReport": "Evaluated {{combos, number}} combinations in {{time}} seconds using {{cpus}} CPU cores.",
+    "SpeedReport": "Evaluated {{combos, number}} combinations in {{time}} seconds using {{cpus}} CPU cores. Adjust max cores in Settings.",
     "StatConstraints": "Stat Priorities & Ranges",
     "StatMax": "Max",
     "StatMin": "Min",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -761,7 +761,8 @@
     "TierNumber": "T{{tier}}",
     "UnableToAddAllMods": "Unable to add all mods.",
     "UnableToAddAllModsBody": "There weren't enough mod slots available to fit {{mods}}.",
-    "UnlockItem": "Unpin Item"
+    "UnlockItem": "Unpin Item",
+    "WhySlow": "Why is this slow?"
   },
   "LoadoutFilter": {
     "Contains": "Shows loadouts which have an item or a mod matching the filter text. Search for items with spaces in their name using quotes.",


### PR DESCRIPTION
Changelog: Link to the user guide for why Loadout Optimizer / Loadout Analyzer can be slow from the Loadouts and LO pages.

<img width="822" height="96" alt="Screenshot 2026-07-13 at 11 49 44 PM" src="https://github.com/user-attachments/assets/10b24fc9-696c-4f3d-a91e-ae97c8d566d3" />
<img width="288" height="93" alt="Screenshot 2026-07-13 at 11 49 50 PM" src="https://github.com/user-attachments/assets/10d5ee6a-4459-4668-8b63-84b896d4d580" />
