### PR TITLE
Clamp stats in loadout optimizer

### DIFF
--- a/src/app/loadout-builder/generated-sets/SetStats.tsx
+++ b/src/app/loadout-builder/generated-sets/SetStats.tsx
@@ -10,7 +10,7 @@ import StatTooltip from 'app/store-stats/StatTooltip';
 import { sumBy } from 'app/utils/collections';
 import { DestinyStatDefinition } from 'bungie-api-ts/destiny2';
 import clsx from 'clsx';
-import { sum } from 'es-toolkit';
+import { clamp } from 'es-toolkit';
 import {
   ArmorStatHashes,
   ArmorStats,
@@ -49,12 +49,8 @@ export function TierlessSetStats({
   setBonusModWarning?: boolean;
 }) {
   const defs = useD2Definitions()!;
-  const totalStats = sum(Object.values(stats));
+  const totalStats = sumBy(Object.values(stats), (stat) => clamp(stat, 0, MAX_STAT));
   const countedStatsTotal = sumEnabledStats(stats, desiredStatRanges); // Total of the stats that were within the desired ranges
-
-  // TODO: Lots of changes needed here once we drop tiers. Maybe we just show a
-  // total stat sum? Doesn't seem that useful...
-  // TODO: Highlight enhanced stats?
 
   return (
     <div className={clsx(styles.container, className)}>

--- a/src/app/loadout-builder/generated-sets/utils.ts
+++ b/src/app/loadout-builder/generated-sets/utils.ts
@@ -1,6 +1,6 @@
 import { sumBy } from 'app/utils/collections';
 import { chainComparator, Comparator, compareBy } from 'app/utils/comparators';
-import { sum } from 'es-toolkit';
+import { clamp, sum } from 'es-toolkit';
 import { ArmorSet, ArmorStatHashes, ArmorStats, DesiredStatRange } from '../types';
 import { getPower } from '../utils';
 
@@ -37,6 +37,6 @@ export function sortGeneratedSets(
 export function sumEnabledStats(stats: ArmorStats, desiredStatRanges: DesiredStatRange[]) {
   return sumBy(desiredStatRanges, (constraint) => {
     const statHash: ArmorStatHashes = constraint.statHash;
-    return Math.min(stats[statHash], constraint.maxStat);
+    return clamp(stats[statHash], 0, constraint.maxStat);
   });
 }

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -2,7 +2,7 @@ import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { MAX_STAT } from 'app/loadout/known-values';
 import { compact, filterMap } from 'app/utils/collections';
 import { BucketHashes } from 'data/d2/generated-enums';
-import { sum } from 'es-toolkit';
+import { clamp, sum } from 'es-toolkit';
 import { infoLog } from '../../utils/log';
 import {
   ArmorBucketHashes,
@@ -1021,12 +1021,12 @@ export async function process(
 
               const { bonusStats, mods } = optimalResult;
               const finalStats = [
-                effectiveStats[0] + bonusStats[0],
-                effectiveStats[1] + bonusStats[1],
-                effectiveStats[2] + bonusStats[2],
-                effectiveStats[3] + bonusStats[3],
-                effectiveStats[4] + bonusStats[4],
-                effectiveStats[5] + bonusStats[5],
+                clamp(effectiveStats[0] + bonusStats[0], 0, MAX_STAT),
+                clamp(effectiveStats[1] + bonusStats[1], 0, MAX_STAT),
+                clamp(effectiveStats[2] + bonusStats[2], 0, MAX_STAT),
+                clamp(effectiveStats[3] + bonusStats[3], 0, MAX_STAT),
+                clamp(effectiveStats[4] + bonusStats[4], 0, MAX_STAT),
+                clamp(effectiveStats[5] + bonusStats[5], 0, MAX_STAT),
               ];
               const finalTotalStats =
                 finalStats[0] +

--- a/src/app/loadout-builder/process-worker/process.ts
+++ b/src/app/loadout-builder/process-worker/process.ts
@@ -2,7 +2,7 @@ import { SetBonusCounts } from '@destinyitemmanager/dim-api-types';
 import { MAX_STAT } from 'app/loadout/known-values';
 import { compact, filterMap } from 'app/utils/collections';
 import { BucketHashes } from 'data/d2/generated-enums';
-import { clamp, sum } from 'es-toolkit';
+import { sum } from 'es-toolkit';
 import { infoLog } from '../../utils/log';
 import {
   ArmorBucketHashes,
@@ -1021,12 +1021,12 @@ export async function process(
 
               const { bonusStats, mods } = optimalResult;
               const finalStats = [
-                clamp(effectiveStats[0] + bonusStats[0], 0, MAX_STAT),
-                clamp(effectiveStats[1] + bonusStats[1], 0, MAX_STAT),
-                clamp(effectiveStats[2] + bonusStats[2], 0, MAX_STAT),
-                clamp(effectiveStats[3] + bonusStats[3], 0, MAX_STAT),
-                clamp(effectiveStats[4] + bonusStats[4], 0, MAX_STAT),
-                clamp(effectiveStats[5] + bonusStats[5], 0, MAX_STAT),
+                effectiveStats[0] + bonusStats[0],
+                effectiveStats[1] + bonusStats[1],
+                effectiveStats[2] + bonusStats[2],
+                effectiveStats[3] + bonusStats[3],
+                effectiveStats[4] + bonusStats[4],
+                effectiveStats[5] + bonusStats[5],
               ];
               const finalTotalStats =
                 finalStats[0] +


### PR DESCRIPTION
Changelog: Clamp stats in Loadout Optimizer sets so negative stats don't reduce the total.

Fixes https://github.com/DestinyItemManager/DIM/issues/11921