### PR TITLE
Allow clicking on single-perk sockets

### DIFF
--- a/src/app/item-popup/Plug.tsx
+++ b/src/app/item-popup/Plug.tsx
@@ -52,7 +52,7 @@ export default function Plug({
   }
 
   const selectable = socketInfo.plugOptions.length > 1;
-  const doClick = (hasMenu || selectable) && onClick ? () => onClick(plug) : undefined;
+  const doClick = onClick ? () => onClick(plug) : undefined;
 
   return (
     <div


### PR DESCRIPTION
Changelog: Perks with more than one option are now shift-clickable in Organizer.

Fixes #11925