### PR TITLE
Improve artifact item picker selectivity

### DIFF
--- a/src/app/loadout-drawer/loadout-utils.ts
+++ b/src/app/loadout-drawer/loadout-utils.ts
@@ -582,6 +582,7 @@ const matchByHash = [
   BucketHashes.Emotes,
   D1BucketHashes.Horn,
   D1BucketHashes.Shader,
+  BucketHashes.Artifacts,
 ];
 
 /**
@@ -716,13 +717,16 @@ export function getInstancedLoadoutItem(allItems: DimItem[], loadoutItem: Loadou
  */
 const itemsByHash = weakMemoize((allItems: DimItem[]) => Map.groupBy(allItems, (i) => i.hash));
 
+/**
+ * This is for subclasses, artifacts, and emblems - it finds all matching items
+ * by hash and then picks the one that's on the desired character It's also used
+ * for moving consumables in search loadouts
+ */
 export function getUninstancedLoadoutItem(
   allItems: DimItem[],
   hash: number,
   storeId: string | undefined,
 ) {
-  // This is for subclasses and emblems - it finds all matching items by hash and then picks the one that's on the desired character
-  // It's also used for moving consumables in search loadouts
   const candidates = itemsByHash(allItems).get(hash) ?? [];
   // the copy of this item being held by the specified store
   const heldItem =

--- a/src/app/loadout/loadout-edit/LoadoutEdit.tsx
+++ b/src/app/loadout/loadout-edit/LoadoutEdit.tsx
@@ -506,7 +506,8 @@ function LoadoutEditArtifactSection({
 
     const item = await showItemPicker({
       filterItems: (item: DimItem) =>
-        item.bucket.hash === warnItem.bucket.hash &&
+        item.hash === warnItem.hash &&
+        item.owner === store.id &&
         itemCanBeInLoadout(item) &&
         isItemLoadoutCompatible(item.classType, loadout.classType),
       prompt: t('Loadouts.FindAnother', {


### PR DESCRIPTION
Changelog: Artifacts in shared loadouts are now automatically matched to the same artifact in your inventory. You don't have to choose it anymore.

Fixes #11955