### PR TITLE
only follow same-origin returnPath after login

### DIFF
--- a/src/authReturn.ts
+++ b/src/authReturn.ts
@@ -40,8 +40,14 @@ async function handleAuthReturn() {
   try {
     const token = await getAccessTokenFromCode(code);
     setToken(token);
-    // If we have a stored path from before we logged in (e.g. a loadout or armory link), send them back to that
-    window.location.href = localStorage.getItem('returnPath') ?? $PUBLIC_PATH;
+    // If we have a stored path from before we logged in (e.g. a loadout or armory link), send them back to that.
+    // Only follow it if it stays on our own origin - a crafted value like "//evil.com" would otherwise be treated
+    // as a protocol-relative URL and redirect the user off-site once they've logged in.
+    const returnPath = localStorage.getItem('returnPath');
+    window.location.href =
+      returnPath && new URL(returnPath, window.location.origin).origin === window.location.origin
+        ? returnPath
+        : $PUBLIC_PATH;
   } catch (error) {
     if (error instanceof TypeError || (error instanceof HttpStatusError && error.status === -1)) {
       setError(


### PR DESCRIPTION
handleAuthReturn finishes the bungie login by pointing the browser at whatever path we stored in localStorage before login, but it never checks the value is one of our own paths. that stored value comes from the pre-login url, so visiting something like app.destinyitemmanager.com//evil.com leaves `//evil.com` in returnPath, and once the user has authorised it gets treated as a protocol-relative url and quietly sends them off-site. this resolves the stored path against our own origin and only follows it when the origin matches, otherwise falling back to the public path, which also covers the backslash variants browsers normalise to `//`.