### PR TITLE
only keep known fields on imported shared loadouts

### DIFF
--- a/src/app/loadout/loadout-share/loadout-import.test.ts
+++ b/src/app/loadout/loadout-share/loadout-import.test.ts
@@ -41,4 +41,27 @@ describe('dim.gg loadout share links parsing', () => {
     }
     expect(decoded.loadout.parameters!.mods!.length).not.toBe(0);
   });
+
+  test('unknown top-level fields on a shared loadout are dropped', () => {
+    const loadout = {
+      name: 'Simple Loadout',
+      classType: 1,
+      equipped: [],
+      unequipped: [],
+      parameters: { mods: [2623485440] },
+      // Not part of the loadout schema - a crafted link should not be able to
+      // smuggle arbitrary keys through the import boundary.
+      injected: 'evil',
+    };
+    const url = `https://app.destinyitemmanager.com/loadouts?loadout=${encodeURIComponent(
+      JSON.stringify(loadout),
+    )}`;
+    const decoded = decodeShareUrl(url);
+    if (decoded?.tag !== 'urlLoadout') {
+      throw new Error();
+    }
+    expect(decoded.loadout.name).toBe('Simple Loadout');
+    expect(decoded.loadout.parameters!.mods).toEqual([2623485440]);
+    expect('injected' in decoded.loadout).toBe(false);
+  });
 });

--- a/src/app/loadout/loadout-share/loadout-import.ts
+++ b/src/app/loadout/loadout-share/loadout-import.ts
@@ -95,13 +95,23 @@ async function getDimSharedLoadout(shareId: string) {
  * constraints are in the correct range.
  */
 function preprocessReceivedLoadout(loadout: Loadout): Loadout {
-  loadout.id = globalThis.crypto.randomUUID();
-  loadout.items = loadout.items.map((item) => ({
+  // A shared loadout arrives as attacker-controlled JSON (a ?loadout= link or a
+  // dim.gg share), and convertDimApiLoadoutToLoadout spreads every top-level key
+  // it happens to carry into the loadout we store. Rebuild it from only the fields
+  // a loadout is allowed to have, so a crafted link can't smuggle extra keys into
+  // something we then persist and sync. This mirrors the newLoadout construction
+  // used for the url parameters case above.
+  const items = loadout.items.map((item) => ({
     ...item,
     id: item.id === '0' ? generateMissingLoadoutItemId() : item.id,
     hash: Number(item.hash),
   }));
-  for (const constraint of loadout.parameters?.statConstraints ?? []) {
+  const received = newLoadout(loadout.name ?? '', items, loadout.classType);
+  received.notes = loadout.notes;
+  received.parameters = loadout.parameters;
+  received.clearSpace = loadout.clearSpace;
+
+  for (const constraint of received.parameters?.statConstraints ?? []) {
     // min/maxTier are deprecated as of Edge of Fate, but we still support them
     // for backwards compatibility.
     if (constraint.maxTier !== undefined) {
@@ -123,5 +133,5 @@ function preprocessReceivedLoadout(loadout: Loadout): Loadout {
     }
   }
 
-  return loadout;
+  return received;
 }


### PR DESCRIPTION
a shared loadout link is fully attacker-controlled json, and convertDimApiLoadoutToLoadout spreads every top-level key it carries straight into the loadout we store and later sync to dim sync, so a crafted ?loadout= link (or dim.gg share) can smuggle arbitrary unmodelled fields past the import boundary. preprocessReceivedLoadout only clamped the stat constraints, so it now rebuilds the received loadout from just the fields a loadout is allowed to have, reusing the same newLoadout construction the url-parameters path already uses. added a small test covering an injected extra key.