### PR TITLE
Prevent armory links from overlapping the close button

### DIFF
--- a/src/app/armory/Links.m.scss
+++ b/src/app/armory/Links.m.scss
@@ -10,14 +10,14 @@
   gap: 4px;
 
   @include phone-portrait {
-    margin-right: 38px;
+    margin-right: 48px;
   }
 
   @media (max-width: 675px) {
-    margin: 0 0 8px 0;
+    margin: 0 48px 8px 0;
     float: none;
     flex-flow: row wrap;
-    justify-content: space-between;
+    gap: 8px;
     > li {
       padding: 8px;
     }


### PR DESCRIPTION
Changelog: Prevent armory links from overlapping the close button
