### PR TITLE
Loadout Optimizer: don't let exotic-only search matches block all builds

### DIFF
--- a/src/app/loadout-builder/item-filter.test.ts
+++ b/src/app/loadout-builder/item-filter.test.ts
@@ -305,6 +305,28 @@ describe('loadout-builder item-filter', () => {
     expect(originalExotics.length).toBe(filteredExotics.length);
   });
 
+  it('ignores an exotic-only search match so multiple buckets do not force double exotics', () => {
+    // Simulate a search (e.g. `tier:5`) that happens to match only exotics: a
+    // filter that keeps every exotic but no legendaries. Since a set can hold
+    // just one exotic, keeping several exotic-only buckets would make every
+    // combination invalid, so the search should be ignored per bucket instead.
+    const [filteredItems, filterInfo] = filterItems({
+      ...defaultArgs,
+      defs,
+      items,
+      lockedModMap: noMods.modMap,
+      unassignedMods: noMods.unassignedMods,
+      searchFilter: (item) => item.isExotic,
+    });
+
+    noPinInvariants(filteredItems, filterInfo);
+    expect(filterInfo.searchQueryEffective).toBe(false);
+    // Every bucket keeps its legendaries rather than collapsing to exotics only.
+    for (const bucketHash of ArmorBucketHashes) {
+      expect(filteredItems[bucketHash].some((item) => !item.isExotic)).toBe(true);
+    }
+  });
+
   it('mod assignment may cause exotic slot to not have options', () => {
     // Find a leg armor exotic where every copy does not have 10 energy
     const exotic = items.find(

--- a/src/app/loadout-builder/item-filter.ts
+++ b/src/app/loadout-builder/item-filter.ts
@@ -239,9 +239,20 @@ export function filterItems({
 
     // If a search filters out all the possible items for a bucket, we ignore
     // the search. This allows users to filter some buckets without getting
-    // stuck making no sets.
-    let finalFilteredItems = searchFilteredItems.length ? searchFilteredItems : itemsThatFitMods;
-    const removedBySearchFilter = searchFilteredItems.length
+    // stuck making no sets. A loadout can hold at most one exotic, so a bucket
+    // whose only matches are exotic can't be paired with another such bucket, so
+    // treat those the same as an empty result and ignore the search there.
+    // Otherwise a query like `tier:5` that happens to match only exotics in
+    // several buckets leaves those buckets exotic-only and no valid sets can be
+    // built. Buckets already restricted to a specific exotic (pinned or locked)
+    // have no legendaries left to fall back to, so they keep their exotic-only
+    // matches.
+    const searchMatchedUsableItem =
+      searchFilteredItems.length > 0 &&
+      (searchFilteredItems.some((item) => !item.isExotic) ||
+        !itemsThatFitMods.some((item) => !item.isExotic));
+    let finalFilteredItems = searchMatchedUsableItem ? searchFilteredItems : itemsThatFitMods;
+    const removedBySearchFilter = searchMatchedUsableItem
       ? itemsThatFitMods.length - searchFilteredItems.length
       : 0;
     filterInfo.searchQueryEffective ||= removedBySearchFilter > 0;


### PR DESCRIPTION
A search can match only exotic armor in several buckets (for example a user searching `tier:5` whose only tier-5 armor in those slots is exotic). Since a loadout can hold at most one exotic, every generated set was then rejected for having more than one exotic, so the optimizer returned no builds.

Treat a bucket whose only search matches are exotic the same as a bucket the search emptied: ignore the search for that bucket and keep its full pool. Buckets already restricted to a specific pinned or locked exotic are unaffected, which is why locking an exotic first already worked around this.

Changelog: Fixed the Loadout Optimizer returning no builds when a search (like tier:5) matched only exotic armor in multiple slots.

Closes #11933
