### PR TITLE
Loadout CSV: Fill Artifact Season/Unlocks columns with new artifact info where possible

### DIFF
--- a/config/i18n.json
+++ b/config/i18n.json
@@ -901,7 +901,8 @@
       "Fashion": "Fashion (shaders & ornaments)",
       "Subclass": "Subclass customization",
       "LoadoutOptimizer": "Loadout Optimizer settings",
-      "Notes": "Notes"
+      "Notes": "Notes",
+      "SocketOverrides": "Subclass/artifact customization"
     },
     "ShareLoadout": "Share",
     "ShowModPlacement": "Show Mod Placement",

--- a/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
@@ -77,7 +77,7 @@ export default function LoadoutShareSheet({
   const numMods = loadout.parameters?.mods?.length ?? 0;
   const numItems = count(loadout.items, (i) => !i.socketOverrides);
   const hasFashion = Boolean(loadout.parameters?.modsByBucket);
-  const hasSubclass = loadout.items.some((i) => i.equip && i.socketOverrides);
+  const hasOverrides = loadout.items.some((i) => i.equip && i.socketOverrides);
   const hasLoParams = Boolean(
     loadout.parameters &&
     (loadout.parameters.query ||
@@ -108,7 +108,7 @@ export default function LoadoutShareSheet({
                   {numItems > 0 && <li>{t('Loadouts.Share.NumItems', { count: numItems })}</li>}
                   {numMods > 0 && <li>{t('Loadouts.Share.NumMods', { count: numItems })}</li>}
                   {hasFashion && <li>{t('Loadouts.Share.Fashion')}</li>}
-                  {hasSubclass && <li>{t('Loadouts.Share.Subclass')}</li>}
+                  {hasOverrides && <li>{t('Loadouts.Share.SocketOverrides')}</li>}
                   {hasLoParams && <li>{t('Loadouts.Share.LoadoutOptimizer')}</li>}
                   {loadout.notes && <li>{t('Loadouts.Share.Notes')}</li>}
                 </ul>

--- a/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
+++ b/src/app/loadout/loadout-share/LoadoutShareSheet.tsx
@@ -106,7 +106,7 @@ export default function LoadoutShareSheet({
                 {t('Loadouts.Share.Summary')}
                 <ul>
                   {numItems > 0 && <li>{t('Loadouts.Share.NumItems', { count: numItems })}</li>}
-                  {numMods > 0 && <li>{t('Loadouts.Share.NumMods', { count: numItems })}</li>}
+                  {numMods > 0 && <li>{t('Loadouts.Share.NumMods', { count: numMods })}</li>}
                   {hasFashion && <li>{t('Loadouts.Share.Fashion')}</li>}
                   {hasOverrides && <li>{t('Loadouts.Share.SocketOverrides')}</li>}
                   {hasLoParams && <li>{t('Loadouts.Share.LoadoutOptimizer')}</li>}

--- a/src/app/loadout/spreadsheets.ts
+++ b/src/app/loadout/spreadsheets.ts
@@ -82,7 +82,9 @@ export function downloadLoadoutsCsv(): ThunkResult {
       const fragments = subclassPlugs.filter((p) =>
         fragmentSocketCategoryHashes.includes(p.socketCategoryHash),
       );
-      // TODO artifact and artifactPlugs
+      const artifact = resolvedLoadout.resolvedLoadoutItems.find(
+        (item) => item.item.bucket.hash === BucketHashes.Artifacts,
+      );
       const stats: CsvRow = {};
       const equippedArmor = resolvedLoadout.resolvedLoadoutItems.filter(
         (i) => i.loadoutItem.equip && i.item.bucket.inArmor,
@@ -122,7 +124,12 @@ export function downloadLoadoutsCsv(): ThunkResult {
       );
 
       const equippedItems = resolvedLoadout.resolvedLoadoutItems
-        .filter((i) => i.loadoutItem.equip && i.item.bucket.hash !== BucketHashes.Subclass)
+        .filter(
+          (i) =>
+            i.loadoutItem.equip &&
+            i.item.bucket.hash !== BucketHashes.Subclass &&
+            i.item.bucket.hash !== BucketHashes.Artifacts,
+        )
         .sort(sortItems);
 
       const equippedItemValues = Object.fromEntries(
@@ -163,9 +170,16 @@ export function downloadLoadoutsCsv(): ThunkResult {
         Aspects: localizeResolvedPlugs(aspects),
         Fragments: localizeResolvedPlugs(fragments),
         Mods: mods.map((mod) => mod.displayProperties.name),
-        'Artifact Season': loadout.parameters?.artifactUnlocks?.seasonNumber,
-        'Artifact Unlocks': loadout.parameters?.artifactUnlocks?.unlockedItemHashes.map(
-          (modHash) => defs.InventoryItem.get(modHash)?.displayProperties.name,
+        'Artifact Season':
+          artifact?.item.name || loadout.parameters?.artifactUnlocks?.seasonNumber || '',
+        'Artifact Unlocks': (
+          artifact?.item.sockets?.allSockets?.map(
+            (s) => artifact?.loadoutItem.socketOverrides?.[s.socketIndex] || 0,
+          ) ||
+          loadout.parameters?.artifactUnlocks?.unlockedItemHashes ||
+          []
+        ).map(
+          (modHash) => (modHash && defs.InventoryItem.get(modHash)?.displayProperties.name) || '',
         ),
       };
     });

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -948,7 +948,7 @@
       "NumMods_one": "{{count}} mod",
       "NumMods_other": "{{count}} mods",
       "Placeholder": "Loading share link",
-      "Subclass": "Subclass customization",
+      "SocketOverrides": "Subclass/artifact customization",
       "Summary": "Share this loadout containing:",
       "Title": "Share \"{{name}}\""
     },


### PR DESCRIPTION
Also update the text on shared loadouts to indicate that socket overrides could be subclass or artifact
Also fixes an issue where share sheet would show incorrect mod counts

<!-- To add entries to the CHANGELOG.md, include lines in your commit messages that start with `Changelog:` followed by the description -->
Changelog: Loadout CSV export now handles new artifacts

Related: https://github.com/DestinyItemManager/dim-api/pull/316

Recreation of #11962 