### PR TITLE
Sort set bonuses alphabetically in optimizer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 * You can now sort and group by anti-champion type in the inventory screen.
 * Added `is:tieredweapon` filter to list weapons with tiers.
 * Add compare filter buttons for breaker type, breaker type + slot, and breaker type + element.
+* Set bonuses in the optimizer's picker are now sorted alphabetically.
 
 ## 8.137.0 <span class="changelog-date">(2026-08-09)</span>
 


### PR DESCRIPTION
Sorted set bonuses alphabetically in optimizer's picker.

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
