### PR TITLE
add base-uri and form-action to the content security policy

### DIFF
--- a/config/content-security-policy.ts
+++ b/config/content-security-policy.ts
@@ -79,6 +79,10 @@ export default function csp(
     objectSrc: SELF,
     // Web app manifest
     manifestSrc: SELF,
+    // Injected markup can't repoint relative URLs or post to another origin.
+    // None of our forms submit cross-origin.
+    baseUri: [SELF],
+    formAction: [SELF],
   };
 
   // Turn on CSP reporting to sentry.io on beta only


### PR DESCRIPTION
The policy we generate leaves base-uri and form-action unset, and neither of those falls back to default-src, so in practice both are unrestricted. That seems worth closing off because the What's New page renders Bungie's global alert HTML unsanitised through dangerouslySetInnerHTML, and while script-src stops inline script it does nothing about an injected base tag repointing relative URLs or a form posting somewhere else. Setting both to 'self' should be behaviour-neutral, as none of the seven forms in the app carry a cross-origin action attribute.