### PR TITLE
Add share button to loadout drawer

### DIFF
--- a/src/app/loadout-drawer/LoadoutDrawer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawer.tsx
@@ -1,3 +1,4 @@
+import { DestinyAccount } from 'app/accounts/destiny-account';
 import { apiPermissionGrantedSelector } from 'app/dim-api/selectors';
 import { AlertIcon } from 'app/dim-ui/AlertIcon';
 import CheckButton from 'app/dim-ui/CheckButton';
@@ -7,6 +8,7 @@ import { useAutocomplete } from 'app/dim-ui/text-complete/text-complete';
 import { t } from 'app/i18next-t';
 import { getStore } from 'app/inventory/stores-helpers';
 import InGameLoadoutIdentifiersSelectButton from 'app/loadout/ingame/InGameLoadoutIdentifiersSelectButton';
+import LoadoutShareSheet from 'app/loadout/loadout-share/LoadoutShareSheet';
 import { useDefinitions } from 'app/manifest/selectors';
 import { searchFilterSelector } from 'app/search/items/item-search-filter';
 import { AppIcon, addIcon, faRandom } from 'app/shell/icons';
@@ -16,7 +18,7 @@ import { useEventBusListener } from 'app/utils/hooks';
 import { infoLog, warnLog } from 'app/utils/log';
 import { useHistory } from 'app/utils/undo-redo-history';
 import { DestinyClass } from 'bungie-api-ts/destiny2';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import TextareaAutosize from 'react-textarea-autosize';
 import Sheet from '../dim-ui/Sheet';
@@ -59,6 +61,7 @@ export default function LoadoutDrawer({
   storeId,
   fromExternal,
   onClose,
+  account,
 }: {
   initialLoadout: Loadout;
   /**
@@ -69,6 +72,7 @@ export default function LoadoutDrawer({
   storeId: string;
   fromExternal: boolean;
   onClose: () => void;
+  account: DestinyAccount;
 }) {
   const dispatch = useThunkDispatch();
   const defs = useDefinitions()!;
@@ -85,6 +89,10 @@ export default function LoadoutDrawer({
     canRedo,
   } = useHistory(initialLoadout);
   const apiPermissionGranted = useSelector(apiPermissionGrantedSelector);
+
+  const [sharing, setSharing] = useState(false);
+  const startShare = () => setSharing(true);
+  const closeShare = () => setSharing(false);
 
   function withUpdater<T extends unknown[]>(fn: (...args: T) => LoadoutUpdateFunction) {
     return (...args: T) => setLoadout(fn(...args));
@@ -214,6 +222,7 @@ export default function LoadoutDrawer({
       redo={redo}
       hasUndo={canUndo}
       hasRedo={canRedo}
+      onShare={startShare}
     />
   );
 
@@ -258,6 +267,7 @@ export default function LoadoutDrawer({
           </CheckButton>
         </div>
       </LoadoutDrawerDropTarget>
+      {sharing && <LoadoutShareSheet account={account} loadout={loadout} onClose={closeShare} />}
     </Sheet>
   );
 }

--- a/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerContainer.tsx
@@ -164,6 +164,7 @@ export default function LoadoutDrawerContainer({ account }: { account: DestinyAc
             storeId={initialLoadout.storeId}
             onClose={handleDrawerClose}
             fromExternal={initialLoadout.fromExternal}
+            account={account}
           />
         ) : (
           <D1LoadoutDrawer

--- a/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
+++ b/src/app/loadout-drawer/LoadoutDrawerFooter.tsx
@@ -3,7 +3,7 @@ import { PressTip } from 'app/dim-ui/PressTip';
 import UserGuideLink from 'app/dim-ui/UserGuideLink';
 import { t } from 'app/i18next-t';
 import { loadoutSavedSelector } from 'app/loadout/selectors';
-import { AppIcon, deleteIcon, redoIcon, undoIcon } from 'app/shell/icons';
+import { AppIcon, deleteIcon, redoIcon, shareIcon, undoIcon } from 'app/shell/icons';
 import { RootState } from 'app/store/types';
 import { isEmpty } from 'app/utils/collections';
 import { isClassCompatible } from 'app/utils/item-utils';
@@ -38,6 +38,7 @@ export default function LoadoutDrawerFooter({
   redo,
   hasUndo,
   hasRedo,
+  onShare,
 }: {
   loadout: Readonly<Loadout>;
   undo?: () => void;
@@ -46,6 +47,7 @@ export default function LoadoutDrawerFooter({
   hasRedo?: boolean;
   onSaveLoadout: (e: React.FormEvent, saveAsNew: boolean) => void;
   onDeleteLoadout: () => void;
+  onShare?: () => void;
 }) {
   const isSaved = useSelector(loadoutSavedSelector(loadout.id));
   const clashingLoadout = useSelector(clashingLoadoutSelector(loadout));
@@ -142,6 +144,16 @@ export default function LoadoutDrawerFooter({
             disabled={!hasRedo}
           >
             <AppIcon icon={redoIcon} />
+          </button>
+        )}
+        {onShare && (
+          <button
+            className="dim-button"
+            type="button"
+            onClick={onShare}
+            title={t('Loadouts.ShareLoadout')}
+          >
+            <AppIcon icon={shareIcon} /> {t('Loadouts.ShareLoadout')}
           </button>
         )}
         <UserGuideLink topic="Loadouts" />


### PR DESCRIPTION
<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Closes #11896 
Adds a loadout share button to the loadout drawer. This pr doesn't add a share button loadout popup, as discussed in the issue, because that would lead to too much clutter, in my opinion.
<img width="1901" height="540" alt="image" src="https://github.com/user-attachments/assets/dff793b2-f2c4-4d77-aca9-92ca9c9895d7" />

Changelog: Added a share button to the loadout edit sheet.

